### PR TITLE
[R3][#58] Add external canary certification workflow and evidence flow

### DIFF
--- a/.github/workflows/r3-external-canary.yml
+++ b/.github/workflows/r3-external-canary.yml
@@ -1,0 +1,50 @@
+name: R3 External Canary Certification
+
+on:
+  workflow_dispatch:
+    inputs:
+      canary_input_json:
+        description: "Path to canary project result JSON"
+        required: false
+        default: "testkit/canary/r3/projects.sample.json"
+
+permissions:
+  contents: read
+
+jobs:
+  certify-r3-canary:
+    name: Generate R3 canary certification
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Temurin 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "8.11.1"
+
+      - name: Run R3 canary certification
+        run: |
+          gradle --no-daemon --stacktrace \
+            -Pr3CanaryInputJson="${{ github.event.inputs.canary_input_json || 'testkit/canary/r3/projects.sample.json' }}" \
+            -Pr3CanaryOutputDir="build/reports/r3-canary" \
+            -Pr3CanaryFailOnGate=true \
+            r3CanaryCertificationEvidence
+
+      - name: Upload R3 canary artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: r3-canary-certification
+          path: |
+            build/reports/r3-canary/**/*.json
+            build/reports/r3-canary/**/*.md
+          if-no-files-found: error
+          retention-days: 14

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -302,6 +302,24 @@ tasks.register<JavaExec>("r2CanaryCertificationEvidence") {
     )
 }
 
+tasks.register<JavaExec>("r3CanaryCertificationEvidence") {
+    group = "verification"
+    description = "Generates R3 external canary certification artifacts from canary result JSON."
+    classpath = sourceSets["main"].runtimeClasspath
+    mainClass.set("org.jongodb.testkit.R2CanaryCertification")
+
+    val inputJson = (findProperty("r3CanaryInputJson") as String?)
+        ?: "build/reports/spring-canary/r3-projects.json"
+    val outputDir = (findProperty("r3CanaryOutputDir") as String?) ?: "build/reports/r3-canary"
+    val failOnGate = (findProperty("r3CanaryFailOnGate") as String?)?.toBoolean() ?: true
+
+    args(
+        "--input-json=$inputJson",
+        "--output-dir=$outputDir",
+        if (failOnGate) "--fail-on-gate" else "--no-fail-on-gate"
+    )
+}
+
 tasks.register<JavaExec>("r3FailureLedger") {
     group = "verification"
     description = "Generates deterministic R3 failure-ledger artifacts from official suite runs."

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -116,6 +116,13 @@ gradle r2CanaryCertificationEvidence \
   -Pr2CanaryInputJson="/path/to/projects.json"
 ```
 
+Run R3 external canary certification from canary result JSON:
+
+```bash
+gradle r3CanaryCertificationEvidence \
+  -Pr3CanaryInputJson="testkit/canary/r3/projects.sample.json"
+```
+
 Run final readiness aggregation:
 
 ```bash
@@ -171,6 +178,9 @@ GitHub Actions workflow:
 - R2 canary:
   - `build/reports/r2-canary/r2-canary-certification.json`
   - `build/reports/r2-canary/r2-canary-certification.md`
+- R3 canary:
+  - `build/reports/r3-canary/r2-canary-certification.json`
+  - `build/reports/r3-canary/r2-canary-certification.md`
 - Final readiness:
   - `build/reports/release-readiness/r1-final-readiness-report.json`
   - `build/reports/release-readiness/r1-final-readiness-report.md`

--- a/docs/research/16-r3-issue-58-external-canary-certification.md
+++ b/docs/research/16-r3-issue-58-external-canary-certification.md
@@ -1,0 +1,38 @@
+# R3 Issue #58: External Canary Certification Flow
+
+Date: 2026-02-24
+
+## Objective
+
+Provide a deterministic certification flow for external Spring canary projects with rollback evidence.
+
+## Added Flow
+
+- Gradle task: `r3CanaryCertificationEvidence`
+- Workflow: `.github/workflows/r3-external-canary.yml`
+- Sample input: `testkit/canary/r3/projects.sample.json`
+
+The flow validates:
+
+- at least 3 project results
+- all `canaryPassed=true`
+- rollback rehearsal attempted and successful for all projects
+
+## Reproduction
+
+```bash
+gradle r3CanaryCertificationEvidence \
+  -Pr3CanaryInputJson="testkit/canary/r3/projects.sample.json" \
+  -Pr3CanaryOutputDir="build/reports/r3-canary" \
+  -Pr3CanaryFailOnGate=true
+```
+
+## Output
+
+- `build/reports/r3-canary/r2-canary-certification.json`
+- `build/reports/r3-canary/r2-canary-certification.md`
+
+## Notes
+
+- The current implementation reuses `R2CanaryCertification` logic with R3-specific task/workflow wiring.
+- For real external sign-off, replace sample input with real project evidence JSON produced by canary executions.

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -19,6 +19,7 @@
 - [`13-r2-canary-certification.md`](./13-r2-canary-certification.md): R2 외부 canary 인증 산출 규격
 - [`14-r3-issue-50-protocol-parity-baseline.md`](./14-r3-issue-50-protocol-parity-baseline.md): R3 failure ledger 기준 protocol parity baseline
 - [`15-r3-issue-53-transaction-baseline.md`](./15-r3-issue-53-transaction-baseline.md): R3 transaction/session baseline과 unsupported surface
+- [`16-r3-issue-58-external-canary-certification.md`](./16-r3-issue-58-external-canary-certification.md): R3 external canary certification flow
 
 ## 권장 읽기 순서
 
@@ -37,6 +38,7 @@
 13. `13-r2-canary-certification.md`로 외부 canary 인증 기준 고정
 14. `14-r3-issue-50-protocol-parity-baseline.md`로 R3 protocol baseline 확인
 15. `15-r3-issue-53-transaction-baseline.md`로 R3 transaction/session baseline 확인
+16. `16-r3-issue-58-external-canary-certification.md`로 R3 external canary 인증 절차 확인
 
 ## 리서치 스냅샷
 

--- a/testkit/canary/r3/projects.sample.json
+++ b/testkit/canary/r3/projects.sample.json
@@ -1,0 +1,40 @@
+{
+  "projects": [
+    {
+      "projectId": "platform-server",
+      "repository": "internal://apps/platform-server",
+      "revision": "canary-2026-02-24-a",
+      "canaryPassed": true,
+      "rollback": {
+        "attempted": true,
+        "success": true,
+        "recoverySeconds": 38
+      },
+      "notes": "MongoTemplate + transaction integration suite"
+    },
+    {
+      "projectId": "spring-suite-boot-2.7-template",
+      "repository": "internal://testkit/spring-suite",
+      "revision": "canary-2026-02-24-b",
+      "canaryPassed": true,
+      "rollback": {
+        "attempted": true,
+        "success": true,
+        "recoverySeconds": 29
+      },
+      "notes": "Template-centric compatibility profile"
+    },
+    {
+      "projectId": "spring-suite-boot-3.2-repository",
+      "repository": "internal://testkit/spring-suite",
+      "revision": "canary-2026-02-24-c",
+      "canaryPassed": true,
+      "rollback": {
+        "attempted": true,
+        "success": true,
+        "recoverySeconds": 34
+      },
+      "notes": "Repository-centric compatibility profile"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add R3 external canary certification Gradle task wiring (r3CanaryCertificationEvidence)
- add workflow_dispatch pipeline to generate and upload R3 canary certification artifacts
- add sample 3-project canary input JSON and research note documenting reproduction flow
- update usage and research index documentation

## Linked Issues (Required)
Closes #58

## Verification
- ./.tooling/gradle-8.10.2/bin/gradle --no-daemon -Pr3CanaryInputJson=testkit/canary/r3/projects.sample.json -Pr3CanaryOutputDir=build/reports/r3-canary-local -Pr3CanaryFailOnGate=true r3CanaryCertificationEvidence
- python3 YAML parse check for .github/workflows/r3-external-canary.yml