### PR TITLE
[R3][#50] Document protocol parity baseline from failure ledger

### DIFF
--- a/docs/research/14-r3-issue-50-protocol-parity-baseline.md
+++ b/docs/research/14-r3-issue-50-protocol-parity-baseline.md
@@ -1,0 +1,35 @@
+# R3 Issue #50: Protocol/Wire Parity Baseline
+
+Date: 2026-02-24
+
+## Objective
+
+Close protocol and command-surface gaps identified by the R3 failure ledger.
+
+## Baseline Method
+
+1. Bootstrap a local single-node replica set fixture.
+2. Check out pinned `mongodb/specifications` commit from `third_party/mongodb-specs/manifest.json`.
+3. Run:
+
+```bash
+gradle r3FailureLedger \
+  -Pr3SpecRepoRoot="third_party/mongodb-specs/.checkout/specifications" \
+  -Pr3FailureLedgerMongoUri="<replica-set-uri>"
+```
+
+4. Inspect `build/reports/r3-failure-ledger/r3-failure-ledger.json`.
+
+## Baseline Result
+
+- `failureCount`: 104
+- `byTrack`:
+  - `aggregation`: 44
+  - `query_update`: 60
+  - `protocol`: 0
+  - `txn`: 0
+
+## Conclusion for Issue #50
+
+For the current pinned corpus and runner profile, there are no protocol-tagged failures in the failure ledger.
+Protocol track remains covered by existing wire/command tests, and parity work is now concentrated on query/update and aggregation tracks.

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -15,6 +15,9 @@
 - [`09-r1-replacement-reference-baseline.md`](./09-r1-replacement-reference-baseline.md): R1 대체 목표의 공식 레퍼런스 기준선
 - [`10-r1-issue-reference-test-matrix.md`](./10-r1-issue-reference-test-matrix.md): R1 이슈별 레퍼런스/테스트/게이트 매핑
 - [`11-r1-issue-37-canary-cutover-rollback-playbook.md`](./11-r1-issue-37-canary-cutover-rollback-playbook.md): Issue #37 canary 전환/롤백 실행 플레이북
+- [`12-r2-scorecard-manifest.md`](./12-r2-scorecard-manifest.md): R2 scorecard/support manifest 산출 규격
+- [`13-r2-canary-certification.md`](./13-r2-canary-certification.md): R2 외부 canary 인증 산출 규격
+- [`14-r3-issue-50-protocol-parity-baseline.md`](./14-r3-issue-50-protocol-parity-baseline.md): R3 failure ledger 기준 protocol parity baseline
 
 ## 권장 읽기 순서
 
@@ -29,6 +32,9 @@
 9. `09-r1-replacement-reference-baseline.md`로 R1 판정 기준 고정
 10. `10-r1-issue-reference-test-matrix.md`로 이슈 실행/검증 매핑 적용
 11. `11-r1-issue-37-canary-cutover-rollback-playbook.md`로 canary cutover/rollback 증빙 운영
+12. `12-r2-scorecard-manifest.md`로 R2 산출물 포맷 고정
+13. `13-r2-canary-certification.md`로 외부 canary 인증 기준 고정
+14. `14-r3-issue-50-protocol-parity-baseline.md`로 R3 protocol baseline 확인
 
 ## 리서치 스냅샷
 


### PR DESCRIPTION
## Summary
- add R3 protocol parity baseline note based on failure-ledger output
- record that protocol-tagged failures are zero for the current pinned corpus/profile
- update research index for R2/R3 operational references

## Linked Issues (Required)
Closes #50

## Verification
- baseline generated with gradle r3FailureLedger and checked from r3-failure-ledger JSON artifact output
- document includes deterministic reproduction steps
