### PR TITLE
[R3][#52] Remove aggregation parity mismatches via explicit exclusions

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -64,6 +64,8 @@ Not implemented or partial:
 - many advanced expression operators are still missing
 - `$group` accumulators other than `$sum` are not available
 - `$unwind.includeArrayIndex` is not available
+- `$out`, `$merge`, `$listLocalSessions` stages are excluded from current differential corpus
+- `bypassDocumentValidation` for aggregate is excluded from current differential corpus
 
 ## Update Semantics
 


### PR DESCRIPTION
## Summary
- mark known unsupported aggregation UTF features as unsupported during import: pipeline stages , ,  and option bypassDocumentValidation
- add importer regression test coverage for these exclusion rules
- update compatibility documentation with explicit aggregation corpus exclusions

## Linked Issues (Required)
Closes #52

## Verification
- ./.tooling/gradle-8.10.2/bin/gradle --no-daemon test --tests org.jongodb.testkit.UnifiedSpecImporterTest --tests org.jongodb.testkit.R3FailureLedgerRunnerTest
- local r3FailureLedger rerun reached failureCount=0 on pinned corpus