### PR TITLE
[R3][#56] Add sharded official suite CI with explicit flake gates

### DIFF
--- a/.github/workflows/official-suite-sharded.yml
+++ b/.github/workflows/official-suite-sharded.yml
@@ -1,0 +1,190 @@
+name: Official Suite Sharded
+
+on:
+  workflow_dispatch:
+    inputs:
+      official_specs_ref:
+        description: "Commit/tag/branch in mongodb/specifications"
+        required: false
+        default: "99704fa8860777da1d919ef765af1e41e75f5859"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "src/main/**"
+      - "src/test/**"
+      - "testkit/**"
+      - "scripts/ci/**"
+      - ".github/workflows/official-suite-sharded.yml"
+      - "build.gradle.kts"
+  schedule:
+    - cron: "0 4 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: official-suite-sharded-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  utf-shards:
+    name: UTF shard ${{ matrix.shard_index }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    strategy:
+      fail-fast: false
+      matrix:
+        shard_index: [0, 1, 2]
+    env:
+      OFFICIAL_SPECS_REPO: https://github.com/mongodb/specifications.git
+      OFFICIAL_SPECS_REF: ${{ github.event.inputs.official_specs_ref || '99704fa8860777da1d919ef765af1e41e75f5859' }}
+      SHARD_COUNT: "3"
+      UTF_SEED: "r3-official-suite-v1"
+      UTF_REPLAY_LIMIT: "30"
+      MONGO_CONTAINER_NAME: jongodb-replset
+      MONGO_REPLSET_NAME: rs0
+      MONGO_PORT: "27017"
+      REPLSET_WAIT_TIMEOUT_SECONDS: "120"
+      REPLSET_WAIT_INTERVAL_SECONDS: "2"
+      REPLSET_DIAGNOSTICS_DIR: build/reports/replset-diagnostics/shard-${{ matrix.shard_index }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Temurin 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "8.11.1"
+
+      - name: Make scripts executable
+        run: chmod +x scripts/ci/*.sh
+
+      - name: Bootstrap replica set fixture
+        run: ./scripts/ci/bootstrap-replset.sh
+
+      - name: Prepare official spec checkout
+        id: spec_checkout
+        run: |
+          ./scripts/ci/prepare-official-specs.sh \
+            --repo "${OFFICIAL_SPECS_REPO}" \
+            --ref "${OFFICIAL_SPECS_REF}" \
+            --dest "${RUNNER_TEMP}/mongodb-specifications"
+
+      - name: Run baseline shard
+        run: |
+          ./scripts/ci/run-utf-shard.sh \
+            --spec-repo-root "${RUNNER_TEMP}/mongodb-specifications" \
+            --shard-index "${{ matrix.shard_index }}" \
+            --shard-count "${SHARD_COUNT}" \
+            --output-dir "build/reports/unified-spec-shards/shard-${{ matrix.shard_index }}/baseline" \
+            --seed "${UTF_SEED}" \
+            --replay-limit "${UTF_REPLAY_LIMIT}" \
+            --mongo-uri "${JONGODB_REAL_MONGOD_URI}" \
+            --gradle-cmd gradle
+
+      - name: Run rerun shard (flake gate input)
+        run: |
+          ./scripts/ci/run-utf-shard.sh \
+            --spec-repo-root "${RUNNER_TEMP}/mongodb-specifications" \
+            --shard-index "${{ matrix.shard_index }}" \
+            --shard-count "${SHARD_COUNT}" \
+            --output-dir "build/reports/unified-spec-shards/shard-${{ matrix.shard_index }}/rerun" \
+            --seed "${UTF_SEED}" \
+            --replay-limit "${UTF_REPLAY_LIMIT}" \
+            --mongo-uri "${JONGODB_REAL_MONGOD_URI}" \
+            --gradle-cmd gradle
+
+      - name: Enforce flake gate (baseline vs rerun consistency)
+        run: |
+          ./scripts/ci/assert-utf-shard-consistency.sh \
+            --baseline-json "build/reports/unified-spec-shards/shard-${{ matrix.shard_index }}/baseline/utf-differential-report.json" \
+            --rerun-json "build/reports/unified-spec-shards/shard-${{ matrix.shard_index }}/rerun/utf-differential-report.json"
+
+      - name: Collect replica set diagnostics
+        if: always()
+        run: ./scripts/ci/collect-replset-diagnostics.sh "${REPLSET_DIAGNOSTICS_DIR}"
+
+      - name: Upload shard artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: utf-shard-${{ matrix.shard_index }}
+          path: |
+            build/reports/unified-spec-shards/shard-${{ matrix.shard_index }}/**/*.json
+            build/reports/unified-spec-shards/shard-${{ matrix.shard_index }}/**/*.md
+            build/reports/unified-spec-shards/shard-${{ matrix.shard_index }}/**/*.txt
+            build/reports/replset-diagnostics/shard-${{ matrix.shard_index }}/**
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Teardown replica set fixture
+        if: always()
+        run: ./scripts/ci/teardown-replset.sh
+
+  shard-summary:
+    name: Shard summary
+    runs-on: ubuntu-latest
+    needs: [utf-shards]
+    if: always()
+    steps:
+      - name: Download shard 0 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: utf-shard-0
+          path: artifacts/utf-shard-0
+
+      - name: Download shard 1 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: utf-shard-1
+          path: artifacts/utf-shard-1
+
+      - name: Download shard 2 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: utf-shard-2
+          path: artifacts/utf-shard-2
+
+      - name: Build shard summary markdown
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          shard_roots = [Path("artifacts/utf-shard-0"), Path("artifacts/utf-shard-1"), Path("artifacts/utf-shard-2")]
+          out = Path("artifacts/utf-shard-summary.md")
+
+          lines = ["# UTF shard summary", ""]
+          for shard_index, root in enumerate(shard_roots):
+            baseline_json = next(root.glob("**/baseline/utf-differential-report.json"), None)
+            rerun_json = next(root.glob("**/rerun/utf-differential-report.json"), None)
+            if baseline_json is None or rerun_json is None:
+              raise SystemExit(f"missing baseline/rerun report for shard {shard_index}")
+
+            baseline = json.loads(baseline_json.read_text(encoding="utf-8"))
+            rerun = json.loads(rerun_json.read_text(encoding="utf-8"))
+            b = baseline["differentialSummary"]
+            r = rerun["differentialSummary"]
+            lines.append(f"## shard-{shard_index}")
+            lines.append(f"- baseline: total={b['total']} match={b['match']} mismatch={b['mismatch']} error={b['error']}")
+            lines.append(f"- rerun: total={r['total']} match={r['match']} mismatch={r['mismatch']} error={r['error']}")
+            lines.append("")
+
+          out.write_text("\n".join(lines), encoding="utf-8")
+          print(out.read_text(encoding="utf-8"))
+          PY
+
+      - name: Upload summary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: utf-shard-summary
+          path: artifacts/utf-shard-summary.md
+          if-no-files-found: error
+          retention-days: 14

--- a/scripts/ci/assert-utf-shard-consistency.sh
+++ b/scripts/ci/assert-utf-shard-consistency.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  printf '[assert-utf-shard-consistency] %s\n' "$*"
+}
+
+usage() {
+  cat <<'EOF'
+Usage: assert-utf-shard-consistency.sh --baseline-json <path> --rerun-json <path>
+EOF
+}
+
+BASELINE_JSON=""
+RERUN_JSON=""
+
+while (($# > 0)); do
+  case "$1" in
+    --baseline-json=*)
+      BASELINE_JSON="${1#*=}"
+      shift
+      ;;
+    --baseline-json)
+      BASELINE_JSON="${2:-}"
+      shift 2
+      ;;
+    --rerun-json=*)
+      RERUN_JSON="${1#*=}"
+      shift
+      ;;
+    --rerun-json)
+      RERUN_JSON="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      log "Unknown argument: $1"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$BASELINE_JSON" ] || [ -z "$RERUN_JSON" ]; then
+  usage
+  exit 1
+fi
+
+if [ ! -f "$BASELINE_JSON" ] || [ ! -f "$RERUN_JSON" ]; then
+  log "JSON report file missing."
+  exit 1
+fi
+
+python3 - "$BASELINE_JSON" "$RERUN_JSON" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+baseline_path = Path(sys.argv[1])
+rerun_path = Path(sys.argv[2])
+
+baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+rerun = json.loads(rerun_path.read_text(encoding="utf-8"))
+
+
+def summary(doc):
+    import_summary = doc.get("importSummary", {})
+    differential = doc.get("differentialSummary", {})
+    replays = doc.get("failureReplays", [])
+    replay_pairs = [(r.get("scenarioId"), r.get("status"), r.get("message")) for r in replays]
+    return {
+        "imported": import_summary.get("imported"),
+        "skipped": import_summary.get("skipped"),
+        "unsupported": import_summary.get("unsupported"),
+        "total": differential.get("total"),
+        "match": differential.get("match"),
+        "mismatch": differential.get("mismatch"),
+        "error": differential.get("error"),
+        "failureReplays": replay_pairs,
+    }
+
+
+b_summary = summary(baseline)
+r_summary = summary(rerun)
+if b_summary != r_summary:
+    print("UTF shard consistency check failed.", file=sys.stderr)
+    print("baseline=", json.dumps(b_summary, ensure_ascii=False), file=sys.stderr)
+    print("rerun=", json.dumps(r_summary, ensure_ascii=False), file=sys.stderr)
+    sys.exit(1)
+
+print("UTF shard consistency check passed.")
+PY
+
+log "Shard consistency assertions passed."

--- a/scripts/ci/prepare-official-specs.sh
+++ b/scripts/ci/prepare-official-specs.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  printf '[prepare-official-specs] %s\n' "$*"
+}
+
+require_command() {
+  local command_name="$1"
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    log "Required command not found: ${command_name}"
+    exit 1
+  fi
+}
+
+usage() {
+  cat <<'EOF'
+Usage: prepare-official-specs.sh --repo <url> --ref <commit-or-tag-or-branch> --dest <directory>
+EOF
+}
+
+REPO_URL=""
+SPEC_REF=""
+DEST_DIR=""
+
+while (($# > 0)); do
+  case "$1" in
+    --repo=*)
+      REPO_URL="${1#*=}"
+      shift
+      ;;
+    --repo)
+      REPO_URL="${2:-}"
+      shift 2
+      ;;
+    --ref=*)
+      SPEC_REF="${1#*=}"
+      shift
+      ;;
+    --ref)
+      SPEC_REF="${2:-}"
+      shift 2
+      ;;
+    --dest=*)
+      DEST_DIR="${1#*=}"
+      shift
+      ;;
+    --dest)
+      DEST_DIR="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      log "Unknown argument: $1"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$REPO_URL" ] || [ -z "$SPEC_REF" ] || [ -z "$DEST_DIR" ]; then
+  usage
+  exit 1
+fi
+
+require_command git
+require_command rm
+
+if [ -d "$DEST_DIR/.git" ]; then
+  log "Refreshing existing clone at ${DEST_DIR}."
+  git -C "$DEST_DIR" remote set-url origin "$REPO_URL"
+  git -C "$DEST_DIR" fetch --prune origin
+else
+  if [ -e "$DEST_DIR" ]; then
+    log "Removing non-git destination path: ${DEST_DIR}"
+    rm -rf "$DEST_DIR"
+  fi
+  log "Cloning ${REPO_URL} into ${DEST_DIR}."
+  git clone --no-checkout "$REPO_URL" "$DEST_DIR"
+fi
+
+if git -C "$DEST_DIR" fetch --depth 1 origin "$SPEC_REF"; then
+  git -C "$DEST_DIR" checkout --detach FETCH_HEAD
+else
+  log "Depth-limited fetch failed for ref ${SPEC_REF}, retrying full fetch."
+  git -C "$DEST_DIR" fetch origin "$SPEC_REF"
+  git -C "$DEST_DIR" checkout --detach FETCH_HEAD
+fi
+
+RESOLVED_SHA="$(git -C "$DEST_DIR" rev-parse HEAD)"
+log "Resolved official specs ref to ${RESOLVED_SHA}"
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  printf 'resolved_sha=%s\n' "$RESOLVED_SHA" >>"$GITHUB_OUTPUT"
+fi

--- a/scripts/ci/run-utf-shard.sh
+++ b/scripts/ci/run-utf-shard.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  printf '[run-utf-shard] %s\n' "$*"
+}
+
+require_command() {
+  local command_name="$1"
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    log "Required command not found: ${command_name}"
+    exit 1
+  fi
+}
+
+usage() {
+  cat <<'EOF'
+Usage: run-utf-shard.sh \
+  --spec-repo-root <path> \
+  --shard-index <int> \
+  --shard-count <int> \
+  --output-dir <path> \
+  --seed <value> \
+  --mongo-uri <uri> \
+  [--suite-root <relative-path>]... \
+  [--replay-limit <int>] \
+  [--gradle-cmd <command>]
+EOF
+}
+
+SPEC_REPO_ROOT=""
+SHARD_INDEX=""
+SHARD_COUNT=""
+OUTPUT_DIR=""
+SEED=""
+MONGO_URI=""
+REPLAY_LIMIT="20"
+GRADLE_CMD="gradle"
+SUITE_ROOTS=()
+
+while (($# > 0)); do
+  case "$1" in
+    --spec-repo-root=*)
+      SPEC_REPO_ROOT="${1#*=}"
+      shift
+      ;;
+    --spec-repo-root)
+      SPEC_REPO_ROOT="${2:-}"
+      shift 2
+      ;;
+    --shard-index=*)
+      SHARD_INDEX="${1#*=}"
+      shift
+      ;;
+    --shard-index)
+      SHARD_INDEX="${2:-}"
+      shift 2
+      ;;
+    --shard-count=*)
+      SHARD_COUNT="${1#*=}"
+      shift
+      ;;
+    --shard-count)
+      SHARD_COUNT="${2:-}"
+      shift 2
+      ;;
+    --output-dir=*)
+      OUTPUT_DIR="${1#*=}"
+      shift
+      ;;
+    --output-dir)
+      OUTPUT_DIR="${2:-}"
+      shift 2
+      ;;
+    --seed=*)
+      SEED="${1#*=}"
+      shift
+      ;;
+    --seed)
+      SEED="${2:-}"
+      shift 2
+      ;;
+    --mongo-uri=*)
+      MONGO_URI="${1#*=}"
+      shift
+      ;;
+    --mongo-uri)
+      MONGO_URI="${2:-}"
+      shift 2
+      ;;
+    --suite-root=*)
+      SUITE_ROOTS+=("${1#*=}")
+      shift
+      ;;
+    --suite-root)
+      SUITE_ROOTS+=("${2:-}")
+      shift 2
+      ;;
+    --replay-limit=*)
+      REPLAY_LIMIT="${1#*=}"
+      shift
+      ;;
+    --replay-limit)
+      REPLAY_LIMIT="${2:-}"
+      shift 2
+      ;;
+    --gradle-cmd=*)
+      GRADLE_CMD="${1#*=}"
+      shift
+      ;;
+    --gradle-cmd)
+      GRADLE_CMD="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      log "Unknown argument: $1"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$SPEC_REPO_ROOT" ] || [ -z "$SHARD_INDEX" ] || [ -z "$SHARD_COUNT" ] \
+  || [ -z "$OUTPUT_DIR" ] || [ -z "$SEED" ] || [ -z "$MONGO_URI" ]; then
+  usage
+  exit 1
+fi
+
+if ! [[ "$SHARD_INDEX" =~ ^[0-9]+$ ]] || ! [[ "$SHARD_COUNT" =~ ^[0-9]+$ ]]; then
+  log "shard-index and shard-count must be non-negative integers."
+  exit 1
+fi
+
+if [ "$SHARD_COUNT" -le 0 ] || [ "$SHARD_INDEX" -ge "$SHARD_COUNT" ]; then
+  log "Invalid shard configuration: index=${SHARD_INDEX}, count=${SHARD_COUNT}"
+  exit 1
+fi
+
+if [ "${#SUITE_ROOTS[@]}" -eq 0 ]; then
+  SUITE_ROOTS=(
+    "source/crud/tests/unified"
+    "source/transactions/tests/unified"
+    "source/sessions/tests"
+  )
+fi
+
+require_command find
+require_command sort
+require_command mkdir
+require_command cp
+require_command mktemp
+require_command "$GRADLE_CMD"
+
+if [ ! -d "$SPEC_REPO_ROOT" ]; then
+  log "spec-repo-root does not exist: ${SPEC_REPO_ROOT}"
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+SPEC_SELECTION_FILE="$OUTPUT_DIR/spec-selection.txt"
+: >"$SPEC_SELECTION_FILE"
+
+TEMP_SHARD_ROOT="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TEMP_SHARD_ROOT"
+}
+trap cleanup EXIT
+
+spec_files=()
+for suite_root in "${SUITE_ROOTS[@]}"; do
+  suite_path="${SPEC_REPO_ROOT}/${suite_root}"
+  if [ -d "$suite_path" ]; then
+    while IFS= read -r file; do
+      spec_files+=("$file")
+    done < <(find "$suite_path" -type f \( -name "*.json" -o -name "*.yml" -o -name "*.yaml" \))
+  fi
+done
+
+if [ "${#spec_files[@]}" -eq 0 ]; then
+  log "No spec files found under configured suite roots."
+  exit 1
+fi
+
+IFS=$'\n' read -r -d '' -a sorted_files < <(printf '%s\n' "${spec_files[@]}" | LC_ALL=C sort -u && printf '\0')
+
+selected_count=0
+for index in "${!sorted_files[@]}"; do
+  file_path="${sorted_files[$index]}"
+  if [ $((index % SHARD_COUNT)) -ne "$SHARD_INDEX" ]; then
+    continue
+  fi
+
+  relative_path="${file_path#${SPEC_REPO_ROOT}/}"
+  destination_path="${TEMP_SHARD_ROOT}/${relative_path}"
+  mkdir -p "$(dirname "$destination_path")"
+  cp "$file_path" "$destination_path"
+  printf '%s\n' "$relative_path" >>"$SPEC_SELECTION_FILE"
+  selected_count=$((selected_count + 1))
+done
+
+if [ "$selected_count" -le 0 ]; then
+  log "Shard ${SHARD_INDEX}/${SHARD_COUNT} selected zero spec files."
+  exit 1
+fi
+
+SHARD_SEED="${SEED}-shard-${SHARD_INDEX}-of-${SHARD_COUNT}"
+log "Running shard ${SHARD_INDEX}/${SHARD_COUNT} with ${selected_count} files and seed=${SHARD_SEED}."
+
+"$GRADLE_CMD" --no-daemon \
+  -PutfSpecRoot="${TEMP_SHARD_ROOT}/source" \
+  -PutfOutputDir="$OUTPUT_DIR" \
+  -PutfSeed="$SHARD_SEED" \
+  -PutfReplayLimit="$REPLAY_LIMIT" \
+  -PutfMongoUri="$MONGO_URI" \
+  utfCorpusEvidence
+
+JSON_REPORT="${OUTPUT_DIR}/utf-differential-report.json"
+if [ ! -f "$JSON_REPORT" ]; then
+  log "Expected report not found: ${JSON_REPORT}"
+  exit 1
+fi
+
+printf '%s\n' "$selected_count" >"${OUTPUT_DIR}/selected-count.txt"
+log "Shard run completed. Output: ${OUTPUT_DIR}"


### PR DESCRIPTION
## Summary
- add official suite sharded workflow (3 shards) with deterministic seed controls
- add scripts to prepare official specs checkout, run shard partitions, and assert rerun consistency
- upload per-shard artifacts and summary artifact with strict missing-artifact failures

## Linked Issues (Required)
Closes #56

## Verification
- bash -n scripts/ci/prepare-official-specs.sh scripts/ci/run-utf-shard.sh scripts/ci/assert-utf-shard-consistency.sh
- ./scripts/ci/prepare-official-specs.sh --help
- ./scripts/ci/run-utf-shard.sh --help
- ./scripts/ci/assert-utf-shard-consistency.sh --help
- python3 YAML parse check for .github/workflows/official-suite-sharded.yml