### PR TITLE
[R4][Txn] Namespace-aware transaction commit merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ Requirements:
 - It is suitable when your test bootstrap can route command/wire messages in-process.
 - For tests that must connect through standard `mongodb://` endpoint semantics, keep a real/embedded `mongod` backend for that test profile.
 
+### Spring Transaction Contract (Current)
+
+- Supported: single transaction manager flow with one or multiple MongoTemplate/Repository paths in the same transaction envelope.
+- Supported: non-transactional writes in a different namespace while a transaction is open are preserved after commit.
+- Supported: non-transactional writes in the same namespace with different `_id` values are preserved after commit.
+- Deterministic policy: if transactional and non-transactional writes touch the same `_id`, the transactional version is applied at commit.
+- Out of scope: distributed transactions, replica-set semantics, and advanced retryable transaction behavior.
+
 ### Spring Boot Test Setup (Initializer)
 
 ```java
@@ -126,7 +134,7 @@ It does not target full MongoDB server parity.
 | Support manifest | 7 `Supported`, 4 `Partial`, 1 `Unsupported` feature groups | Source: `docs/SUPPORT_MATRIX.md` |
 | Query language | Core comparison/logical/array/regex + partial `$expr` | Advanced expression/operator parity is incomplete |
 | Aggregation | Core stages + selected Tier-2 stages | Expression depth and many advanced operators are missing |
-| Transactions | Single-process session/transaction flow (`start`/`commit`/`abort`) | No distributed/replica-set semantics |
+| Transactions | Single-process session/transaction flow (`start`/`commit`/`abort`) | Namespace-aware commit merge preserves out-of-transaction interleavings for different namespaces and different `_id` values |
 | Wire protocol | `OP_MSG` in-process ingress | No external TCP server process |
 
 Detailed boundaries:

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -115,8 +115,9 @@ Current limitations:
 Supported:
 - session + transaction envelope validation (`lsid`, `txnNumber`, `autocommit=false`)
 - start/commit/abort flow
-- transaction snapshot publish on commit
+- namespace-aware commit merge for transaction writes
 - expected transaction error labels for no-such-transaction cases
+- deterministic conflict rule: transactional writes win when transactional and non-transactional paths touch the same `_id`
 
 Current scope:
 - single in-memory process semantics

--- a/docs/SPRING_TESTING.md
+++ b/docs/SPRING_TESTING.md
@@ -85,6 +85,21 @@ Keep Testcontainers/real `mongod` for tests that require:
 - advanced transaction/retry semantics outside current support scope
 - deployment-level behavior
 
+## Transaction Contract (Current)
+
+| Scenario | Support | Notes |
+| --- | --- | --- |
+| Single-template transactional path | Supported | `startTransaction` -> CRUD -> `commitTransaction` / `abortTransaction` |
+| Multi-template same transaction manager path | Supported | Multiple namespaces can participate in one transaction envelope |
+| Out-of-scope write, different namespace during open transaction | Supported | Non-transactional writes are preserved after commit |
+| Out-of-scope write, same namespace with different `_id` | Supported | Non-transactional writes are preserved after commit |
+| Same `_id` touched by both transactional and non-transactional writes | Deterministic | Commit applies the transactional version for that `_id` |
+
+Not covered by this contract:
+- distributed transaction semantics
+- replica-set and deployment-level transaction behavior
+- advanced commit retry semantics across network/process failures
+
 ## Troubleshooting
 
 - If you see `codeName=NotImplemented` with `UnsupportedFeature`, the test is using an unsupported feature path.

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -26,7 +26,7 @@ Source artifact: `build/reports/r2-compatibility/r2-support-manifest.json`.
 | `index.unique-sparse-partial` | index | Supported | Unique/sparse/partial |
 | `index.collation-metadata` | index | Supported | Collation metadata round-trip |
 | `index.collation-semantic` | index | Unsupported | Locale-aware comparison semantics |
-| `transactions-single-session` | transaction | Supported | Session + txn command flow |
+| `transactions-single-session` | transaction | Supported | Session + txn flow with namespace-aware commit merge and deterministic same-`_id` resolution |
 | `transactions-retryable-advanced` | transaction | Partial | Partial compatibility |
 | `protocol-unsupported-contract` | protocol | Supported | NotImplemented + UnsupportedFeature labels |
 
@@ -35,4 +35,3 @@ Source artifact: `build/reports/r2-compatibility/r2-support-manifest.json`.
 - The matrix is intended for test-environment substitution scenarios.
 - Unsupported UTF coverage is tracked in `docs/COMPATIBILITY_SCORECARD.md` with reason counts.
 - New feature expansion should update both this matrix and `docs/COMPATIBILITY.md`.
-

--- a/src/main/java/org/jongodb/engine/InMemoryEngineStore.java
+++ b/src/main/java/org/jongodb/engine/InMemoryEngineStore.java
@@ -1,6 +1,10 @@
 package org.jongodb.engine;
 
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -30,5 +34,44 @@ public final class InMemoryEngineStore implements EngineStore {
         for (final var entry : source.collections.entrySet()) {
             collections.put(entry.getKey(), entry.getValue().snapshot());
         }
+    }
+
+    public void mergeTransactionSnapshot(
+            final InMemoryEngineStore baselineSnapshot, final InMemoryEngineStore transactionSnapshot) {
+        Objects.requireNonNull(baselineSnapshot, "baselineSnapshot");
+        Objects.requireNonNull(transactionSnapshot, "transactionSnapshot");
+
+        final Map<Namespace, InMemoryCollectionStore.CollectionState> baselineStates =
+                baselineSnapshot.collectionStatesSnapshot();
+        final Map<Namespace, InMemoryCollectionStore.CollectionState> transactionStates =
+                transactionSnapshot.collectionStatesSnapshot();
+        final Map<Namespace, InMemoryCollectionStore.CollectionState> currentStates = collectionStatesSnapshot();
+
+        final Set<Namespace> touchedNamespaces = new HashSet<>();
+        touchedNamespaces.addAll(baselineStates.keySet());
+        touchedNamespaces.addAll(transactionStates.keySet());
+
+        synchronized (this) {
+            for (final Namespace namespace : touchedNamespaces) {
+                final InMemoryCollectionStore.CollectionState baselineState = baselineStates.get(namespace);
+                final InMemoryCollectionStore.CollectionState transactionState = transactionStates.get(namespace);
+                if (InMemoryCollectionStore.statesEqual(baselineState, transactionState)) {
+                    continue;
+                }
+
+                final InMemoryCollectionStore.CollectionState currentState = currentStates.get(namespace);
+                final InMemoryCollectionStore.CollectionState mergedState =
+                        InMemoryCollectionStore.mergeTransactionState(baselineState, transactionState, currentState);
+                collections.computeIfAbsent(namespace, key -> new InMemoryCollectionStore()).replaceState(mergedState);
+            }
+        }
+    }
+
+    private synchronized Map<Namespace, InMemoryCollectionStore.CollectionState> collectionStatesSnapshot() {
+        final Map<Namespace, InMemoryCollectionStore.CollectionState> states = new LinkedHashMap<>();
+        for (final var entry : collections.entrySet()) {
+            states.put(entry.getKey(), entry.getValue().snapshotState());
+        }
+        return states;
     }
 }

--- a/testkit/spring-suite/src/main/java/org/jongodb/testkit/springsuite/SpringCompatibilityMatrixRunner.java
+++ b/testkit/spring-suite/src/main/java/org/jongodb/testkit/springsuite/SpringCompatibilityMatrixRunner.java
@@ -511,6 +511,155 @@ public final class SpringCompatibilityMatrixRunner {
                 )
             ),
             new SpringScenario(
+                "spring.transaction-template.multi-template.same-manager",
+                SpringSurface.TRANSACTION_TEMPLATE,
+                "Single transaction writes across two template-backed namespaces",
+                scenario(
+                    "spring.transaction-template.multi-template.same-manager",
+                    "start transaction + write namespace A/B + commit",
+                    command(
+                        "insert",
+                        payload(
+                            "collection",
+                            "spring_txn_users",
+                            "documents",
+                            List.of(payload("_id", 11, "name", "txn-user")),
+                            "lsid",
+                            payload("id", "spring-session-tx-2"),
+                            "txnNumber",
+                            1,
+                            "autocommit",
+                            false,
+                            "startTransaction",
+                            true
+                        )
+                    ),
+                    command(
+                        "insert",
+                        payload(
+                            "collection",
+                            "spring_txn_tenant_mappings",
+                            "documents",
+                            List.of(payload("_id", 12, "tenantId", "tenant-a")),
+                            "lsid",
+                            payload("id", "spring-session-tx-2"),
+                            "txnNumber",
+                            1,
+                            "autocommit",
+                            false
+                        )
+                    ),
+                    command(
+                        "commitTransaction",
+                        payload(
+                            "lsid",
+                            payload("id", "spring-session-tx-2"),
+                            "txnNumber",
+                            1,
+                            "autocommit",
+                            false
+                        )
+                    ),
+                    command("find", payload("collection", "spring_txn_users", "filter", payload("_id", 11))),
+                    command("find", payload("collection", "spring_txn_tenant_mappings", "filter", payload("_id", 12)))
+                )
+            ),
+            new SpringScenario(
+                "spring.transaction-template.out-of-scope.namespace-interleaving",
+                SpringSurface.TRANSACTION_TEMPLATE,
+                "Transactional namespace commit preserves non-transactional writes in other namespace",
+                scenario(
+                    "spring.transaction-template.out-of-scope.namespace-interleaving",
+                    "start transaction + out-of-scope write + commit",
+                    command(
+                        "insert",
+                        payload(
+                            "collection",
+                            "spring_txn_scope_users",
+                            "documents",
+                            List.of(payload("_id", 21, "state", "txn")),
+                            "lsid",
+                            payload("id", "spring-session-tx-3"),
+                            "txnNumber",
+                            1,
+                            "autocommit",
+                            false,
+                            "startTransaction",
+                            true
+                        )
+                    ),
+                    command(
+                        "insert",
+                        payload(
+                            "collection",
+                            "spring_txn_scope_mappings",
+                            "documents",
+                            List.of(payload("_id", 22, "state", "outside"))
+                        )
+                    ),
+                    command(
+                        "commitTransaction",
+                        payload(
+                            "lsid",
+                            payload("id", "spring-session-tx-3"),
+                            "txnNumber",
+                            1,
+                            "autocommit",
+                            false
+                        )
+                    ),
+                    command("find", payload("collection", "spring_txn_scope_users", "filter", payload("_id", 21))),
+                    command("find", payload("collection", "spring_txn_scope_mappings", "filter", payload("_id", 22)))
+                )
+            ),
+            new SpringScenario(
+                "spring.transaction-template.out-of-scope.same-namespace-interleaving",
+                SpringSurface.TRANSACTION_TEMPLATE,
+                "Transactional commit preserves non-transactional writes in same namespace when ids differ",
+                scenario(
+                    "spring.transaction-template.out-of-scope.same-namespace-interleaving",
+                    "start transaction + out-of-scope write same namespace + commit",
+                    command(
+                        "insert",
+                        payload(
+                            "collection",
+                            "spring_txn_scope_same_namespace",
+                            "documents",
+                            List.of(payload("_id", 31, "state", "txn")),
+                            "lsid",
+                            payload("id", "spring-session-tx-4"),
+                            "txnNumber",
+                            1,
+                            "autocommit",
+                            false,
+                            "startTransaction",
+                            true
+                        )
+                    ),
+                    command(
+                        "insert",
+                        payload(
+                            "collection",
+                            "spring_txn_scope_same_namespace",
+                            "documents",
+                            List.of(payload("_id", 32, "state", "outside"))
+                        )
+                    ),
+                    command(
+                        "commitTransaction",
+                        payload(
+                            "lsid",
+                            payload("id", "spring-session-tx-4"),
+                            "txnNumber",
+                            1,
+                            "autocommit",
+                            false
+                        )
+                    ),
+                    command("find", payload("collection", "spring_txn_scope_same_namespace", "filter", payload()))
+                )
+            ),
+            new SpringScenario(
                 "spring.repository.aggregation-lookup",
                 SpringSurface.REPOSITORY,
                 "Repository aggregation with $lookup join",


### PR DESCRIPTION
## Summary
- replace full-store transaction commit publish with namespace-aware merge semantics
- preserve out-of-transaction writes that interleave during an open transaction (different namespace and same namespace with different `_id`)
- add deterministic conflict behavior for same `_id` interleavings (transactional version applied at commit)
- expand regression and spring matrix coverage, and document the Spring transaction support contract

## Behavioral change
Before:
- transaction commit replaced the full in-memory store snapshot
- interleaved non-transactional writes could be dropped on commit

After:
- commit merges transaction deltas into current store state
- out-of-transaction writes outside transactional delta are preserved
- same `_id` conflicts resolve deterministically to transactional state at commit

## Verification
- `./.tooling/gradle-8.10.2/bin/gradle test`
- `./.tooling/gradle-8.10.2/bin/gradle springCompatibilityMatrixEvidence -PspringMatrixFailOnFailures=true`

Closes #78
Closes #77
Closes #76
Related: #74
