### PR TITLE
[R3][#48] Add deterministic official spec sync + pin manifest

### DIFF
--- a/scripts/spec-sync/README.md
+++ b/scripts/spec-sync/README.md
@@ -1,0 +1,26 @@
+# MongoDB Spec Sync Tooling
+
+This folder provides deterministic pinning/sync tooling for the
+`mongodb/specifications` repository.
+
+## Commands
+
+Sync a pinned commit and update manifest metadata:
+
+```bash
+./scripts/spec-sync/sync-mongodb-specs.sh \
+  --commit 99704fa8860777da1d919ef765af1e41e75f5859
+```
+
+Verify manifest/checkouts for CI or local checks:
+
+```bash
+./scripts/spec-sync/verify-mongodb-specs.sh
+```
+
+## Notes
+
+- The default checkout is local-only at
+  `third_party/mongodb-specs/.checkout/specifications`.
+- Full specs are intentionally not vendored by default.
+- The manifest is written to `third_party/mongodb-specs/manifest.json`.

--- a/scripts/spec-sync/sync-mongodb-specs.sh
+++ b/scripts/spec-sync/sync-mongodb-specs.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+DEFAULT_REPO_URL="https://github.com/mongodb/specifications.git"
+DEFAULT_MANIFEST_PATH="third_party/mongodb-specs/manifest.json"
+DEFAULT_CHECKOUT_DIR="third_party/mongodb-specs/.checkout/specifications"
+
+DEFAULT_INCLUDED_SUITES=(
+  "source/transactions/tests/unified"
+  "source/sessions/tests"
+  "source/crud/tests/unified"
+  "source/unified-test-format"
+)
+
+print_usage() {
+  cat <<'EOF'
+Usage:
+  sync-mongodb-specs.sh --commit <sha> [options]
+
+Options:
+  --commit <sha>            Required MongoDB specifications commit to pin.
+  --repo-url <url>          Source repository URL.
+                            Default: https://github.com/mongodb/specifications.git
+  --manifest <path>         Manifest file path.
+                            Default: third_party/mongodb-specs/manifest.json
+  --checkout-dir <path>     Local checkout directory for pinned commit.
+                            Default: third_party/mongodb-specs/.checkout/specifications
+  --suite-root <path>       Included suite root under the spec repo (repeatable).
+                            Default roots:
+                              - source/transactions/tests/unified
+                              - source/sessions/tests
+                              - source/crud/tests/unified
+                              - source/unified-test-format
+  --help                    Show help.
+EOF
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+resolve_path() {
+  local input="$1"
+  if [[ "${input}" = /* ]]; then
+    printf '%s\n' "${input}"
+  else
+    printf '%s/%s\n' "${REPO_ROOT}" "${input}"
+  fi
+}
+
+normalize_suite_root() {
+  local root="$1"
+  root="${root#/}"
+  root="${root%/}"
+  printf '%s\n' "${root}"
+}
+
+json_escape() {
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
+repo_url="${DEFAULT_REPO_URL}"
+manifest_path="${DEFAULT_MANIFEST_PATH}"
+checkout_dir="${DEFAULT_CHECKOUT_DIR}"
+pinned_commit=""
+included_suites=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --commit)
+      [[ $# -ge 2 ]] || die "--commit requires a value"
+      pinned_commit="$2"
+      shift 2
+      ;;
+    --repo-url)
+      [[ $# -ge 2 ]] || die "--repo-url requires a value"
+      repo_url="$2"
+      shift 2
+      ;;
+    --manifest)
+      [[ $# -ge 2 ]] || die "--manifest requires a value"
+      manifest_path="$2"
+      shift 2
+      ;;
+    --checkout-dir)
+      [[ $# -ge 2 ]] || die "--checkout-dir requires a value"
+      checkout_dir="$2"
+      shift 2
+      ;;
+    --suite-root)
+      [[ $# -ge 2 ]] || die "--suite-root requires a value"
+      normalized_suite="$(normalize_suite_root "$2")"
+      [[ -n "${normalized_suite}" ]] || die "--suite-root cannot be empty"
+      included_suites+=("${normalized_suite}")
+      shift 2
+      ;;
+    --help|-h)
+      print_usage
+      exit 0
+      ;;
+    *)
+      die "unknown option: $1"
+      ;;
+  esac
+done
+
+[[ -n "${pinned_commit}" ]] || die "--commit is required"
+
+if [[ "${#included_suites[@]}" -eq 0 ]]; then
+  included_suites=("${DEFAULT_INCLUDED_SUITES[@]}")
+fi
+
+manifest_abs="$(resolve_path "${manifest_path}")"
+checkout_abs="$(resolve_path "${checkout_dir}")"
+
+mkdir -p "$(dirname "${manifest_abs}")"
+mkdir -p "$(dirname "${checkout_abs}")"
+
+if [[ -d "${checkout_abs}/.git" ]]; then
+  current_origin="$(git -C "${checkout_abs}" config --get remote.origin.url || true)"
+  if [[ -z "${current_origin}" ]]; then
+    git -C "${checkout_abs}" remote add origin "${repo_url}"
+  elif [[ "${current_origin}" != "${repo_url}" ]]; then
+    git -C "${checkout_abs}" remote set-url origin "${repo_url}"
+  fi
+else
+  rm -rf "${checkout_abs}"
+  if ! git clone --no-checkout --filter=blob:none "${repo_url}" "${checkout_abs}" >/dev/null 2>&1; then
+    rm -rf "${checkout_abs}"
+    git clone --no-checkout "${repo_url}" "${checkout_abs}" >/dev/null
+  fi
+fi
+
+if ! git -C "${checkout_abs}" fetch --force --depth 1 origin "${pinned_commit}" >/dev/null 2>&1; then
+  git -C "${checkout_abs}" fetch --force --prune origin >/dev/null
+fi
+
+resolved_commit="$(git -C "${checkout_abs}" rev-parse --verify "${pinned_commit}^{commit}")"
+git -C "${checkout_abs}" -c advice.detachedHead=false checkout --detach --force "${resolved_commit}" >/dev/null
+
+actual_commit="$(git -C "${checkout_abs}" rev-parse --verify HEAD)"
+if [[ "${actual_commit}" != "${resolved_commit}" ]]; then
+  die "checkout mismatch: expected ${resolved_commit}, got ${actual_commit}"
+fi
+
+generated_at_utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+tmp_manifest="${manifest_abs}.tmp"
+{
+  echo "{"
+  echo "  \"schemaVersion\": 1,"
+  echo "  \"sourceRepoUrl\": \"$(json_escape "${repo_url}")\","
+  echo "  \"pinnedCommit\": \"${actual_commit}\","
+  echo "  \"generatedAtUtc\": \"${generated_at_utc}\","
+  echo "  \"checkoutDir\": \"$(json_escape "${checkout_dir}")\","
+  echo "  \"includedSuiteRoots\": ["
+  for i in "${!included_suites[@]}"; do
+    comma=","
+    if [[ "${i}" -eq $((${#included_suites[@]} - 1)) ]]; then
+      comma=""
+    fi
+    echo "    \"$(json_escape "${included_suites[$i]}")\"${comma}"
+  done
+  echo "  ]"
+  echo "}"
+} > "${tmp_manifest}"
+mv "${tmp_manifest}" "${manifest_abs}"
+
+echo "synced mongodb/specifications"
+echo "repo: ${repo_url}"
+echo "commit: ${actual_commit}"
+echo "checkout: ${checkout_dir}"
+echo "manifest: ${manifest_path}"

--- a/scripts/spec-sync/verify-mongodb-specs.sh
+++ b/scripts/spec-sync/verify-mongodb-specs.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+DEFAULT_MANIFEST_PATH="third_party/mongodb-specs/manifest.json"
+
+print_usage() {
+  cat <<'EOF'
+Usage:
+  verify-mongodb-specs.sh [options]
+
+Options:
+  --manifest <path>       Manifest file path.
+                          Default: third_party/mongodb-specs/manifest.json
+  --checkout-dir <path>   Override checkout directory instead of manifest value.
+  --help                  Show help.
+EOF
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+resolve_path() {
+  local input="$1"
+  if [[ "${input}" = /* ]]; then
+    printf '%s\n' "${input}"
+  else
+    printf '%s/%s\n' "${REPO_ROOT}" "${input}"
+  fi
+}
+
+normalize_repo_url() {
+  local url="$1"
+  case "${url}" in
+    git@github.com:*)
+      url="https://github.com/${url#git@github.com:}"
+      ;;
+    ssh://git@github.com/*)
+      url="https://github.com/${url#ssh://git@github.com/}"
+      ;;
+    git://github.com/*)
+      url="https://github.com/${url#git://github.com/}"
+      ;;
+  esac
+  url="${url%/}"
+  url="${url%.git}"
+  printf '%s\n' "${url}"
+}
+
+manifest_path="${DEFAULT_MANIFEST_PATH}"
+checkout_override=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --manifest)
+      [[ $# -ge 2 ]] || die "--manifest requires a value"
+      manifest_path="$2"
+      shift 2
+      ;;
+    --checkout-dir)
+      [[ $# -ge 2 ]] || die "--checkout-dir requires a value"
+      checkout_override="$2"
+      shift 2
+      ;;
+    --help|-h)
+      print_usage
+      exit 0
+      ;;
+    *)
+      die "unknown option: $1"
+      ;;
+  esac
+done
+
+[[ -x "$(command -v python3 || true)" ]] || die "python3 is required for manifest parsing"
+
+manifest_abs="$(resolve_path "${manifest_path}")"
+[[ -f "${manifest_abs}" ]] || die "manifest not found: ${manifest_abs}"
+
+if ! parsed_lines="$(python3 - "${manifest_abs}" <<'PY'
+import json
+import re
+import sys
+
+manifest_path = sys.argv[1]
+
+with open(manifest_path, "r", encoding="utf-8") as fh:
+    data = json.load(fh)
+
+required_keys = ("sourceRepoUrl", "pinnedCommit", "generatedAtUtc", "includedSuiteRoots")
+for key in required_keys:
+    if key not in data:
+        raise SystemExit(f"missing required key: {key}")
+
+source_repo = data["sourceRepoUrl"]
+pinned_commit = data["pinnedCommit"]
+generated_at = data["generatedAtUtc"]
+checkout_dir = data.get("checkoutDir", "third_party/mongodb-specs/.checkout/specifications")
+included_roots = data["includedSuiteRoots"]
+
+if not isinstance(source_repo, str) or not source_repo:
+    raise SystemExit("invalid sourceRepoUrl")
+if not isinstance(pinned_commit, str) or not re.fullmatch(r"[0-9a-f]{40}", pinned_commit):
+    raise SystemExit("invalid pinnedCommit; expected lowercase 40-char sha")
+if not isinstance(generated_at, str) or not re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", generated_at):
+    raise SystemExit("invalid generatedAtUtc; expected YYYY-MM-DDTHH:MM:SSZ")
+if not isinstance(checkout_dir, str) or not checkout_dir.strip():
+    raise SystemExit("invalid checkoutDir")
+if (
+    not isinstance(included_roots, list)
+    or len(included_roots) == 0
+    or any((not isinstance(v, str)) or not v.strip() for v in included_roots)
+):
+    raise SystemExit("invalid includedSuiteRoots")
+
+print(f"repo={source_repo}")
+print(f"commit={pinned_commit}")
+print(f"generated={generated_at}")
+print(f"checkout={checkout_dir}")
+for root in included_roots:
+    normalized = root.strip().strip("/")
+    print(f"root={normalized}")
+PY
+)"; then
+  die "manifest validation failed for ${manifest_abs}"
+fi
+
+source_repo=""
+pinned_commit=""
+generated_at=""
+checkout_manifest=""
+included_roots=()
+
+while IFS= read -r line; do
+  case "${line}" in
+    repo=*)
+      source_repo="${line#repo=}"
+      ;;
+    commit=*)
+      pinned_commit="${line#commit=}"
+      ;;
+    generated=*)
+      generated_at="${line#generated=}"
+      ;;
+    checkout=*)
+      checkout_manifest="${line#checkout=}"
+      ;;
+    root=*)
+      included_roots+=("${line#root=}")
+      ;;
+  esac
+done <<EOF
+${parsed_lines}
+EOF
+
+[[ -n "${source_repo}" ]] || die "manifest missing sourceRepoUrl"
+[[ -n "${pinned_commit}" ]] || die "manifest missing pinnedCommit"
+[[ -n "${generated_at}" ]] || die "manifest missing generatedAtUtc"
+[[ "${#included_roots[@]}" -gt 0 ]] || die "manifest missing includedSuiteRoots"
+
+checkout_path="${checkout_manifest}"
+if [[ -n "${checkout_override}" ]]; then
+  checkout_path="${checkout_override}"
+fi
+
+checkout_abs="$(resolve_path "${checkout_path}")"
+[[ -d "${checkout_abs}/.git" ]] || die "checkout git dir not found: ${checkout_abs}"
+
+actual_commit="$(git -C "${checkout_abs}" rev-parse --verify HEAD)"
+if [[ "${actual_commit}" != "${pinned_commit}" ]]; then
+  die "checkout commit mismatch: expected ${pinned_commit}, got ${actual_commit}"
+fi
+
+origin_url="$(git -C "${checkout_abs}" config --get remote.origin.url || true)"
+[[ -n "${origin_url}" ]] || die "remote.origin.url missing in checkout: ${checkout_abs}"
+
+normalized_manifest_repo="$(normalize_repo_url "${source_repo}")"
+normalized_origin_repo="$(normalize_repo_url "${origin_url}")"
+if [[ "${normalized_manifest_repo}" != "${normalized_origin_repo}" ]]; then
+  die "origin URL mismatch: expected ${source_repo}, got ${origin_url}"
+fi
+
+for suite_root in "${included_roots[@]}"; do
+  [[ -e "${checkout_abs}/${suite_root}" ]] || die "included suite root missing: ${suite_root}"
+done
+
+echo "manifest and checkout verified"
+echo "manifest: ${manifest_path}"
+echo "generatedAtUtc: ${generated_at}"
+echo "repo: ${source_repo}"
+echo "commit: ${pinned_commit}"

--- a/testkit/spec-sync/README.md
+++ b/testkit/spec-sync/README.md
@@ -1,0 +1,10 @@
+# Spec Sync Tests
+
+Run the spec-sync integration test:
+
+```bash
+./testkit/spec-sync/test-spec-sync.sh
+```
+
+The test creates temporary local git repositories, runs sync/verify scripts,
+and validates both success and mismatch-failure behavior.

--- a/testkit/spec-sync/test-spec-sync.sh
+++ b/testkit/spec-sync/test-spec-sync.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+SYNC_SCRIPT="${REPO_ROOT}/scripts/spec-sync/sync-mongodb-specs.sh"
+VERIFY_SCRIPT="${REPO_ROOT}/scripts/spec-sync/verify-mongodb-specs.sh"
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/jongodb-spec-sync.XXXXXX")"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+remote_repo="${tmp_dir}/specifications-remote.git"
+seed_repo="${tmp_dir}/specifications-seed"
+checkout_dir="${tmp_dir}/specifications-checkout"
+manifest_path="${tmp_dir}/manifest.json"
+
+mkdir -p "${seed_repo}"
+git init "${seed_repo}" >/dev/null
+
+mkdir -p "${seed_repo}/source/transactions/tests/unified"
+mkdir -p "${seed_repo}/source/sessions/tests"
+mkdir -p "${seed_repo}/source/crud/tests/unified"
+mkdir -p "${seed_repo}/source/unified-test-format"
+
+cat > "${seed_repo}/source/transactions/tests/unified/txn.yml" <<'EOF'
+description: transactions fixture
+EOF
+cat > "${seed_repo}/source/sessions/tests/sessions.yml" <<'EOF'
+description: sessions fixture
+EOF
+cat > "${seed_repo}/source/crud/tests/unified/crud.yml" <<'EOF'
+description: crud fixture
+EOF
+cat > "${seed_repo}/source/unified-test-format/schema-latest.json" <<'EOF'
+{"type":"object"}
+EOF
+
+git -C "${seed_repo}" add .
+git -C "${seed_repo}" \
+  -c user.name="spec-sync-test" \
+  -c user.email="spec-sync-test@example.com" \
+  commit -m "seed commit" >/dev/null
+commit_one="$(git -C "${seed_repo}" rev-parse --verify HEAD)"
+
+echo "description: transactions fixture v2" > "${seed_repo}/source/transactions/tests/unified/txn.yml"
+git -C "${seed_repo}" add source/transactions/tests/unified/txn.yml
+git -C "${seed_repo}" \
+  -c user.name="spec-sync-test" \
+  -c user.email="spec-sync-test@example.com" \
+  commit -m "update commit" >/dev/null
+commit_two="$(git -C "${seed_repo}" rev-parse --verify HEAD)"
+
+git init --bare "${remote_repo}" >/dev/null
+git -C "${seed_repo}" remote add origin "${remote_repo}"
+git -C "${seed_repo}" push --force origin HEAD:main >/dev/null
+
+"${SYNC_SCRIPT}" \
+  --repo-url "${remote_repo}" \
+  --commit "${commit_one}" \
+  --checkout-dir "${checkout_dir}" \
+  --manifest "${manifest_path}" >/dev/null
+
+"${VERIFY_SCRIPT}" --manifest "${manifest_path}" >/dev/null
+
+manifest_commit="$(sed -n 's/.*"pinnedCommit": "\([0-9a-f]\{40\}\)".*/\1/p' "${manifest_path}")"
+if [[ "${manifest_commit}" != "${commit_one}" ]]; then
+  echo "expected manifest pinnedCommit=${commit_one}, got ${manifest_commit}" >&2
+  exit 1
+fi
+
+git -C "${checkout_dir}" fetch --force origin "${commit_two}" >/dev/null
+git -C "${checkout_dir}" -c advice.detachedHead=false checkout --detach --force "${commit_two}" >/dev/null
+
+if "${VERIFY_SCRIPT}" --manifest "${manifest_path}" >/dev/null 2>&1; then
+  echo "verify should fail when checkout commit diverges from manifest" >&2
+  exit 1
+fi
+
+echo "spec-sync integration test passed"

--- a/third_party/mongodb-specs/.gitignore
+++ b/third_party/mongodb-specs/.gitignore
@@ -1,0 +1,2 @@
+# Local clone/checkout used by spec-sync tooling.
+.checkout/

--- a/third_party/mongodb-specs/README.md
+++ b/third_party/mongodb-specs/README.md
@@ -1,0 +1,7 @@
+# MongoDB Specs Metadata
+
+This directory stores metadata for deterministic sync of
+`mongodb/specifications`.
+
+- `manifest.json`: pinned source metadata used by sync/verify tooling.
+- `.checkout/`: local checkout (ignored by git; not vendored by default).

--- a/third_party/mongodb-specs/manifest.json
+++ b/third_party/mongodb-specs/manifest.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": 1,
+  "sourceRepoUrl": "https://github.com/mongodb/specifications.git",
+  "pinnedCommit": "99704fa8860777da1d919ef765af1e41e75f5859",
+  "generatedAtUtc": "2026-02-24T01:02:06Z",
+  "checkoutDir": "third_party/mongodb-specs/.checkout/specifications",
+  "includedSuiteRoots": [
+    "source/transactions/tests/unified",
+    "source/sessions/tests",
+    "source/crud/tests/unified",
+    "source/unified-test-format"
+  ]
+}


### PR DESCRIPTION
## Summary
- add deterministic MongoDB specifications sync script with pinned commit checkout
- add manifest verifier for repo URL, commit SHA, and included suite roots
- add lightweight test/docs and metadata under third_party without vendoring full spec corpus

## Linked Issues (Required)
Closes #48

## Verification
- ./testkit/spec-sync/test-spec-sync.sh
- ./scripts/spec-sync/verify-mongodb-specs.sh