### PR TITLE
[R4][Spring] Add drop-in Spring test adapters for jongodb

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,30 @@ Requirements:
 - It is suitable when your test bootstrap can route command/wire messages in-process.
 - For tests that must connect through standard `mongodb://` endpoint semantics, keep a real/embedded `mongod` backend for that test profile.
 
+### Spring Boot Test Setup (Initializer)
+
+```java
+@SpringBootTest
+@ContextConfiguration(initializers = JongodbMongoInitializer.class)
+class MyIntegrationTest {
+}
+```
+
+### Spring Boot Test Setup (DynamicPropertySource)
+
+```java
+@SpringBootTest
+class MyIntegrationTest {
+  @DynamicPropertySource
+  static void mongoProps(DynamicPropertyRegistry registry) {
+    JongodbMongoDynamicPropertySupport.register(registry);
+  }
+}
+```
+
+See full migration guidance:
+- `docs/SPRING_TESTING.md`
+
 ## Compatibility Snapshot (Current)
 
 This project targets integration-test compatibility for common Spring data paths.
@@ -192,6 +216,7 @@ GitHub Actions workflow:
 ## Documentation
 
 - Usage: `docs/USAGE.md`
+- Spring test integration: `docs/SPRING_TESTING.md`
 - Compatibility matrix: `docs/COMPATIBILITY.md`
 - Compatibility scorecard: `docs/COMPATIBILITY_SCORECARD.md`
 - Support matrix: `docs/SUPPORT_MATRIX.md`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,9 +33,13 @@ dependencies {
     api("org.mongodb:bson:4.11.2")
     implementation("org.mongodb:mongodb-driver-sync:4.11.2")
     implementation("org.yaml:snakeyaml:2.2")
+    compileOnly("org.springframework:spring-context:6.1.17")
+    compileOnly("org.springframework:spring-test:6.1.17")
 
     testImplementation(platform("org.junit:junit-bom:5.10.2"))
     testImplementation("org.junit.jupiter:junit-jupiter")
+    testImplementation("org.springframework:spring-context:6.1.17")
+    testImplementation("org.springframework:spring-test:6.1.17")
 }
 
 jreleaser {

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ Top-level documentation:
 
 Runtime and compatibility:
 - `docs/USAGE.md`
+- `docs/SPRING_TESTING.md`
 - `docs/COMPATIBILITY.md`
 - `docs/COMPATIBILITY_SCORECARD.md`
 - `docs/SUPPORT_MATRIX.md`

--- a/docs/SPRING_TESTING.md
+++ b/docs/SPRING_TESTING.md
@@ -1,0 +1,99 @@
+# Spring Test Integration Guide
+
+Status date: 2026-02-24
+
+This guide explains how to use `jongodb` from Spring Boot tests and how to migrate common MongoDB Testcontainers setups.
+
+## Supported Integration Styles
+
+- `ApplicationContextInitializer`: `org.jongodb.spring.test.JongodbMongoInitializer`
+- `@DynamicPropertySource`: `org.jongodb.spring.test.JongodbMongoDynamicPropertySupport`
+
+Both styles wire:
+- `spring.data.mongodb.uri`
+- `spring.data.mongodb.host`
+- `spring.data.mongodb.port`
+
+## Quick Adoption
+
+### 1) Add dependency
+
+```kotlin
+dependencies {
+    testImplementation("io.github.midagedev:jongodb:<version>")
+}
+```
+
+### 2) Replace test bootstrap
+
+Initializer style:
+
+```java
+@SpringBootTest
+@ContextConfiguration(initializers = JongodbMongoInitializer.class)
+class MyIntegrationTest {
+}
+```
+
+Dynamic property style:
+
+```java
+@SpringBootTest
+class MyIntegrationTest {
+  @DynamicPropertySource
+  static void mongoProps(DynamicPropertyRegistry registry) {
+    JongodbMongoDynamicPropertySupport.register(registry);
+  }
+}
+```
+
+Optional test database name:
+- `jongodb.test.database=<dbName>` (initializer style)
+- `JongodbMongoDynamicPropertySupport.register(registry, "<dbName>")` (dynamic style)
+
+## Migration from MongoDB Testcontainers
+
+### Before (typical pattern)
+
+```java
+@Container
+static MongoDBContainer mongo = new MongoDBContainer("mongo:7");
+
+@DynamicPropertySource
+static void mongoProps(DynamicPropertyRegistry registry) {
+  registry.add("spring.data.mongodb.uri", mongo::getReplicaSetUrl);
+}
+```
+
+### After (jongodb pattern)
+
+```java
+@DynamicPropertySource
+static void mongoProps(DynamicPropertyRegistry registry) {
+  JongodbMongoDynamicPropertySupport.register(registry);
+}
+```
+
+## Fit / Non-Fit
+
+Use `jongodb` when:
+- you need fast in-memory integration tests
+- your tests focus on common CRUD, core aggregation, and single-process transaction paths
+
+Keep Testcontainers/real `mongod` for tests that require:
+- full MongoDB feature parity
+- advanced transaction/retry semantics outside current support scope
+- deployment-level behavior
+
+## Troubleshooting
+
+- If you see `codeName=NotImplemented` with `UnsupportedFeature`, the test is using an unsupported feature path.
+- For unsupported paths, keep a fallback profile that still runs the same test on Testcontainers/real `mongod`.
+- If test isolation requires a clean DB per class, use a unique database name per test class.
+
+## Related Docs
+
+- `docs/COMPATIBILITY.md`
+- `docs/SUPPORT_MATRIX.md`
+- `docs/COMPATIBILITY_SCORECARD.md`
+- `docs/USAGE.md`

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -33,6 +33,46 @@ dependencies {
 
 If you need command-level integration without sockets, instantiate `WireCommandIngress` in your test bootstrap and route BSON commands through `OpMsgCodec`.
 
+## Spring Boot Test Integration
+
+### Option A: `ApplicationContextInitializer`
+
+Use `JongodbMongoInitializer` when your tests already use `@ContextConfiguration` initializers:
+
+```java
+import org.jongodb.spring.test.JongodbMongoInitializer;
+import org.springframework.test.context.ContextConfiguration;
+
+@SpringBootTest
+@ContextConfiguration(initializers = JongodbMongoInitializer.class)
+class AccountIntegrationTest {
+}
+```
+
+Optional database override:
+- set `jongodb.test.database=<dbName>` as a test property.
+
+### Option B: `@DynamicPropertySource`
+
+Use `JongodbMongoDynamicPropertySupport` as a drop-in replacement pattern for many Testcontainers setups:
+
+```java
+import org.jongodb.spring.test.JongodbMongoDynamicPropertySupport;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+@SpringBootTest
+class AccountIntegrationTest {
+  @DynamicPropertySource
+  static void mongoProps(DynamicPropertyRegistry registry) {
+    JongodbMongoDynamicPropertySupport.register(registry);
+  }
+}
+```
+
+See migration details:
+- `docs/SPRING_TESTING.md`
+
 ## In-Process Runtime Usage
 
 ### 1) Command Dispatcher API

--- a/src/main/java/org/jongodb/server/TcpMongoServer.java
+++ b/src/main/java/org/jongodb/server/TcpMongoServer.java
@@ -1,0 +1,318 @@
+package org.jongodb.server;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.bson.BsonBinaryWriter;
+import org.bson.BsonDocument;
+import org.bson.RawBsonDocument;
+import org.bson.codecs.BsonDocumentCodec;
+import org.bson.codecs.EncoderContext;
+import org.bson.io.BasicOutputBuffer;
+import org.jongodb.command.CommandDispatcher;
+import org.jongodb.command.CommandStore;
+import org.jongodb.command.EngineBackedCommandStore;
+import org.jongodb.engine.InMemoryEngineStore;
+import org.jongodb.wire.OpMsg;
+import org.jongodb.wire.OpMsgCodec;
+
+/**
+ * In-memory TCP bridge server for MongoDB wire requests.
+ *
+ * <p>This class is intended for integration-test bootstrap, so Spring test contexts can connect
+ * using regular {@code mongodb://} URIs while requests are handled by {@link CommandDispatcher}.
+ */
+public final class TcpMongoServer implements AutoCloseable {
+    private static final String DEFAULT_HOST = "127.0.0.1";
+    private static final int HEADER_LENGTH = 16;
+    private static final int OP_REPLY_FIELDS_LENGTH = 20;
+    private static final int OP_REPLY = 1;
+    private static final int OP_QUERY = 2004;
+    private static final int OP_MSG = 2013;
+
+    private final CommandDispatcher dispatcher;
+    private final OpMsgCodec opMsgCodec = new OpMsgCodec();
+    private final AtomicInteger responseRequestId = new AtomicInteger(1);
+    private final AtomicBoolean running = new AtomicBoolean(false);
+    private final ServerSocket serverSocket;
+    private final List<Socket> clientSockets = new CopyOnWriteArrayList<>();
+    private final Thread acceptThread;
+    private final String host;
+
+    public static TcpMongoServer inMemory() {
+        return new TcpMongoServer();
+    }
+
+    public TcpMongoServer() {
+        this(new EngineBackedCommandStore(new InMemoryEngineStore()));
+    }
+
+    public TcpMongoServer(final CommandStore commandStore) {
+        Objects.requireNonNull(commandStore, "commandStore");
+        this.dispatcher = new CommandDispatcher(commandStore);
+        this.host = DEFAULT_HOST;
+        this.serverSocket = newServerSocket(host);
+        this.acceptThread = new Thread(this::acceptLoop, "jongodb-tcp-accept");
+        this.acceptThread.setDaemon(true);
+    }
+
+    public void start() {
+        if (running.compareAndSet(false, true)) {
+            acceptThread.start();
+        }
+    }
+
+    public boolean isRunning() {
+        return running.get();
+    }
+
+    public String host() {
+        return host;
+    }
+
+    public int port() {
+        return serverSocket.getLocalPort();
+    }
+
+    public String connectionString(final String database) {
+        final String normalizedDatabase = normalizeDatabase(database);
+        return "mongodb://" + host + ":" + port() + "/" + normalizedDatabase;
+    }
+
+    @Override
+    public void close() {
+        if (!running.compareAndSet(true, false)) {
+            return;
+        }
+
+        closeQuietly(serverSocket);
+        for (final Socket socket : clientSockets) {
+            closeQuietly(socket);
+        }
+        try {
+            acceptThread.join(1000L);
+        } catch (final InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static ServerSocket newServerSocket(final String host) {
+        try {
+            return new ServerSocket(0, 50, InetAddress.getByName(host));
+        } catch (final IOException ioException) {
+            throw new IllegalStateException("failed to allocate TCP server socket", ioException);
+        }
+    }
+
+    private static void closeQuietly(final AutoCloseable closeable) {
+        try {
+            closeable.close();
+        } catch (final Exception ignore) {
+            // no-op: test teardown should be best-effort.
+        }
+    }
+
+    private void acceptLoop() {
+        while (running.get()) {
+            final Socket socket;
+            try {
+                socket = serverSocket.accept();
+            } catch (final IOException ioException) {
+                if (running.get()) {
+                    throw new IllegalStateException("failed to accept tcp client", ioException);
+                }
+                return;
+            }
+
+            clientSockets.add(socket);
+            final Thread worker = new Thread(
+                    () -> handleClient(socket),
+                    "jongodb-tcp-client-" + socket.getPort());
+            worker.setDaemon(true);
+            worker.start();
+        }
+    }
+
+    private void handleClient(final Socket socket) {
+        try (Socket client = socket;
+                BufferedInputStream input = new BufferedInputStream(client.getInputStream());
+                BufferedOutputStream output = new BufferedOutputStream(client.getOutputStream())) {
+            client.setTcpNoDelay(true);
+
+            while (running.get()) {
+                final byte[] request = readMessage(input);
+                if (request == null) {
+                    break;
+                }
+
+                final byte[] response;
+                try {
+                    response = handleRequest(request);
+                } catch (final RuntimeException runtimeException) {
+                    System.err.println("jongodb tcp request failed: " + runtimeException.getMessage());
+                    runtimeException.printStackTrace();
+                    break;
+                }
+                output.write(response);
+                output.flush();
+            }
+        } catch (final IOException ioException) {
+            if (running.get()) {
+                System.err.println("jongodb tcp client io failure: " + ioException.getMessage());
+            }
+        } finally {
+            clientSockets.remove(socket);
+        }
+    }
+
+    private byte[] handleRequest(final byte[] request) {
+        final int opcode = readIntLE(request, 12);
+        if (opcode == OP_MSG) {
+            return handleOpMsg(request);
+        }
+        if (opcode == OP_QUERY) {
+            return handleOpQuery(request);
+        }
+        throw new IllegalArgumentException("unsupported opcode: " + opcode);
+    }
+
+    private byte[] handleOpMsg(final byte[] request) {
+        final OpMsg opMsg = opMsgCodec.decode(request);
+        final BsonDocument responseBody = dispatcher.dispatch(opMsg.body());
+        final OpMsg response = new OpMsg(responseRequestId.getAndIncrement(), opMsg.requestId(), 0, responseBody);
+        return opMsgCodec.encode(response);
+    }
+
+    private byte[] handleOpQuery(final byte[] request) {
+        final int requestId = readIntLE(request, 4);
+        int cursor = HEADER_LENGTH;
+        cursor += 4; // flags
+        cursor = readCString(request, cursor); // fullCollectionName
+        cursor += 4; // numberToSkip
+        cursor += 4; // numberToReturn
+
+        final int documentLength = readIntLE(request, cursor);
+        if (documentLength <= 0 || cursor + documentLength > request.length) {
+            throw new IllegalArgumentException("invalid OP_QUERY document length: " + documentLength);
+        }
+        final byte[] queryBytes = java.util.Arrays.copyOfRange(request, cursor, cursor + documentLength);
+        final BsonDocument queryDocument = new RawBsonDocument(queryBytes);
+        final BsonDocument responseBody = dispatcher.dispatch(queryDocument);
+        return encodeOpReply(requestId, responseBody);
+    }
+
+    private byte[] encodeOpReply(final int responseTo, final BsonDocument document) {
+        final byte[] bodyBytes = encodeBson(document);
+        final int totalLength = HEADER_LENGTH + OP_REPLY_FIELDS_LENGTH + bodyBytes.length;
+        return ByteBuffer.allocate(totalLength)
+                .order(ByteOrder.LITTLE_ENDIAN)
+                .putInt(totalLength)
+                .putInt(responseRequestId.getAndIncrement())
+                .putInt(responseTo)
+                .putInt(OP_REPLY)
+                .putInt(0) // responseFlags
+                .putLong(0L) // cursorId
+                .putInt(0) // startingFrom
+                .putInt(1) // numberReturned
+                .put(bodyBytes)
+                .array();
+    }
+
+    private static byte[] encodeBson(final BsonDocument document) {
+        final BasicOutputBuffer outputBuffer = new BasicOutputBuffer();
+        try (BsonBinaryWriter writer = new BsonBinaryWriter(outputBuffer)) {
+            new BsonDocumentCodec().encode(
+                    writer,
+                    document,
+                    EncoderContext.builder().isEncodingCollectibleDocument(true).build());
+        }
+        return outputBuffer.toByteArray();
+    }
+
+    private static byte[] readMessage(final BufferedInputStream input) throws IOException {
+        final byte[] headerLengthBytes = new byte[4];
+        final int first = input.read();
+        if (first == -1) {
+            return null;
+        }
+
+        headerLengthBytes[0] = (byte) first;
+        if (!readFully(input, headerLengthBytes, 1, 3)) {
+            return null;
+        }
+
+        final int messageLength = littleEndianInt(headerLengthBytes);
+        if (messageLength < HEADER_LENGTH) {
+            throw new IllegalArgumentException("invalid message length: " + messageLength);
+        }
+
+        final byte[] message = new byte[messageLength];
+        System.arraycopy(headerLengthBytes, 0, message, 0, 4);
+        if (!readFully(input, message, 4, messageLength - 4)) {
+            return null;
+        }
+        return message;
+    }
+
+    private static boolean readFully(
+            final BufferedInputStream input,
+            final byte[] target,
+            final int offset,
+            final int length)
+            throws IOException {
+        int total = 0;
+        while (total < length) {
+            final int read = input.read(target, offset + total, length - total);
+            if (read == -1) {
+                return false;
+            }
+            total += read;
+        }
+        return true;
+    }
+
+    private static int readCString(final byte[] bytes, final int offset) {
+        int index = offset;
+        while (index < bytes.length && bytes[index] != 0) {
+            index++;
+        }
+        if (index >= bytes.length) {
+            throw new IllegalArgumentException("malformed cstring in wire request");
+        }
+        return index + 1;
+    }
+
+    private static int readIntLE(final byte[] bytes, final int offset) {
+        if (offset < 0 || offset + 4 > bytes.length) {
+            throw new IllegalArgumentException("unable to read int32 at offset " + offset);
+        }
+        return (bytes[offset] & 0xff)
+                | ((bytes[offset + 1] & 0xff) << 8)
+                | ((bytes[offset + 2] & 0xff) << 16)
+                | ((bytes[offset + 3] & 0xff) << 24);
+    }
+
+    private static int littleEndianInt(final byte[] bytes) {
+        return (bytes[0] & 0xff)
+                | ((bytes[1] & 0xff) << 8)
+                | ((bytes[2] & 0xff) << 16)
+                | ((bytes[3] & 0xff) << 24);
+    }
+
+    private static String normalizeDatabase(final String database) {
+        if (database == null || database.isBlank()) {
+            return "test";
+        }
+        return database.trim();
+    }
+}

--- a/src/main/java/org/jongodb/spring/test/JongodbMongoDynamicPropertySupport.java
+++ b/src/main/java/org/jongodb/spring/test/JongodbMongoDynamicPropertySupport.java
@@ -1,0 +1,83 @@
+package org.jongodb.spring.test;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.jongodb.server.TcpMongoServer;
+import org.springframework.test.context.DynamicPropertyRegistry;
+
+/**
+ * Helper for Spring tests using {@code @DynamicPropertySource} style configuration.
+ *
+ * <p>Usage:
+ *
+ * <pre>{@code
+ * @DynamicPropertySource
+ * static void mongoProps(DynamicPropertyRegistry registry) {
+ *   JongodbMongoDynamicPropertySupport.register(registry);
+ * }
+ * }</pre>
+ */
+public final class JongodbMongoDynamicPropertySupport {
+    private static final Object LOCK = new Object();
+    private static final AtomicReference<TcpMongoServer> SHARED_SERVER = new AtomicReference<>();
+    private static final AtomicBoolean SHUTDOWN_HOOK_REGISTERED = new AtomicBoolean(false);
+
+    private JongodbMongoDynamicPropertySupport() {}
+
+    public static TcpMongoServer register(final DynamicPropertyRegistry registry) {
+        return register(registry, JongodbMongoInitializer.DEFAULT_DATABASE);
+    }
+
+    public static TcpMongoServer register(final DynamicPropertyRegistry registry, final String database) {
+        Objects.requireNonNull(registry, "registry");
+        final String normalizedDatabase = normalizeDatabase(database);
+        final TcpMongoServer server = ensureRunningServer();
+
+        registry.add("spring.data.mongodb.uri", () -> server.connectionString(normalizedDatabase));
+        registry.add("spring.data.mongodb.host", server::host);
+        registry.add("spring.data.mongodb.port", server::port);
+        return server;
+    }
+
+    public static void stop() {
+        synchronized (LOCK) {
+            final TcpMongoServer server = SHARED_SERVER.getAndSet(null);
+            if (server != null) {
+                server.close();
+            }
+        }
+    }
+
+    private static TcpMongoServer ensureRunningServer() {
+        synchronized (LOCK) {
+            final TcpMongoServer existing = SHARED_SERVER.get();
+            if (existing != null && existing.isRunning()) {
+                return existing;
+            }
+            if (existing != null) {
+                existing.close();
+            }
+
+            final TcpMongoServer created = TcpMongoServer.inMemory();
+            created.start();
+            SHARED_SERVER.set(created);
+            registerShutdownHookOnce();
+            return created;
+        }
+    }
+
+    private static void registerShutdownHookOnce() {
+        if (!SHUTDOWN_HOOK_REGISTERED.compareAndSet(false, true)) {
+            return;
+        }
+        Runtime.getRuntime().addShutdownHook(new Thread(JongodbMongoDynamicPropertySupport::stop, "jongodb-tcp-shutdown"));
+    }
+
+    private static String normalizeDatabase(final String database) {
+        if (database == null || database.isBlank()) {
+            return JongodbMongoInitializer.DEFAULT_DATABASE;
+        }
+        return database.trim();
+    }
+}

--- a/src/main/java/org/jongodb/spring/test/JongodbMongoInitializer.java
+++ b/src/main/java/org/jongodb/spring/test/JongodbMongoInitializer.java
@@ -1,0 +1,49 @@
+package org.jongodb.spring.test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import org.jongodb.server.TcpMongoServer;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.core.env.MapPropertySource;
+
+/**
+ * Spring test initializer that starts an in-memory {@link TcpMongoServer} and wires MongoDB
+ * properties for the test context.
+ */
+public final class JongodbMongoInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+    public static final String DEFAULT_DATABASE = "test";
+    public static final String DATABASE_PROPERTY = "jongodb.test.database";
+    public static final String SERVER_BEAN_NAME = "jongodbTcpMongoServer";
+
+    @Override
+    public void initialize(final ConfigurableApplicationContext context) {
+        Objects.requireNonNull(context, "context");
+
+        final String database = normalizeDatabase(context.getEnvironment().getProperty(DATABASE_PROPERTY));
+        final TcpMongoServer server = TcpMongoServer.inMemory();
+        server.start();
+
+        final Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("spring.data.mongodb.uri", server.connectionString(database));
+        properties.put("spring.data.mongodb.host", server.host());
+        properties.put("spring.data.mongodb.port", Integer.toString(server.port()));
+
+        context.getEnvironment().getPropertySources().addFirst(new MapPropertySource("jongodbInMemoryMongo", properties));
+        context.getBeanFactory().registerSingleton(SERVER_BEAN_NAME, server);
+        context.addApplicationListener(event -> {
+            if (event instanceof ContextClosedEvent) {
+                server.close();
+            }
+        });
+    }
+
+    private static String normalizeDatabase(final String candidate) {
+        if (candidate == null || candidate.isBlank()) {
+            return DEFAULT_DATABASE;
+        }
+        return candidate.trim();
+    }
+}

--- a/src/test/java/org/jongodb/server/TcpMongoServerTest.java
+++ b/src/test/java/org/jongodb/server/TcpMongoServerTest.java
@@ -1,0 +1,138 @@
+package org.jongodb.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import org.bson.BsonBinaryWriter;
+import org.bson.BsonDocument;
+import org.bson.RawBsonDocument;
+import org.bson.codecs.BsonDocumentCodec;
+import org.bson.codecs.EncoderContext;
+import org.bson.io.BasicOutputBuffer;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.Test;
+
+final class TcpMongoServerTest {
+    @Test
+    void supportsMongoClientPingAndCrudThroughTcpUri() {
+        try (TcpMongoServer server = TcpMongoServer.inMemory()) {
+            server.start();
+
+            try (MongoClient client = MongoClients.create(server.connectionString("app"))) {
+                final BsonDocument ping = BsonDocument.parse(client.getDatabase("app").runCommand(BsonDocument.parse("{\"ping\":1}")).toJson());
+                assertEquals(1.0, ping.getNumber("ok").doubleValue(), 0.0);
+
+                final MongoCollection<org.bson.Document> users = client.getDatabase("app").getCollection("users");
+                final ObjectId id = new ObjectId();
+                users.insertOne(new org.bson.Document("_id", id).append("name", "alice"));
+                final org.bson.Document found = users.find(new org.bson.Document("_id", id)).first();
+                assertNotNull(found);
+                assertEquals("alice", found.getString("name"));
+            }
+        }
+    }
+
+    @Test
+    void supportsLegacyOpQueryCommandPath() throws IOException {
+        try (TcpMongoServer server = TcpMongoServer.inMemory()) {
+            server.start();
+
+            try (Socket socket = new Socket(server.host(), server.port());
+                    BufferedOutputStream output = new BufferedOutputStream(socket.getOutputStream());
+                    BufferedInputStream input = new BufferedInputStream(socket.getInputStream())) {
+                final byte[] request = encodeOpQueryCommand(42, "admin.$cmd", BsonDocument.parse("{\"ping\":1,\"$db\":\"test\"}"));
+                output.write(request);
+                output.flush();
+
+                final byte[] response = readMessage(input);
+                assertNotNull(response);
+                assertEquals(1, readIntLE(response, 12)); // OP_REPLY
+                final BsonDocument responseDoc = decodeReplyDocument(response);
+                assertEquals(1.0, responseDoc.getNumber("ok").doubleValue(), 0.0);
+            }
+        }
+    }
+
+    private static byte[] encodeOpQueryCommand(final int requestId, final String namespace, final BsonDocument command) {
+        final byte[] namespaceBytes = namespace.getBytes(StandardCharsets.UTF_8);
+        final byte[] commandBytes = encodeBson(command);
+        final int messageLength = 16 + 4 + namespaceBytes.length + 1 + 4 + 4 + commandBytes.length;
+
+        return ByteBuffer.allocate(messageLength)
+                .order(ByteOrder.LITTLE_ENDIAN)
+                .putInt(messageLength)
+                .putInt(requestId)
+                .putInt(0)
+                .putInt(2004) // OP_QUERY
+                .putInt(0) // flags
+                .put(namespaceBytes)
+                .put((byte) 0)
+                .putInt(0) // numberToSkip
+                .putInt(1) // numberToReturn
+                .put(commandBytes)
+                .array();
+    }
+
+    private static byte[] readMessage(final BufferedInputStream input) throws IOException {
+        final byte[] sizeBytes = new byte[4];
+        if (!readFully(input, sizeBytes, 0, 4)) {
+            return null;
+        }
+        final int size = readIntLE(sizeBytes, 0);
+        final byte[] message = new byte[size];
+        System.arraycopy(sizeBytes, 0, message, 0, 4);
+        if (!readFully(input, message, 4, size - 4)) {
+            throw new IOException("incomplete response");
+        }
+        return message;
+    }
+
+    private static BsonDocument decodeReplyDocument(final byte[] message) {
+        final int documentOffset = 16 + 20;
+        final int documentLength = readIntLE(message, documentOffset);
+        final byte[] document = java.util.Arrays.copyOfRange(message, documentOffset, documentOffset + documentLength);
+        return new RawBsonDocument(document);
+    }
+
+    private static byte[] encodeBson(final BsonDocument document) {
+        final BasicOutputBuffer outputBuffer = new BasicOutputBuffer();
+        try (BsonBinaryWriter writer = new BsonBinaryWriter(outputBuffer)) {
+            new BsonDocumentCodec().encode(
+                    writer,
+                    document,
+                    EncoderContext.builder().isEncodingCollectibleDocument(true).build());
+        }
+        return outputBuffer.toByteArray();
+    }
+
+    private static boolean readFully(final BufferedInputStream input, final byte[] target, final int offset, final int length)
+            throws IOException {
+        int readTotal = 0;
+        while (readTotal < length) {
+            final int read = input.read(target, offset + readTotal, length - readTotal);
+            if (read == -1) {
+                return false;
+            }
+            readTotal += read;
+        }
+        return true;
+    }
+
+    private static int readIntLE(final byte[] bytes, final int offset) {
+        return (bytes[offset] & 0xff)
+                | ((bytes[offset + 1] & 0xff) << 8)
+                | ((bytes[offset + 2] & 0xff) << 16)
+                | ((bytes[offset + 3] & 0xff) << 24);
+    }
+}

--- a/src/test/java/org/jongodb/spring/test/JongodbMongoDynamicPropertySupportTest.java
+++ b/src/test/java/org/jongodb/spring/test/JongodbMongoDynamicPropertySupportTest.java
@@ -1,0 +1,80 @@
+package org.jongodb.spring.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.bson.BsonDocument;
+import org.jongodb.server.TcpMongoServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.DynamicPropertyRegistry;
+
+final class JongodbMongoDynamicPropertySupportTest {
+    @AfterEach
+    void tearDown() {
+        JongodbMongoDynamicPropertySupport.stop();
+    }
+
+    @Test
+    void registersDynamicMongoPropertiesAndStartsSharedServer() {
+        final RecordingDynamicPropertyRegistry registry = new RecordingDynamicPropertyRegistry();
+        final TcpMongoServer server = JongodbMongoDynamicPropertySupport.register(registry, "dynodb");
+
+        assertTrue(server.isRunning());
+        final String uri = registry.stringValue("spring.data.mongodb.uri");
+        assertNotNull(uri);
+        assertTrue(uri.endsWith("/dynodb"));
+        assertEquals(server.host(), registry.stringValue("spring.data.mongodb.host"));
+        assertEquals(server.port(), registry.intValue("spring.data.mongodb.port"));
+
+        try (MongoClient client = MongoClients.create(uri)) {
+            final BsonDocument ping = BsonDocument.parse(client.getDatabase("dynodb").runCommand(BsonDocument.parse("{\"ping\":1}")).toJson());
+            assertEquals(1.0, ping.getNumber("ok").doubleValue(), 0.0);
+        }
+    }
+
+    @Test
+    void reusesSharedServerAcrossMultipleRegistrations() {
+        final RecordingDynamicPropertyRegistry first = new RecordingDynamicPropertyRegistry();
+        final RecordingDynamicPropertyRegistry second = new RecordingDynamicPropertyRegistry();
+
+        final TcpMongoServer firstServer = JongodbMongoDynamicPropertySupport.register(first);
+        final TcpMongoServer secondServer = JongodbMongoDynamicPropertySupport.register(second, "anotherdb");
+        assertSame(firstServer, secondServer);
+        assertTrue(firstServer.isRunning());
+
+        JongodbMongoDynamicPropertySupport.stop();
+        assertFalse(firstServer.isRunning());
+    }
+
+    private static final class RecordingDynamicPropertyRegistry implements DynamicPropertyRegistry {
+        private final Map<String, Supplier<Object>> values = new LinkedHashMap<>();
+
+        @Override
+        public void add(final String name, final Supplier<Object> valueSupplier) {
+            values.put(name, valueSupplier);
+        }
+
+        private String stringValue(final String key) {
+            final Supplier<Object> supplier = values.get(key);
+            return supplier == null ? null : String.valueOf(supplier.get());
+        }
+
+        private int intValue(final String key) {
+            final Supplier<Object> supplier = values.get(key);
+            final Object value = supplier == null ? null : supplier.get();
+            if (value instanceof Number number) {
+                return number.intValue();
+            }
+            return Integer.parseInt(String.valueOf(value));
+        }
+    }
+}

--- a/src/test/java/org/jongodb/spring/test/JongodbMongoInitializerTest.java
+++ b/src/test/java/org/jongodb/spring/test/JongodbMongoInitializerTest.java
@@ -1,0 +1,50 @@
+package org.jongodb.spring.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import org.bson.BsonDocument;
+import org.jongodb.server.TcpMongoServer;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.core.env.MapPropertySource;
+
+final class JongodbMongoInitializerTest {
+    @Test
+    void initializesMongoPropertiesAndClosesServerOnContextClose() {
+        final AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        context.getEnvironment()
+                .getPropertySources()
+                .addFirst(new MapPropertySource("jongodbTestProps", java.util.Map.of("jongodb.test.database", "sampledb")));
+
+        final JongodbMongoInitializer initializer = new JongodbMongoInitializer();
+        initializer.initialize(context);
+        context.refresh();
+
+        final String uri = context.getEnvironment().getProperty("spring.data.mongodb.uri");
+        final String host = context.getEnvironment().getProperty("spring.data.mongodb.host");
+        final String port = context.getEnvironment().getProperty("spring.data.mongodb.port");
+
+        assertNotNull(uri);
+        assertNotNull(host);
+        assertNotNull(port);
+        assertTrue(uri.endsWith("/sampledb"));
+
+        final TcpMongoServer server = context.getBean(JongodbMongoInitializer.SERVER_BEAN_NAME, TcpMongoServer.class);
+        assertTrue(server.isRunning());
+        assertEquals(host, server.host());
+        assertEquals(Integer.parseInt(port), server.port());
+
+        try (MongoClient client = MongoClients.create(uri)) {
+            final BsonDocument ping = BsonDocument.parse(client.getDatabase("sampledb").runCommand(BsonDocument.parse("{\"ping\":1}")).toJson());
+            assertEquals(1.0, ping.getNumber("ok").doubleValue(), 0.0);
+        }
+
+        context.close();
+        assertFalse(server.isRunning());
+    }
+}


### PR DESCRIPTION
## Summary
- add reusable in-memory TCP Mongo bridge server (`TcpMongoServer`) with OP_MSG and OP_QUERY handling
- add Spring Boot test adapters:
  - `JongodbMongoInitializer` (`ApplicationContextInitializer`)
  - `JongodbMongoDynamicPropertySupport` (`@DynamicPropertySource` helper)
- add integration tests for tcp server + spring initializer/helper lifecycle
- add Spring migration guide and usage docs for replacing Testcontainers bootstrap code

## Linked Issues (Required)
Closes #72
Closes #70
Closes #71

## Verification
- `./.tooling/gradle-8.10.2/bin/gradle --no-daemon test --tests org.jongodb.server.TcpMongoServerTest --tests org.jongodb.spring.test.JongodbMongoInitializerTest --tests org.jongodb.spring.test.JongodbMongoDynamicPropertySupportTest`
- `./.tooling/gradle-8.10.2/bin/gradle --no-daemon test`

## Notes
- Spring types are added as `compileOnly` to avoid forcing runtime Spring dependencies on non-Spring consumers.
- Documentation includes direct migration examples from MongoDB Testcontainers dynamic-property setup.
