### PR TITLE
feat(spring-test): add single-hook @JongodbMongoTest integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jongodb
 
-In-memory MongoDB-compatible backend for integration tests.
+In-memory MongoDB-compatible backend for fast Spring integration tests.
 
 `jongodb` targets fast, deterministic Spring Boot test execution without starting a MongoDB container or external process.
 It is not a production MongoDB replacement.
@@ -64,6 +64,15 @@ dependencies {
 ```
 
 ### 2) Spring Boot integration
+
+Single-hook annotation style:
+
+```java
+@SpringBootTest
+@JongodbMongoTest
+class MyIntegrationTest {
+}
+```
 
 Initializer style:
 
@@ -161,7 +170,7 @@ static void mongoProps(DynamicPropertyRegistry registry) {
 ### From mongo-java-server and similar backends
 
 1. Replace test dependency with `io.github.midagedev:jongodb:<version>`.
-2. Switch bootstrap to `JongodbMongoInitializer` or `JongodbMongoDynamicPropertySupport`.
+2. Switch bootstrap to `JongodbMongoTest`, `JongodbMongoInitializer`, or `JongodbMongoDynamicPropertySupport`.
 3. Run integration tests and classify failures.
 4. Keep a fallback profile for unsupported feature paths.
 

--- a/docs/SPRING_TESTING.md
+++ b/docs/SPRING_TESTING.md
@@ -6,6 +6,7 @@ This guide explains how to use `jongodb` from Spring Boot tests and how to migra
 
 ## Supported Integration Styles
 
+- Single-hook annotation: `org.jongodb.spring.test.JongodbMongoTest`
 - `ApplicationContextInitializer`: `org.jongodb.spring.test.JongodbMongoInitializer`
 - `@DynamicPropertySource`: `org.jongodb.spring.test.JongodbMongoDynamicPropertySupport`
 
@@ -25,6 +26,15 @@ dependencies {
 ```
 
 ### 2) Replace test bootstrap
+
+Single-hook annotation style (recommended for most Spring Boot tests):
+
+```java
+@SpringBootTest
+@JongodbMongoTest
+class MyIntegrationTest {
+}
+```
 
 Initializer style:
 
@@ -48,6 +58,7 @@ class MyIntegrationTest {
 ```
 
 Optional test database name:
+- `@TestPropertySource(properties = "jongodb.test.database=<dbName>")` (single-hook/initializer style)
 - `jongodb.test.database=<dbName>` (initializer style)
 - `JongodbMongoDynamicPropertySupport.register(registry, "<dbName>")` (dynamic style)
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -35,7 +35,23 @@ If you need command-level integration without sockets, instantiate `WireCommandI
 
 ## Spring Boot Test Integration
 
-### Option A: `ApplicationContextInitializer`
+### Option A: Single-hook annotation
+
+Use `JongodbMongoTest` to opt in with one annotation instead of custom initializer or `@DynamicPropertySource` boilerplate:
+
+```java
+import org.jongodb.spring.test.JongodbMongoTest;
+
+@SpringBootTest
+@JongodbMongoTest
+class AccountIntegrationTest {
+}
+```
+
+Optional database override:
+- add `@TestPropertySource(properties = "jongodb.test.database=<dbName>")`.
+
+### Option B: `ApplicationContextInitializer`
 
 Use `JongodbMongoInitializer` when your tests already use `@ContextConfiguration` initializers:
 
@@ -52,7 +68,7 @@ class AccountIntegrationTest {
 Optional database override:
 - set `jongodb.test.database=<dbName>` as a test property.
 
-### Option B: `@DynamicPropertySource`
+### Option C: `@DynamicPropertySource`
 
 Use `JongodbMongoDynamicPropertySupport` as a drop-in replacement pattern for many Testcontainers setups:
 

--- a/src/main/java/org/jongodb/spring/test/JongodbMongoTest.java
+++ b/src/main/java/org/jongodb/spring/test/JongodbMongoTest.java
@@ -1,0 +1,26 @@
+package org.jongodb.spring.test;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * Single-hook Spring test integration for jongodb.
+ *
+ * <p>Use with {@code @SpringBootTest} (or other Spring TestContext entry points) to bootstrap an
+ * in-memory MongoDB endpoint without custom initializer boilerplate.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@ContextConfiguration(initializers = JongodbMongoInitializer.class)
+public @interface JongodbMongoTest {
+    @AliasFor(annotation = ContextConfiguration.class, attribute = "classes")
+    Class<?>[] classes() default {};
+}

--- a/src/test/java/org/jongodb/spring/test/JongodbMongoTestDatabaseOverrideWiringTest.java
+++ b/src/test/java/org/jongodb/spring/test/JongodbMongoTestDatabaseOverrideWiringTest.java
@@ -1,0 +1,55 @@
+package org.jongodb.spring.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import org.bson.BsonDocument;
+import org.jongodb.server.TcpMongoServer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@TestPropertySource(properties = "jongodb.test.database=ordersdb")
+@JongodbMongoTest(classes = JongodbMongoTestDatabaseOverrideWiringTest.TestConfig.class)
+final class JongodbMongoTestDatabaseOverrideWiringTest {
+    @Autowired
+    private Environment environment;
+
+    @Autowired
+    @Qualifier(JongodbMongoInitializer.SERVER_BEAN_NAME)
+    private TcpMongoServer server;
+
+    @Test
+    void wiresMongoUriHostPortAndOverriddenDatabase() {
+        final String uri = environment.getProperty("spring.data.mongodb.uri");
+        final String host = environment.getProperty("spring.data.mongodb.host");
+        final String port = environment.getProperty("spring.data.mongodb.port");
+
+        assertNotNull(uri);
+        assertNotNull(host);
+        assertNotNull(port);
+        assertTrue(uri.endsWith("/ordersdb"));
+        assertEquals(server.host(), host);
+        assertEquals(server.port(), Integer.parseInt(port));
+
+        try (MongoClient client = MongoClients.create(uri)) {
+            final BsonDocument ping = BsonDocument.parse(
+                    client.getDatabase("ordersdb").runCommand(BsonDocument.parse("{\"ping\":1}")).toJson());
+            assertEquals(1.0, ping.getNumber("ok").doubleValue(), 0.0);
+        }
+    }
+
+    @Configuration
+    static class TestConfig {}
+}

--- a/src/test/java/org/jongodb/spring/test/JongodbMongoTestDefaultWiringTest.java
+++ b/src/test/java/org/jongodb/spring/test/JongodbMongoTestDefaultWiringTest.java
@@ -1,0 +1,53 @@
+package org.jongodb.spring.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import org.bson.BsonDocument;
+import org.jongodb.server.TcpMongoServer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@JongodbMongoTest(classes = JongodbMongoTestDefaultWiringTest.TestConfig.class)
+final class JongodbMongoTestDefaultWiringTest {
+    @Autowired
+    private Environment environment;
+
+    @Autowired
+    @Qualifier(JongodbMongoInitializer.SERVER_BEAN_NAME)
+    private TcpMongoServer server;
+
+    @Test
+    void wiresMongoUriHostPortAndDefaultDatabase() {
+        final String uri = environment.getProperty("spring.data.mongodb.uri");
+        final String host = environment.getProperty("spring.data.mongodb.host");
+        final String port = environment.getProperty("spring.data.mongodb.port");
+
+        assertNotNull(uri);
+        assertNotNull(host);
+        assertNotNull(port);
+        assertTrue(uri.endsWith("/test"));
+        assertEquals(server.host(), host);
+        assertEquals(server.port(), Integer.parseInt(port));
+
+        try (MongoClient client = MongoClients.create(uri)) {
+            final BsonDocument ping = BsonDocument.parse(
+                    client.getDatabase("test").runCommand(BsonDocument.parse("{\"ping\":1}")).toJson());
+            assertEquals(1.0, ping.getNumber("ok").doubleValue(), 0.0);
+        }
+    }
+
+    @Configuration
+    static class TestConfig {}
+}


### PR DESCRIPTION
## Summary
- add `@JongodbMongoTest` as a single-hook Spring TestContext integration annotation
- keep `JongodbMongoInitializer` and `JongodbMongoDynamicPropertySupport` fully backward compatible
- add focused wiring tests for default and overridden database property behavior
- document single-hook usage in README and Spring docs

## Why
Issue #82 targets migration ergonomics from container-based test setups to jongodb with less boilerplate.

## Scope
- `src/main/java/org/jongodb/spring/test/**`
- `src/test/java/org/jongodb/spring/test/**`
- `docs/SPRING_TESTING.md`
- `docs/USAGE.md`
- `README.md` (Spring usage sections)

## Review Findings
- no blocking defects found in maintainer review for this lane
- residual risk: coverage is Spring TestContext focused; full Boot app auto-config path is not expanded in this PR

## Verification
- `/Users/hckim/.local/gradle-8.10.2/bin/gradle --no-daemon test --tests "org.jongodb.spring.test.*"`

Closes #82
