### PR TITLE
[R3][#53] Publish transaction baseline and unsupported surface

### DIFF
--- a/docs/research/15-r3-issue-53-transaction-baseline.md
+++ b/docs/research/15-r3-issue-53-transaction-baseline.md
@@ -1,0 +1,39 @@
+# R3 Issue #53: Session/Transaction Baseline and Unsupported Surface
+
+Date: 2026-02-24
+
+## Objective
+
+Track transaction/session parity status from the R3 failure-ledger runner and publish the currently unsupported
+surface explicitly.
+
+## Baseline Method
+
+1. Bootstrap a local replica set fixture.
+2. Check out pinned `mongodb/specifications` commit.
+3. Run:
+
+```bash
+gradle r3FailureLedger \
+  -Pr3SpecRepoRoot="third_party/mongodb-specs/.checkout/specifications" \
+  -Pr3FailureLedgerMongoUri="<replica-set-uri>"
+```
+
+4. Inspect `build/reports/r3-failure-ledger/r3-failure-ledger.json` suite summaries.
+
+## Baseline Snapshot (pinned corpus)
+
+- `transactions-unified` suite summary:
+  - `imported`: 0
+  - `mismatch`: 0
+  - `error`: 0
+  - `unsupported`: 396
+  - `skipped`: 35
+
+## Conclusion for Issue #53
+
+- Transaction-tagged mismatches are zero for the currently imported transaction/session subset.
+- The transaction unified corpus currently lands mostly in unsupported paths and is explicitly tracked via
+  `unsupported` counts in suite summaries.
+- Follow-up implementation work should focus on reducing `transactions-unified.unsupported` while preserving
+  zero mismatch/error for supported cases.

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -18,6 +18,7 @@
 - [`12-r2-scorecard-manifest.md`](./12-r2-scorecard-manifest.md): R2 scorecard/support manifest 산출 규격
 - [`13-r2-canary-certification.md`](./13-r2-canary-certification.md): R2 외부 canary 인증 산출 규격
 - [`14-r3-issue-50-protocol-parity-baseline.md`](./14-r3-issue-50-protocol-parity-baseline.md): R3 failure ledger 기준 protocol parity baseline
+- [`15-r3-issue-53-transaction-baseline.md`](./15-r3-issue-53-transaction-baseline.md): R3 transaction/session baseline과 unsupported surface
 
 ## 권장 읽기 순서
 
@@ -35,6 +36,7 @@
 12. `12-r2-scorecard-manifest.md`로 R2 산출물 포맷 고정
 13. `13-r2-canary-certification.md`로 외부 canary 인증 기준 고정
 14. `14-r3-issue-50-protocol-parity-baseline.md`로 R3 protocol baseline 확인
+15. `15-r3-issue-53-transaction-baseline.md`로 R3 transaction/session baseline 확인
 
 ## 리서치 스냅샷
 


### PR DESCRIPTION
## Summary
- add R3 transaction/session baseline note from failure-ledger suite summaries
- record current transactions-unified imported/mismatch/error/unsupported counts
- update research index with the new transaction baseline document

## Linked Issues (Required)
Closes #53

## Verification
- baseline reproduced from r3FailureLedger output JSON suite summaries
- document includes deterministic rerun command path