### PR TITLE
[R3][#55] Enforce differential oracle gate and trend artifacts

### DIFF
--- a/.github/workflows/r3-failure-ledger.yml
+++ b/.github/workflows/r3-failure-ledger.yml
@@ -62,7 +62,50 @@ jobs:
             -Pr3SpecRepoRoot="${RUNNER_TEMP}/mongodb-specifications" \
             -Pr3FailureLedgerOutputDir="${R3_LEDGER_OUTPUT_DIR}" \
             -Pr3FailureLedgerMongoUri="${JONGODB_REAL_MONGOD_URI}" \
+            -Pr3FailureLedgerFailOnFailures=true \
             r3FailureLedger
+
+      - name: Build trend snapshot
+        run: |
+          python3 - <<'PY'
+          import json
+          from datetime import datetime, timezone
+          from pathlib import Path
+
+          report = Path("build/reports/r3-failure-ledger/r3-failure-ledger.json")
+          out = Path("build/reports/r3-failure-ledger/r3-failure-ledger-trend.md")
+          data = json.loads(report.read_text(encoding="utf-8"))
+
+          now = datetime.now(timezone.utc).isoformat()
+          lines = [
+              "# R3 Differential Trend Snapshot",
+              "",
+              f"- generatedAtUtc: {now}",
+              f"- reportGeneratedAt: {data.get('generatedAt')}",
+              f"- failureCount: {data.get('failureCount')}",
+              f"- suiteCount: {data.get('suiteCount')}",
+              "",
+              "## byTrack",
+          ]
+          by_track = data.get("byTrack", {})
+          if by_track:
+              for key in sorted(by_track):
+                  lines.append(f"- {key}: {by_track[key]}")
+          else:
+              lines.append("- none")
+
+          lines.append("")
+          lines.append("## byStatus")
+          by_status = data.get("byStatus", {})
+          if by_status:
+              for key in sorted(by_status):
+                  lines.append(f"- {key}: {by_status[key]}")
+          else:
+              lines.append("- none")
+
+          out.write_text("\n".join(lines) + "\n", encoding="utf-8")
+          print(out.read_text(encoding="utf-8"))
+          PY
 
       - name: Collect replica set diagnostics
         if: always()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -316,12 +316,14 @@ tasks.register<JavaExec>("r3FailureLedger") {
     val replayLimit = (findProperty("r3FailureLedgerReplayLimit") as String?) ?: "20"
     val mongoUri = (findProperty("r3FailureLedgerMongoUri") as String?)
         ?: (System.getenv("JONGODB_REAL_MONGOD_URI") ?: "")
+    val failOnFailures = (findProperty("r3FailureLedgerFailOnFailures") as String?)?.toBoolean() ?: false
 
     args(
         "--spec-repo-root=$specRepoRoot",
         "--output-dir=$outputDir",
         "--seed=$seed",
-        "--replay-limit=$replayLimit"
+        "--replay-limit=$replayLimit",
+        if (failOnFailures) "--fail-on-failures" else "--no-fail-on-failures"
     )
     if (mongoUri.isNotBlank()) {
         args("--mongo-uri=$mongoUri")

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -93,7 +93,8 @@ Generate R3 failure ledger artifacts:
 ```bash
 gradle r3FailureLedger \
   -Pr3SpecRepoRoot="third_party/mongodb-specs/.checkout/specifications" \
-  -Pr3FailureLedgerMongoUri="mongodb://localhost:27017"
+  -Pr3FailureLedgerMongoUri="mongodb://localhost:27017" \
+  -Pr3FailureLedgerFailOnFailures=true
 ```
 
 Run Spring compatibility matrix:
@@ -159,6 +160,7 @@ GitHub Actions workflow:
 - R3 failure ledger:
   - `build/reports/r3-failure-ledger/r3-failure-ledger.json`
   - `build/reports/r3-failure-ledger/r3-failure-ledger.md`
+  - `build/reports/r3-failure-ledger/r3-failure-ledger-trend.md`
 - Spring matrix:
   - `build/reports/spring-matrix/spring-compatibility-matrix.json`
   - `build/reports/spring-matrix/spring-compatibility-matrix.md`


### PR DESCRIPTION
## Summary
- add fail-on-failures gate option to R3FailureLedgerRunner and wire it through Gradle task properties
- update r3-failure-ledger workflow to run with gate enforcement and fail when failures or missing suites are present
- add trend snapshot markdown generation step for nightly artifact publishing
- extend runner tests to cover gate pass/fail behavior

## Linked Issues (Required)
Closes #55

## Verification
- ./.tooling/gradle-8.10.2/bin/gradle --no-daemon test --tests org.jongodb.testkit.R3FailureLedgerRunnerTest
- python3 YAML parse check for .github/workflows/r3-failure-ledger.yml
- local run with fail-on-failures=true verifies non-zero exit on missing suite roots