### PR TITLE
[R3][#49] Add unified failure taxonomy ledger runner + CI artifacts

### DIFF
--- a/.github/workflows/r3-failure-ledger.yml
+++ b/.github/workflows/r3-failure-ledger.yml
@@ -1,0 +1,93 @@
+name: R3 Failure Ledger
+
+on:
+  workflow_dispatch:
+    inputs:
+      official_specs_ref:
+        description: "Commit/tag/branch in mongodb/specifications"
+        required: false
+        default: "99704fa8860777da1d919ef765af1e41e75f5859"
+  schedule:
+    - cron: "30 4 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  generate-ledger:
+    name: Generate failure ledger
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      OFFICIAL_SPECS_REPO: https://github.com/mongodb/specifications.git
+      OFFICIAL_SPECS_REF: ${{ github.event.inputs.official_specs_ref || '99704fa8860777da1d919ef765af1e41e75f5859' }}
+      MONGO_CONTAINER_NAME: jongodb-replset
+      MONGO_REPLSET_NAME: rs0
+      MONGO_PORT: "27017"
+      REPLSET_WAIT_TIMEOUT_SECONDS: "120"
+      REPLSET_WAIT_INTERVAL_SECONDS: "2"
+      REPLSET_DIAGNOSTICS_DIR: build/reports/replset-diagnostics/r3-failure-ledger
+      R3_LEDGER_OUTPUT_DIR: build/reports/r3-failure-ledger
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Temurin 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "8.11.1"
+
+      - name: Make scripts executable
+        run: chmod +x scripts/ci/*.sh
+
+      - name: Bootstrap replica set fixture
+        run: ./scripts/ci/bootstrap-replset.sh
+
+      - name: Prepare official specs checkout
+        run: |
+          ./scripts/ci/prepare-official-specs.sh \
+            --repo "${OFFICIAL_SPECS_REPO}" \
+            --ref "${OFFICIAL_SPECS_REF}" \
+            --dest "${RUNNER_TEMP}/mongodb-specifications"
+
+      - name: Run failure ledger generation
+        run: |
+          gradle --no-daemon --stacktrace \
+            -Pr3SpecRepoRoot="${RUNNER_TEMP}/mongodb-specifications" \
+            -Pr3FailureLedgerOutputDir="${R3_LEDGER_OUTPUT_DIR}" \
+            -Pr3FailureLedgerMongoUri="${JONGODB_REAL_MONGOD_URI}" \
+            r3FailureLedger
+
+      - name: Collect replica set diagnostics
+        if: always()
+        run: ./scripts/ci/collect-replset-diagnostics.sh "${REPLSET_DIAGNOSTICS_DIR}"
+
+      - name: Upload failure ledger artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: r3-failure-ledger
+          path: |
+            build/reports/r3-failure-ledger/**/*.json
+            build/reports/r3-failure-ledger/**/*.md
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload replica set diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: r3-failure-ledger-diagnostics
+          path: build/reports/replset-diagnostics/r3-failure-ledger/**
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Teardown replica set fixture
+        if: always()
+        run: ./scripts/ci/teardown-replset.sh

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -301,3 +301,29 @@ tasks.register<JavaExec>("r2CanaryCertificationEvidence") {
         if (failOnGate) "--fail-on-gate" else "--no-fail-on-gate"
     )
 }
+
+tasks.register<JavaExec>("r3FailureLedger") {
+    group = "verification"
+    description = "Generates deterministic R3 failure-ledger artifacts from official suite runs."
+    classpath = sourceSets["main"].runtimeClasspath
+    mainClass.set("org.jongodb.testkit.R3FailureLedgerRunner")
+
+    val specRepoRoot = (findProperty("r3SpecRepoRoot") as String?)
+        ?: "third_party/mongodb-specs/.checkout/specifications"
+    val outputDir = (findProperty("r3FailureLedgerOutputDir") as String?)
+        ?: "build/reports/r3-failure-ledger"
+    val seed = (findProperty("r3FailureLedgerSeed") as String?) ?: "r3-failure-ledger-v1"
+    val replayLimit = (findProperty("r3FailureLedgerReplayLimit") as String?) ?: "20"
+    val mongoUri = (findProperty("r3FailureLedgerMongoUri") as String?)
+        ?: (System.getenv("JONGODB_REAL_MONGOD_URI") ?: "")
+
+    args(
+        "--spec-repo-root=$specRepoRoot",
+        "--output-dir=$outputDir",
+        "--seed=$seed",
+        "--replay-limit=$replayLimit"
+    )
+    if (mongoUri.isNotBlank()) {
+        args("--mongo-uri=$mongoUri")
+    }
+}

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -88,6 +88,14 @@ gradle replayFailureBundle \
   -PreplayFailureId="utf::some-case-id"
 ```
 
+Generate R3 failure ledger artifacts:
+
+```bash
+gradle r3FailureLedger \
+  -Pr3SpecRepoRoot="third_party/mongodb-specs/.checkout/specifications" \
+  -Pr3FailureLedgerMongoUri="mongodb://localhost:27017"
+```
+
 Run Spring compatibility matrix:
 
 ```bash
@@ -148,6 +156,9 @@ GitHub Actions workflow:
   - `build/reports/unified-spec/utf-differential-report.json`
   - `build/reports/unified-spec/utf-differential-report.md`
   - `build/reports/unified-spec/failure-replay-bundles/manifest.json`
+- R3 failure ledger:
+  - `build/reports/r3-failure-ledger/r3-failure-ledger.json`
+  - `build/reports/r3-failure-ledger/r3-failure-ledger.md`
 - Spring matrix:
   - `build/reports/spring-matrix/spring-compatibility-matrix.json`
   - `build/reports/spring-matrix/spring-compatibility-matrix.md`

--- a/src/main/java/org/jongodb/testkit/R3FailureLedgerRunner.java
+++ b/src/main/java/org/jongodb/testkit/R3FailureLedgerRunner.java
@@ -1,0 +1,604 @@
+package org.jongodb.testkit;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.bson.Document;
+
+/**
+ * Generates deterministic R3 failure-ledger artifacts from official suite runs.
+ */
+public final class R3FailureLedgerRunner {
+    private static final String DEFAULT_MONGO_URI_ENV = "JONGODB_REAL_MONGOD_URI";
+    private static final Path DEFAULT_SPEC_REPO_ROOT = Path.of("third_party/mongodb-specs/.checkout/specifications");
+    private static final Path DEFAULT_OUTPUT_DIR = Path.of("build/reports/r3-failure-ledger");
+    private static final String DEFAULT_SEED = "r3-failure-ledger-v1";
+    private static final int DEFAULT_REPLAY_LIMIT = 20;
+    private static final String JSON_ARTIFACT_FILE = "r3-failure-ledger.json";
+    private static final String MARKDOWN_ARTIFACT_FILE = "r3-failure-ledger.md";
+    private static final Pattern CODE_PATTERN = Pattern.compile("code=([-]?[0-9]+)");
+
+    private static final List<SuiteConfig> DEFAULT_SUITES = List.of(
+            new SuiteConfig("crud-unified", "source/crud/tests/unified"),
+            new SuiteConfig("transactions-unified", "source/transactions/tests/unified"),
+            new SuiteConfig("sessions", "source/sessions/tests"));
+
+    private final Clock clock;
+    private final UnifiedSpecImporter importer;
+    private final Supplier<DifferentialBackend> leftBackendFactory;
+    private final Function<String, DifferentialBackend> rightBackendFactory;
+
+    public R3FailureLedgerRunner() {
+        this(
+                Clock.systemUTC(),
+                new UnifiedSpecImporter(),
+                () -> new WireCommandIngressBackend("wire-backend"),
+                mongoUri -> new RealMongodBackend("real-mongod", mongoUri));
+    }
+
+    R3FailureLedgerRunner(
+            final Clock clock,
+            final UnifiedSpecImporter importer,
+            final Supplier<DifferentialBackend> leftBackendFactory,
+            final Function<String, DifferentialBackend> rightBackendFactory) {
+        this.clock = Objects.requireNonNull(clock, "clock");
+        this.importer = Objects.requireNonNull(importer, "importer");
+        this.leftBackendFactory = Objects.requireNonNull(leftBackendFactory, "leftBackendFactory");
+        this.rightBackendFactory = Objects.requireNonNull(rightBackendFactory, "rightBackendFactory");
+    }
+
+    public static void main(final String[] args) throws Exception {
+        if (containsHelpFlag(args)) {
+            printUsage();
+            return;
+        }
+
+        final RunConfig config;
+        try {
+            config = RunConfig.fromArgs(args);
+        } catch (final IllegalArgumentException exception) {
+            System.err.println("Invalid argument: " + exception.getMessage());
+            printUsage();
+            System.exit(1);
+            return;
+        }
+
+        final R3FailureLedgerRunner runner = new R3FailureLedgerRunner();
+        final RunResult result = runner.runAndWrite(config);
+        final ArtifactPaths paths = artifactPaths(config.outputDir());
+
+        System.out.println("R3 failure ledger generated.");
+        System.out.println("- generatedAt: " + result.generatedAt());
+        System.out.println("- specRepoRoot: " + result.config().specRepoRoot());
+        System.out.println("- failures: " + result.entries().size());
+        System.out.println("- jsonArtifact: " + paths.jsonArtifact());
+        System.out.println("- markdownArtifact: " + paths.markdownArtifact());
+    }
+
+    public RunResult runAndWrite(final RunConfig config) throws IOException {
+        Objects.requireNonNull(config, "config");
+        final RunResult result = run(config);
+        final ArtifactPaths paths = artifactPaths(config.outputDir());
+        Files.createDirectories(config.outputDir());
+        Files.writeString(paths.jsonArtifact(), renderJson(result), StandardCharsets.UTF_8);
+        Files.writeString(paths.markdownArtifact(), renderMarkdown(result), StandardCharsets.UTF_8);
+        return result;
+    }
+
+    public RunResult run(final RunConfig config) throws IOException {
+        Objects.requireNonNull(config, "config");
+        final UnifiedSpecCorpusRunner unifiedRunner = new UnifiedSpecCorpusRunner(
+                clock,
+                importer,
+                leftBackendFactory,
+                rightBackendFactory);
+
+        final Instant generatedAt = clock.instant();
+        final List<FailureLedgerEntry> entries = new ArrayList<>();
+        final List<SuiteRunSummary> suiteSummaries = new ArrayList<>();
+
+        for (final SuiteConfig suiteConfig : config.suites()) {
+            final Path suiteSpecRoot = config.specRepoRoot().resolve(suiteConfig.relativeSpecRoot()).normalize();
+            if (!Files.exists(suiteSpecRoot)) {
+                suiteSummaries.add(SuiteRunSummary.missing(suiteConfig.id(), suiteConfig.relativeSpecRoot()));
+                continue;
+            }
+
+            final UnifiedSpecCorpusRunner.RunConfig suiteRunConfig = new UnifiedSpecCorpusRunner.RunConfig(
+                    suiteSpecRoot,
+                    config.outputDir().resolve("suite-artifacts").resolve(suiteConfig.id()),
+                    config.seed() + "-" + suiteConfig.id(),
+                    config.mongoUri(),
+                    config.replayLimit());
+            final UnifiedSpecCorpusRunner.RunResult suiteResult = unifiedRunner.run(suiteRunConfig);
+            suiteSummaries.add(SuiteRunSummary.fromSuite(suiteConfig.id(), suiteConfig.relativeSpecRoot(), suiteResult));
+            collectFailures(entries, suiteConfig.id(), suiteConfig.relativeSpecRoot(), suiteResult);
+        }
+
+        entries.sort(Comparator.comparing(FailureLedgerEntry::failureId));
+        final Map<String, Integer> byTrack = countBy(entries, FailureLedgerEntry::track);
+        final Map<String, Integer> byStatus = countBy(entries, entry -> entry.status().name());
+
+        return new RunResult(
+                config,
+                generatedAt,
+                List.copyOf(entries),
+                List.copyOf(suiteSummaries),
+                Map.copyOf(byTrack),
+                Map.copyOf(byStatus));
+    }
+
+    public static ArtifactPaths artifactPaths(final Path outputDir) {
+        Objects.requireNonNull(outputDir, "outputDir");
+        final Path normalized = outputDir.normalize();
+        return new ArtifactPaths(
+                normalized.resolve(JSON_ARTIFACT_FILE),
+                normalized.resolve(MARKDOWN_ARTIFACT_FILE));
+    }
+
+    private static void collectFailures(
+            final List<FailureLedgerEntry> sink,
+            final String suiteId,
+            final String suiteRoot,
+            final UnifiedSpecCorpusRunner.RunResult suiteResult) {
+        final Map<String, UnifiedSpecImporter.ImportedScenario> byCaseId = new LinkedHashMap<>();
+        for (final UnifiedSpecImporter.ImportedScenario importedScenario : suiteResult.importResult().importedScenarios()) {
+            byCaseId.put(importedScenario.caseId(), importedScenario);
+        }
+
+        for (final DiffResult diffResult : suiteResult.differentialReport().results()) {
+            if (diffResult.status() == DiffStatus.MATCH) {
+                continue;
+            }
+            final UnifiedSpecImporter.ImportedScenario importedScenario = byCaseId.get(diffResult.scenarioId());
+            final Scenario scenario = importedScenario == null ? null : importedScenario.scenario();
+            final List<ScenarioCommand> commands = scenario == null ? List.of() : scenario.commands();
+            final String sourcePath = importedScenario == null ? "" : importedScenario.sourcePath();
+            final String track = classifyTrack(suiteId, sourcePath, commands);
+            final String primaryCommand = commands.isEmpty() ? "unknown" : commands.get(0).commandName();
+            final String firstDiffPath = diffResult.entries().isEmpty() ? null : diffResult.entries().get(0).path();
+            final String message = failureMessage(diffResult);
+            final String errorKey = buildErrorKey(diffResult, message);
+
+            sink.add(new FailureLedgerEntry(
+                    buildFailureId(suiteId, diffResult),
+                    suiteId,
+                    suiteRoot,
+                    diffResult.scenarioId(),
+                    sourcePath,
+                    track,
+                    diffResult.status(),
+                    primaryCommand,
+                    commandNames(commands),
+                    firstDiffPath,
+                    errorKey,
+                    message));
+        }
+    }
+
+    private static String buildFailureId(final String suiteId, final DiffResult diffResult) {
+        return suiteId + "::" + diffResult.status().name().toLowerCase(Locale.ROOT) + "::" + diffResult.scenarioId();
+    }
+
+    private static String failureMessage(final DiffResult diffResult) {
+        if (diffResult.status() == DiffStatus.ERROR) {
+            return diffResult.errorMessage().orElse("unknown error");
+        }
+        if (diffResult.entries().isEmpty()) {
+            return "mismatch without diff entries";
+        }
+        final DiffEntry first = diffResult.entries().get(0);
+        final String note = first.note() == null ? "" : first.note();
+        return first.path() + ": " + (note.isBlank() ? "value mismatch" : note);
+    }
+
+    private static String buildErrorKey(final DiffResult diffResult, final String message) {
+        if (diffResult.status() != DiffStatus.ERROR) {
+            return "mismatch";
+        }
+        final Matcher matcher = CODE_PATTERN.matcher(message);
+        if (matcher.find()) {
+            return "code:" + matcher.group(1);
+        }
+        return "error:unknown-code";
+    }
+
+    private static String classifyTrack(
+            final String suiteId,
+            final String sourcePath,
+            final List<ScenarioCommand> commands) {
+        final String suiteLower = suiteId.toLowerCase(Locale.ROOT);
+        final String sourceLower = sourcePath == null ? "" : sourcePath.toLowerCase(Locale.ROOT);
+        if (suiteLower.contains("transaction") || sourceLower.contains("/transactions/")) {
+            return "txn";
+        }
+
+        boolean hasTxn = false;
+        boolean hasAggregation = false;
+        boolean hasQueryUpdate = false;
+        for (final ScenarioCommand command : commands) {
+            final String name = command.commandName().toLowerCase(Locale.ROOT);
+            if (name.contains("transaction")) {
+                hasTxn = true;
+            }
+            if ("aggregate".equals(name)) {
+                hasAggregation = true;
+            }
+            if ("find".equals(name)
+                    || name.startsWith("update")
+                    || name.startsWith("delete")
+                    || name.startsWith("insert")
+                    || "findandmodify".equals(name)
+                    || "replaceone".equals(name)) {
+                hasQueryUpdate = true;
+            }
+
+            final Map<String, Object> payload = command.payload();
+            if (payload.containsKey("txnNumber")
+                    || payload.containsKey("startTransaction")
+                    || "committransaction".equals(name)
+                    || "aborttransaction".equals(name)) {
+                hasTxn = true;
+            }
+        }
+        if (hasTxn) {
+            return "txn";
+        }
+        if (hasAggregation) {
+            return "aggregation";
+        }
+        if (hasQueryUpdate) {
+            return "query_update";
+        }
+        return "protocol";
+    }
+
+    private static List<String> commandNames(final List<ScenarioCommand> commands) {
+        final List<String> names = new ArrayList<>(commands.size());
+        for (final ScenarioCommand command : commands) {
+            names.add(command.commandName());
+        }
+        return List.copyOf(names);
+    }
+
+    private static Map<String, Integer> countBy(
+            final List<FailureLedgerEntry> entries,
+            final Function<FailureLedgerEntry, String> keyFunction) {
+        final Map<String, Integer> counts = new TreeMap<>();
+        for (final FailureLedgerEntry entry : entries) {
+            final String key = keyFunction.apply(entry);
+            counts.merge(key, 1, Integer::sum);
+        }
+        return counts;
+    }
+
+    String renderJson(final RunResult result) {
+        final Document root = new Document();
+        root.put("generatedAt", result.generatedAt().toString());
+        root.put("seed", result.config().seed());
+        root.put("specRepoRoot", result.config().specRepoRoot().toString());
+        root.put("suiteCount", result.config().suites().size());
+        root.put("failureCount", result.entries().size());
+        root.put("byTrack", new Document(result.byTrack()));
+        root.put("byStatus", new Document(result.byStatus()));
+
+        final List<Document> suiteSummaryDocs = new ArrayList<>();
+        for (final SuiteRunSummary suiteSummary : result.suiteSummaries()) {
+            suiteSummaryDocs.add(new Document()
+                    .append("suiteId", suiteSummary.suiteId())
+                    .append("suiteRoot", suiteSummary.suiteRoot())
+                    .append("status", suiteSummary.status())
+                    .append("imported", suiteSummary.imported())
+                    .append("skipped", suiteSummary.skipped())
+                    .append("unsupported", suiteSummary.unsupported())
+                    .append("total", suiteSummary.total())
+                    .append("match", suiteSummary.match())
+                    .append("mismatch", suiteSummary.mismatch())
+                    .append("error", suiteSummary.error()));
+        }
+        root.put("suiteSummaries", suiteSummaryDocs);
+
+        final List<Document> failureDocs = new ArrayList<>();
+        for (final FailureLedgerEntry entry : result.entries()) {
+            failureDocs.add(new Document()
+                    .append("failureId", entry.failureId())
+                    .append("suiteId", entry.suiteId())
+                    .append("suiteRoot", entry.suiteRoot())
+                    .append("scenarioId", entry.scenarioId())
+                    .append("sourcePath", entry.sourcePath())
+                    .append("track", entry.track())
+                    .append("status", entry.status().name())
+                    .append("primaryCommand", entry.primaryCommand())
+                    .append("commandNames", entry.commandNames())
+                    .append("firstDiffPath", entry.firstDiffPath())
+                    .append("errorKey", entry.errorKey())
+                    .append("message", entry.message()));
+        }
+        root.put("entries", failureDocs);
+        return root.toJson();
+    }
+
+    String renderMarkdown(final RunResult result) {
+        final StringBuilder markdown = new StringBuilder();
+        markdown.append("# R3 Failure Ledger\n\n");
+        markdown.append("- generatedAt: ").append(result.generatedAt()).append('\n');
+        markdown.append("- specRepoRoot: ").append(result.config().specRepoRoot()).append('\n');
+        markdown.append("- seed: ").append(result.config().seed()).append('\n');
+        markdown.append("- failureCount: ").append(result.entries().size()).append('\n');
+        markdown.append('\n');
+
+        markdown.append("## Track Breakdown\n\n");
+        if (result.byTrack().isEmpty()) {
+            markdown.append("- none\n\n");
+        } else {
+            for (final Map.Entry<String, Integer> entry : result.byTrack().entrySet()) {
+                markdown.append("- ").append(entry.getKey()).append(": ").append(entry.getValue()).append('\n');
+            }
+            markdown.append('\n');
+        }
+
+        markdown.append("## Suite Summaries\n\n");
+        for (final SuiteRunSummary suiteSummary : result.suiteSummaries()) {
+            markdown.append("- ").append(suiteSummary.suiteId())
+                    .append(" [").append(suiteSummary.status()).append("] ")
+                    .append("imported=").append(suiteSummary.imported())
+                    .append(", mismatch=").append(suiteSummary.mismatch())
+                    .append(", error=").append(suiteSummary.error())
+                    .append('\n');
+        }
+        markdown.append('\n');
+
+        markdown.append("## Failure Entries\n\n");
+        if (result.entries().isEmpty()) {
+            markdown.append("- none\n");
+        } else {
+            for (final FailureLedgerEntry entry : result.entries()) {
+                markdown.append("- ").append(entry.failureId())
+                        .append(" [track=").append(entry.track())
+                        .append(", status=").append(entry.status().name())
+                        .append("] ").append(entry.message())
+                        .append('\n');
+            }
+        }
+        return markdown.toString();
+    }
+
+    private static boolean containsHelpFlag(final String[] args) {
+        for (final String arg : args) {
+            if ("--help".equals(arg) || "-h".equals(arg)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void printUsage() {
+        System.out.println("Usage: R3FailureLedgerRunner [options]");
+        System.out.println("  --spec-repo-root=<path>    Official specs checkout root");
+        System.out.println("  --output-dir=<path>        Output dir (default: build/reports/r3-failure-ledger)");
+        System.out.println("  --seed=<value>             Deterministic seed");
+        System.out.println("  --mongo-uri=<uri>          Real mongod URI (or env JONGODB_REAL_MONGOD_URI)");
+        System.out.println("  --replay-limit=<n>         Failure replay capture limit per suite");
+        System.out.println("  --suite=<id>:<root>        Additional suite mapping (repeatable)");
+        System.out.println("  --help, -h                 Show help");
+    }
+
+    public record SuiteConfig(String id, String relativeSpecRoot) {
+        public SuiteConfig {
+            id = requireText(id, "suite.id");
+            relativeSpecRoot = requireText(relativeSpecRoot, "suite.relativeSpecRoot");
+        }
+    }
+
+    public record FailureLedgerEntry(
+            String failureId,
+            String suiteId,
+            String suiteRoot,
+            String scenarioId,
+            String sourcePath,
+            String track,
+            DiffStatus status,
+            String primaryCommand,
+            List<String> commandNames,
+            String firstDiffPath,
+            String errorKey,
+            String message) {
+        public FailureLedgerEntry {
+            failureId = requireText(failureId, "failureId");
+            suiteId = requireText(suiteId, "suiteId");
+            suiteRoot = requireText(suiteRoot, "suiteRoot");
+            scenarioId = requireText(scenarioId, "scenarioId");
+            sourcePath = sourcePath == null ? "" : sourcePath;
+            track = requireText(track, "track");
+            status = Objects.requireNonNull(status, "status");
+            primaryCommand = requireText(primaryCommand, "primaryCommand");
+            commandNames = List.copyOf(Objects.requireNonNull(commandNames, "commandNames"));
+            firstDiffPath = firstDiffPath == null ? "" : firstDiffPath;
+            errorKey = requireText(errorKey, "errorKey");
+            message = requireText(message, "message");
+        }
+    }
+
+    public record SuiteRunSummary(
+            String suiteId,
+            String suiteRoot,
+            String status,
+            int imported,
+            int skipped,
+            int unsupported,
+            int total,
+            int match,
+            int mismatch,
+            int error) {
+        static SuiteRunSummary missing(final String suiteId, final String suiteRoot) {
+            return new SuiteRunSummary(suiteId, suiteRoot, "MISSING", 0, 0, 0, 0, 0, 0, 0);
+        }
+
+        static SuiteRunSummary fromSuite(
+                final String suiteId,
+                final String suiteRoot,
+                final UnifiedSpecCorpusRunner.RunResult runResult) {
+            return new SuiteRunSummary(
+                    suiteId,
+                    suiteRoot,
+                    "OK",
+                    runResult.importResult().importedCount(),
+                    runResult.importResult().skippedCount(),
+                    runResult.importResult().unsupportedCount(),
+                    runResult.differentialReport().totalScenarios(),
+                    runResult.differentialReport().matchCount(),
+                    runResult.differentialReport().mismatchCount(),
+                    runResult.differentialReport().errorCount());
+        }
+
+        public SuiteRunSummary {
+            suiteId = requireText(suiteId, "suiteId");
+            suiteRoot = requireText(suiteRoot, "suiteRoot");
+            status = requireText(status, "status");
+        }
+    }
+
+    public record ArtifactPaths(Path jsonArtifact, Path markdownArtifact) {}
+
+    public record RunResult(
+            RunConfig config,
+            Instant generatedAt,
+            List<FailureLedgerEntry> entries,
+            List<SuiteRunSummary> suiteSummaries,
+            Map<String, Integer> byTrack,
+            Map<String, Integer> byStatus) {
+        public RunResult {
+            config = Objects.requireNonNull(config, "config");
+            generatedAt = Objects.requireNonNull(generatedAt, "generatedAt");
+            entries = List.copyOf(Objects.requireNonNull(entries, "entries"));
+            suiteSummaries = List.copyOf(Objects.requireNonNull(suiteSummaries, "suiteSummaries"));
+            byTrack = Map.copyOf(Objects.requireNonNull(byTrack, "byTrack"));
+            byStatus = Map.copyOf(Objects.requireNonNull(byStatus, "byStatus"));
+        }
+    }
+
+    public record RunConfig(
+            Path specRepoRoot,
+            Path outputDir,
+            String seed,
+            String mongoUri,
+            int replayLimit,
+            List<SuiteConfig> suites) {
+        public RunConfig {
+            specRepoRoot = normalizePath(specRepoRoot, "specRepoRoot");
+            outputDir = normalizePath(outputDir, "outputDir");
+            seed = requireText(seed, "seed");
+            mongoUri = requireText(mongoUri, "mongoUri");
+            if (replayLimit <= 0) {
+                throw new IllegalArgumentException("replayLimit must be > 0");
+            }
+            suites = List.copyOf(Objects.requireNonNull(suites, "suites"));
+            if (suites.isEmpty()) {
+                throw new IllegalArgumentException("at least one suite is required");
+            }
+        }
+
+        static RunConfig fromArgs(final String[] args) {
+            Path specRepoRoot = DEFAULT_SPEC_REPO_ROOT;
+            Path outputDir = DEFAULT_OUTPUT_DIR;
+            String seed = DEFAULT_SEED;
+            String mongoUri = trimToNull(System.getenv(DEFAULT_MONGO_URI_ENV));
+            int replayLimit = DEFAULT_REPLAY_LIMIT;
+            final List<SuiteConfig> suites = new ArrayList<>(DEFAULT_SUITES);
+
+            for (final String arg : args) {
+                if (arg == null || arg.isBlank()) {
+                    continue;
+                }
+                if (arg.startsWith("--spec-repo-root=")) {
+                    specRepoRoot = Path.of(requireText(valueAfterPrefix(arg, "--spec-repo-root="), "spec-repo-root"));
+                    continue;
+                }
+                if (arg.startsWith("--output-dir=")) {
+                    outputDir = Path.of(requireText(valueAfterPrefix(arg, "--output-dir="), "output-dir"));
+                    continue;
+                }
+                if (arg.startsWith("--seed=")) {
+                    seed = requireText(valueAfterPrefix(arg, "--seed="), "seed");
+                    continue;
+                }
+                if (arg.startsWith("--mongo-uri=")) {
+                    mongoUri = requireText(valueAfterPrefix(arg, "--mongo-uri="), "mongo-uri");
+                    continue;
+                }
+                if (arg.startsWith("--replay-limit=")) {
+                    replayLimit = parsePositiveInt(valueAfterPrefix(arg, "--replay-limit="), "replay-limit");
+                    continue;
+                }
+                if (arg.startsWith("--suite=")) {
+                    final String raw = requireText(valueAfterPrefix(arg, "--suite="), "suite");
+                    final int separator = raw.indexOf(':');
+                    if (separator <= 0 || separator >= raw.length() - 1) {
+                        throw new IllegalArgumentException("suite must be <id>:<relative-path>");
+                    }
+                    suites.add(new SuiteConfig(raw.substring(0, separator), raw.substring(separator + 1)));
+                    continue;
+                }
+                throw new IllegalArgumentException("unknown argument: " + arg);
+            }
+
+            if (mongoUri == null || mongoUri.isBlank()) {
+                throw new IllegalArgumentException("mongo-uri must be provided (arg or " + DEFAULT_MONGO_URI_ENV + ")");
+            }
+            return new RunConfig(specRepoRoot, outputDir, seed, mongoUri, replayLimit, suites);
+        }
+    }
+
+    private static int parsePositiveInt(final String value, final String fieldName) {
+        try {
+            final int parsed = Integer.parseInt(requireText(value, fieldName));
+            if (parsed <= 0) {
+                throw new IllegalArgumentException(fieldName + " must be > 0");
+            }
+            return parsed;
+        } catch (final NumberFormatException exception) {
+            throw new IllegalArgumentException(fieldName + " must be an integer", exception);
+        }
+    }
+
+    private static Path normalizePath(final Path path, final String fieldName) {
+        Objects.requireNonNull(path, fieldName);
+        return path.normalize();
+    }
+
+    private static String valueAfterPrefix(final String arg, final String prefix) {
+        return arg.substring(prefix.length());
+    }
+
+    private static String requireText(final String value, final String fieldName) {
+        final String normalized = trimToNull(value);
+        if (normalized == null) {
+            throw new IllegalArgumentException(fieldName + " must not be blank");
+        }
+        return normalized;
+    }
+
+    private static String trimToNull(final String value) {
+        if (value == null) {
+            return null;
+        }
+        final String normalized = value.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+}

--- a/src/test/java/org/jongodb/testkit/R3FailureLedgerRunnerTest.java
+++ b/src/test/java/org/jongodb/testkit/R3FailureLedgerRunnerTest.java
@@ -1,0 +1,153 @@
+package org.jongodb.testkit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class R3FailureLedgerRunnerTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void runAndWriteGeneratesDeterministicFailureLedgerArtifacts() throws Exception {
+        final Path specRepoRoot = tempDir.resolve("specifications");
+        writeFixtureSpecTree(specRepoRoot);
+
+        final Clock fixedClock = Clock.fixed(Instant.parse("2026-02-24T01:30:00Z"), ZoneOffset.UTC);
+        final R3FailureLedgerRunner runner = new R3FailureLedgerRunner(
+                fixedClock,
+                new UnifiedSpecImporter(),
+                () -> new StubBackend("left-backend", scenario -> successResult(scenario.id())),
+                mongoUri -> new StubBackend("right-backend", scenario -> {
+                    if (scenario.description().contains("mismatch")) {
+                        return successResult("different-" + scenario.id());
+                    }
+                    if (scenario.description().contains("error-case")) {
+                        throw new IllegalStateException("forced-error");
+                    }
+                    return successResult(scenario.id());
+                }));
+
+        final R3FailureLedgerRunner.RunConfig config = new R3FailureLedgerRunner.RunConfig(
+                specRepoRoot,
+                tempDir.resolve("out"),
+                "seed-r3",
+                "mongodb://example",
+                10,
+                List.of(
+                        new R3FailureLedgerRunner.SuiteConfig("crud-unified", "source/crud/tests/unified"),
+                        new R3FailureLedgerRunner.SuiteConfig("transactions-unified", "source/transactions/tests/unified")));
+
+        final R3FailureLedgerRunner.RunResult first = runner.runAndWrite(config);
+        final R3FailureLedgerRunner.RunResult second = runner.run(config);
+
+        assertEquals(extractFailureIds(first), extractFailureIds(second));
+        assertEquals(3, first.entries().size());
+        assertEquals(1, first.byTrack().get("txn"));
+        assertEquals(1, first.byTrack().get("aggregation"));
+        assertEquals(1, first.byTrack().get("query_update"));
+
+        final R3FailureLedgerRunner.ArtifactPaths artifactPaths = R3FailureLedgerRunner.artifactPaths(config.outputDir());
+        assertTrue(Files.exists(artifactPaths.jsonArtifact()));
+        assertTrue(Files.exists(artifactPaths.markdownArtifact()));
+
+        final Document json = Document.parse(Files.readString(artifactPaths.jsonArtifact()));
+        assertEquals(3, json.getInteger("failureCount"));
+        assertEquals(3, json.getList("entries", Document.class).size());
+        assertEquals(1, json.get("byTrack", Document.class).getInteger("txn"));
+    }
+
+    private static List<String> extractFailureIds(final R3FailureLedgerRunner.RunResult result) {
+        final List<String> ids = new ArrayList<>();
+        for (final R3FailureLedgerRunner.FailureLedgerEntry entry : result.entries()) {
+            ids.add(entry.failureId());
+        }
+        return List.copyOf(ids);
+    }
+
+    private static ScenarioOutcome successResult(final String marker) {
+        return ScenarioOutcome.success(List.of(Map.of(
+                "ok", 1,
+                "marker", marker)));
+    }
+
+    private static void writeFixtureSpecTree(final Path specRepoRoot) throws IOException {
+        final Path crudDir = specRepoRoot.resolve("source/crud/tests/unified");
+        final Path txnDir = specRepoRoot.resolve("source/transactions/tests/unified");
+        Files.createDirectories(crudDir);
+        Files.createDirectories(txnDir);
+
+        Files.writeString(
+                crudDir.resolve("crud.json"),
+                """
+                {
+                  "database_name": "app",
+                  "collection_name": "orders",
+                  "tests": [
+                    {
+                      "description": "mismatch-agg",
+                      "operations": [
+                        {"name": "aggregate", "arguments": {"pipeline": []}}
+                      ]
+                    },
+                    {
+                      "description": "error-case",
+                      "operations": [
+                        {"name": "find", "arguments": {"filter": {"status": "pending"}}}
+                      ]
+                    }
+                  ]
+                }
+                """);
+
+        Files.writeString(
+                txnDir.resolve("txn.json"),
+                """
+                {
+                  "database_name": "app",
+                  "collection_name": "users",
+                  "tests": [
+                    {
+                      "description": "txn-mismatch",
+                      "operations": [
+                        {"name": "find", "arguments": {"filter": {"name": "kim"}}}
+                      ]
+                    }
+                  ]
+                }
+                """);
+    }
+
+    private static final class StubBackend implements DifferentialBackend {
+        private final String name;
+        private final Function<Scenario, ScenarioOutcome> executor;
+
+        private StubBackend(final String name, final Function<Scenario, ScenarioOutcome> executor) {
+            this.name = name;
+            this.executor = executor;
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public ScenarioOutcome execute(final Scenario scenario) {
+            return executor.apply(scenario);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add R3FailureLedgerRunner to execute official suite roots and emit deterministic failure-ledger JSON/Markdown artifacts
- add track/status taxonomy and stable failure IDs for non-match differential cases
- add Gradle entrypoint r3FailureLedger and CI workflow to publish ledger artifacts
- add focused runner determinism test and usage updates

## Linked Issues (Required)
Closes #49

## Verification
- ./.tooling/gradle-8.10.2/bin/gradle --no-daemon test --tests org.jongodb.testkit.R3FailureLedgerRunnerTest --tests org.jongodb.testkit.UnifiedSpecCorpusRunnerTest
- python3 YAML parse check for .github/workflows/r3-failure-ledger.yml
- bash -n scripts/ci/prepare-official-specs.sh scripts/ci/run-utf-shard.sh scripts/ci/assert-utf-shard-consistency.sh
