### PR TITLE
[R3][#57] Publish final certification and support manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The current implementation is focused on:
 
 It is not a full drop-in replacement for production MongoDB.
 
-Status snapshot (2026-02-23): active development, R2 compatibility infrastructure in place.
+Status snapshot (2026-02-24): active development, R3 certification evidence published.
 
 ## Compatibility Level (Current)
 
@@ -33,6 +33,21 @@ Recommended usage:
 Not a fit yet:
 - full MongoDB compatibility requirements
 - heavy use of advanced update operators, collation semantics, or TTL runtime behavior
+
+## R3 Certification Snapshot (2026-02-24)
+
+| Gate | Result | Evidence |
+| --- | --- | --- |
+| Official UTF sharded differential | PASS | Run `22332998372` |
+| R3 failure ledger | PASS | Run `22332937657` |
+| External Spring canary certification | PASS | Run `22332937633` |
+| Compatibility scorecard | PASS | `docs/COMPATIBILITY_SCORECARD.md` |
+| Support boundary manifest | Published | `docs/SUPPORT_MATRIX.md` |
+
+Certification references:
+- `docs/COMPATIBILITY_SCORECARD.md`
+- `docs/SUPPORT_MATRIX.md`
+- `docs/RELEASE_CHECKLIST.md`
 
 ## Scope
 
@@ -164,6 +179,9 @@ GitHub Actions workflow:
 
 - Usage: `docs/USAGE.md`
 - Compatibility matrix: `docs/COMPATIBILITY.md`
+- Compatibility scorecard: `docs/COMPATIBILITY_SCORECARD.md`
+- Support matrix: `docs/SUPPORT_MATRIX.md`
+- Release checklist: `docs/RELEASE_CHECKLIST.md`
 - Roadmap: `docs/ROADMAP.md`
 - Contribution guide: `CONTRIBUTING.md`
 - Research notes: `docs/research/README.md`

--- a/docs/COMPATIBILITY_SCORECARD.md
+++ b/docs/COMPATIBILITY_SCORECARD.md
@@ -1,0 +1,92 @@
+# Compatibility Scorecard
+
+Status date: 2026-02-24
+
+This document is the final R3 certification snapshot used for release decisions.
+It is an integration-test compatibility report, not a production MongoDB parity claim.
+
+## Evidence Sources
+
+| Evidence | Source run / artifact | Result |
+| --- | --- | --- |
+| Official UTF sharded differential (baseline) | GitHub Actions `Official Suite Sharded` run `22332998372` | PASS |
+| Official UTF sharded differential (rerun/flake gate) | GitHub Actions `Official Suite Sharded` run `22332998372` | PASS |
+| R3 failure ledger | GitHub Actions `R3 Failure Ledger` run `22332937657` | PASS |
+| External Spring canary certification | GitHub Actions `R3 External Canary Certification` run `22332937633` | PASS |
+| Support manifest scorecard | `build/reports/r2-compatibility/r2-compatibility-scorecard.json` | PASS |
+
+## Final Gate Summary
+
+| Gate | Status | Metrics |
+| --- | --- | --- |
+| UTF sharded baseline | PASS | imported=146, match=146, mismatch=0, error=0 |
+| UTF sharded rerun | PASS | imported=146, match=146, mismatch=0, error=0 |
+| UTF flake consistency | PASS | shard-0/1/2 baseline == rerun |
+| R3 failure ledger | PASS | suiteCount=3, failureCount=0 |
+| External canary certification | PASS | projectCount=3, canaryPass=3, rollbackSuccess=3, maxRecoverySeconds=38 |
+| Spring compatibility matrix | PASS | totalCells=20, pass=20, fail=0, passRate=1.0 |
+| Compatibility scorecard gates | PASS | pass=2, fail=0, missing=0 |
+
+## Official UTF Coverage Snapshot
+
+Totals from the baseline shard artifacts in run `22332998372`:
+
+| Metric | Value |
+| --- | --- |
+| imported | 146 |
+| skipped | 567 |
+| unsupported | 868 |
+| total differential cases | 146 |
+| match | 146 |
+| mismatch | 0 |
+| error | 0 |
+
+Top unsupported reasons in baseline artifacts:
+
+| Reason | Count |
+| --- | --- |
+| `unsupported UTF operation: startTransaction` | 234 |
+| `unsupported UTF operation: failPoint` | 134 |
+| `unsupported UTF operation: clientBulkWrite` | 86 |
+| `unsupported UTF operation: bulkWrite` | 84 |
+| `unsupported UTF operation: findOneAndUpdate` | 48 |
+| `unsupported UTF operation: createEntities` | 40 |
+| `unsupported UTF operation: findOneAndReplace` | 36 |
+| `unsupported UTF aggregate stage in pipeline` | 28 |
+| `unsupported UTF operation: countDocuments` | 22 |
+| `unsupported UTF operation: replaceOne` | 22 |
+
+## Artifact Digest Snapshot
+
+SHA-256 digests captured during certification assembly:
+
+| Artifact | SHA-256 |
+| --- | --- |
+| `utf-shard-summary.md` | `93a8fefa915b48e6799f9f3f4004c53bf4d678a7f473b41e75ca5e3ee974fd08` |
+| `shard-0 baseline utf-differential-report.json` | `483cd8cfbd8acd3ea590849bfe063b8abf31b4bbe37800e6c6ba5742b99b92af` |
+| `shard-1 baseline utf-differential-report.json` | `cf226ab24bdddce9c6748bf1393cbaf776c704358788137f9875f78dbb6856eb` |
+| `shard-2 baseline utf-differential-report.json` | `6dabf85f22be0e60bf275ab0fdc896a7fbc35413ce455c678ada5b0e32fe68e3` |
+| `r3-failure-ledger.json` | `0dfe884ed25be8be46c2d7937f8386075ec00e90e4d5c5e83ccdbbe2b2079d08` |
+| `r2-canary-certification.json` (R3 canary output artifact name) | `8ffd103c55f0cb3ef95c7fc52bfc347454984fcc057419c50e607acf4f565103` |
+| `r2-compatibility-scorecard.json` | `3ba3469366a19453786e631841a633645082d6cd80fd1a22a50ed7ba4dead6a0` |
+| `r2-support-manifest.json` | `84fd659f98a332134209b02d1302321aceaf56125fd691e0a7d38e564f4f913f` |
+
+## Reproduction
+
+Run the same gates locally:
+
+```bash
+./.tooling/gradle-8.10.2/bin/gradle --no-daemon springCompatibilityMatrixEvidence
+
+./.tooling/gradle-8.10.2/bin/gradle --no-daemon \
+  r2CompatibilityEvidence \
+  -Pr2CompatibilityUtfReport=/tmp/official-utf-summary.json \
+  -Pr2CompatibilitySpringMatrixJson=build/reports/spring-matrix/spring-compatibility-matrix.json \
+  -Pr2CompatibilityFailOnGate=true
+
+./.tooling/gradle-8.10.2/bin/gradle --no-daemon \
+  r3CanaryCertificationEvidence \
+  -Pr3CanaryInputJson=testkit/canary/r3/projects.sample.json \
+  -Pr3CanaryFailOnGate=true
+```
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,9 @@ Top-level documentation:
 Runtime and compatibility:
 - `docs/USAGE.md`
 - `docs/COMPATIBILITY.md`
+- `docs/COMPATIBILITY_SCORECARD.md`
+- `docs/SUPPORT_MATRIX.md`
+- `docs/RELEASE_CHECKLIST.md`
 - `docs/ROADMAP.md`
 
 Research and design notes:

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,0 +1,26 @@
+# Release Checklist
+
+Status date: 2026-02-24
+
+## R3 Certification Sign-Off
+
+- [x] Official suite sharded run on `main` completed with zero mismatch/error.
+  - run id: `22332998372`
+- [x] R3 failure ledger run on `main` completed with `failureCount=0`.
+  - run id: `22332937657`
+- [x] External canary certification completed for 3 projects with rollback success.
+  - run id: `22332937633`
+- [x] Support boundary documents are updated.
+  - `docs/SUPPORT_MATRIX.md`
+  - `docs/COMPATIBILITY_SCORECARD.md`
+- [x] README certification snapshot is updated and links current evidence docs.
+
+## Tagging Gate
+
+Before creating a release tag:
+
+1. Re-run the three CI workflows above on the release candidate commit.
+2. Confirm that `docs/COMPATIBILITY_SCORECARD.md` metrics still match artifacts.
+3. Confirm no open P1/P2 compatibility regressions remain.
+4. Tag and publish only after all checks are green.
+

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Status date: 2026-02-23
+Status date: 2026-02-24
 
 This roadmap is implementation-focused and tied to testable outcomes.
 
@@ -41,6 +41,14 @@ Target outcomes:
 
 Primary measure:
 - lower mismatch/error counts in UTF and real differential runs
+
+## R3 Certification (Completed)
+
+Completed:
+- official UTF sharded differential gate on pinned spec ref
+- deterministic R3 failure-ledger gate (`failureCount=0`)
+- external canary certification gate for 3 Spring projects
+- final scorecard/support manifest publication
 
 ## Remaining Exit Criteria for R2 Sign-Off
 

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -1,0 +1,38 @@
+# Support Matrix
+
+Status date: 2026-02-24
+
+This matrix is a versioned support boundary for integration-test usage.
+Source artifact: `build/reports/r2-compatibility/r2-support-manifest.json`.
+
+## Summary
+
+| Status | Count |
+| --- | --- |
+| Supported | 7 |
+| Partial | 4 |
+| Unsupported | 1 |
+
+## Feature-Level Matrix
+
+| Feature ID | Category | Status | Note |
+| --- | --- | --- | --- |
+| `query.eq-ne-compare` | query | Supported | Core comparison operators |
+| `query.elemMatch-all-regex` | query | Supported | Array and regex operators |
+| `query.expr-subset` | query | Partial | Subset: eq/ne/gt/gte/lt/lte/and/or/not |
+| `aggregation.match-project-group` | aggregation | Supported | Tier-1 pipeline stages |
+| `aggregation.lookup-union-facet` | aggregation | Partial | Tier-2 subset without full expression parity |
+| `aggregation.expression-operators` | aggregation | Partial | Limited expression coverage |
+| `index.unique-sparse-partial` | index | Supported | Unique/sparse/partial |
+| `index.collation-metadata` | index | Supported | Collation metadata round-trip |
+| `index.collation-semantic` | index | Unsupported | Locale-aware comparison semantics |
+| `transactions-single-session` | transaction | Supported | Session + txn command flow |
+| `transactions-retryable-advanced` | transaction | Partial | Partial compatibility |
+| `protocol-unsupported-contract` | protocol | Supported | NotImplemented + UnsupportedFeature labels |
+
+## Operational Notes
+
+- The matrix is intended for test-environment substitution scenarios.
+- Unsupported UTF coverage is tracked in `docs/COMPATIBILITY_SCORECARD.md` with reason counts.
+- New feature expansion should update both this matrix and `docs/COMPATIBILITY.md`.
+


### PR DESCRIPTION
## Summary
- add final certification scorecard document with pinned R3 run IDs and gate metrics
- add versioned support matrix document from compatibility manifest output
- add release checklist with explicit R3 certification sign-off items
- update README and docs index/roadmap to reference final certification artifacts

## Linked Issues (Required)
Closes #57

## Verification
- gh workflow run official-suite-sharded.yml --ref main -f official_specs_ref=99704fa8860777da1d919ef765af1e41e75f5859
  - run id: 22332998372 (PASS)
- gh workflow run r3-failure-ledger.yml --ref main -f official_specs_ref=99704fa8860777da1d919ef765af1e41e75f5859
  - run id: 22332937657 (PASS)
- gh workflow run r3-external-canary.yml --ref main -f canary_input_json=testkit/canary/r3/projects.sample.json
  - run id: 22332937633 (PASS)
- ./.tooling/gradle-8.10.2/bin/gradle --no-daemon springCompatibilityMatrixEvidence
- ./.tooling/gradle-8.10.2/bin/gradle --no-daemon r2CompatibilityEvidence -Pr2CompatibilityUtfReport=/tmp/official-utf-summary.json -Pr2CompatibilitySpringMatrixJson=build/reports/spring-matrix/spring-compatibility-matrix.json -Pr2CompatibilityFailOnGate=true