### PR TITLE
feat(command): CRUD parity pack for countDocuments/replaceOne/findOneAnd*

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -26,6 +26,10 @@ Certification context:
 | `listIndexes` | Partial | Metadata round-trip |
 | `update` | Partial | Operator set intentionally limited |
 | `delete` | Supported | `limit` 0/1 behavior |
+| `countDocuments` | Partial | Filter + skip/limit + hint/collation/readConcern shape validation |
+| `replaceOne` | Partial | Rewrites to single replacement `update` path (`multi=false`) |
+| `findOneAndUpdate` | Partial | Rewrites to `findAndModify`; operator updates only |
+| `findOneAndReplace` | Partial | Rewrites to `findAndModify`; replacement updates only |
 | `commitTransaction`, `abortTransaction` | Supported | Session/txn envelope supported |
 
 ## Query Operators

--- a/src/main/java/org/jongodb/command/CommandDispatcher.java
+++ b/src/main/java/org/jongodb/command/CommandDispatcher.java
@@ -43,6 +43,10 @@ public final class CommandDispatcher {
         configuredHandlers.put("update", new UpdateCommandHandler(routedStore));
         configuredHandlers.put("delete", new DeleteCommandHandler(routedStore));
         configuredHandlers.put("findandmodify", new FindAndModifyCommandHandler(routedStore));
+        configuredHandlers.put("countdocuments", new CountDocumentsCommandHandler(routedStore));
+        configuredHandlers.put("replaceone", new ReplaceOneCommandHandler(routedStore));
+        configuredHandlers.put("findoneandupdate", new FindOneAndUpdateCommandHandler(routedStore));
+        configuredHandlers.put("findoneandreplace", new FindOneAndReplaceCommandHandler(routedStore));
         configuredHandlers.put("committransaction", new CommitTransactionCommandHandler());
         configuredHandlers.put("aborttransaction", new AbortTransactionCommandHandler());
         this.handlers = Map.copyOf(configuredHandlers);

--- a/src/main/java/org/jongodb/command/CountDocumentsCommandHandler.java
+++ b/src/main/java/org/jongodb/command/CountDocumentsCommandHandler.java
@@ -1,0 +1,146 @@
+package org.jongodb.command;
+
+import java.util.List;
+import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.BsonInt64;
+import org.bson.BsonValue;
+
+public final class CountDocumentsCommandHandler implements CommandHandler {
+    private final CommandStore store;
+
+    public CountDocumentsCommandHandler(final CommandStore store) {
+        this.store = store;
+    }
+
+    @Override
+    public BsonDocument handle(final BsonDocument command) {
+        final String database = readDatabase(command);
+        final String collection = readCollection(command);
+        if (collection == null) {
+            return CommandErrors.typeMismatch("countDocuments must be a string");
+        }
+
+        BsonDocument optionError = CrudCommandOptionValidator.validateReadConcern(command);
+        if (optionError != null) {
+            return optionError;
+        }
+        optionError = CrudCommandOptionValidator.validateHint(command, "hint");
+        if (optionError != null) {
+            return optionError;
+        }
+        optionError = CrudCommandOptionValidator.validateCollation(command, "collation");
+        if (optionError != null) {
+            return optionError;
+        }
+
+        final BsonValue filterValue = command.containsKey("filter") ? command.get("filter") : command.get("query");
+        final BsonDocument filter;
+        if (filterValue == null) {
+            filter = new BsonDocument();
+        } else if (!filterValue.isDocument()) {
+            return CommandErrors.typeMismatch("filter must be a document");
+        } else {
+            filter = filterValue.asDocument();
+        }
+
+        final int skip;
+        final BsonValue skipValue = command.get("skip");
+        if (skipValue == null) {
+            skip = 0;
+        } else {
+            final Long parsedSkip = readIntegralLong(skipValue);
+            if (parsedSkip == null) {
+                return CommandErrors.typeMismatch("skip must be an integer");
+            }
+            if (parsedSkip < 0 || parsedSkip > Integer.MAX_VALUE) {
+                return CommandErrors.badValue("skip must be a non-negative integer");
+            }
+            skip = parsedSkip.intValue();
+        }
+
+        final int limit;
+        final BsonValue limitValue = command.get("limit");
+        if (limitValue == null) {
+            limit = 0;
+        } else {
+            final Long parsedLimit = readIntegralLong(limitValue);
+            if (parsedLimit == null) {
+                return CommandErrors.typeMismatch("limit must be an integer");
+            }
+            if (parsedLimit < 0 || parsedLimit > Integer.MAX_VALUE) {
+                return CommandErrors.badValue("limit must be a non-negative integer");
+            }
+            limit = parsedLimit.intValue();
+        }
+
+        final List<BsonDocument> matches;
+        try {
+            matches = store.find(database, collection, filter);
+        } catch (final IllegalArgumentException exception) {
+            return CommandExceptionMapper.fromIllegalArgument(exception);
+        }
+
+        final int fromIndex = Math.min(skip, matches.size());
+        int toIndex = matches.size();
+        if (limit > 0) {
+            toIndex = Math.min(fromIndex + limit, matches.size());
+        }
+        final long count = toIndex - fromIndex;
+
+        return new BsonDocument()
+                .append("n", new BsonInt64(count))
+                .append("count", new BsonInt64(count))
+                .append("ok", new BsonDouble(1.0));
+    }
+
+    private static String readDatabase(final BsonDocument command) {
+        final BsonValue value = command.get("$db");
+        if (value == null || !value.isString()) {
+            return "test";
+        }
+        return value.asString().getValue();
+    }
+
+    private static String readCollection(final BsonDocument command) {
+        final BsonValue canonical = command.get("countDocuments");
+        if (canonical != null) {
+            if (canonical.isString()) {
+                return canonical.asString().getValue();
+            }
+            return null;
+        }
+
+        for (final String key : command.keySet()) {
+            if (!"countdocuments".equalsIgnoreCase(key)) {
+                continue;
+            }
+            final BsonValue value = command.get(key);
+            if (value != null && value.isString()) {
+                return value.asString().getValue();
+            }
+            return null;
+        }
+        return null;
+    }
+
+    private static Long readIntegralLong(final BsonValue value) {
+        if (value.isInt32()) {
+            return (long) value.asInt32().getValue();
+        }
+        if (value.isInt64()) {
+            return value.asInt64().getValue();
+        }
+        if (value.isDouble()) {
+            final double doubleValue = value.asDouble().getValue();
+            if (!Double.isFinite(doubleValue) || Math.rint(doubleValue) != doubleValue) {
+                return null;
+            }
+            if (doubleValue < Long.MIN_VALUE || doubleValue > Long.MAX_VALUE) {
+                return null;
+            }
+            return (long) doubleValue;
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/jongodb/command/FindOneAndReplaceCommandHandler.java
+++ b/src/main/java/org/jongodb/command/FindOneAndReplaceCommandHandler.java
@@ -1,0 +1,181 @@
+package org.jongodb.command;
+
+import org.bson.BsonBoolean;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+
+public final class FindOneAndReplaceCommandHandler implements CommandHandler {
+    private final FindAndModifyCommandHandler findAndModifyCommandHandler;
+
+    public FindOneAndReplaceCommandHandler(final CommandStore store) {
+        this.findAndModifyCommandHandler = new FindAndModifyCommandHandler(store);
+    }
+
+    @Override
+    public BsonDocument handle(final BsonDocument command) {
+        final String database = readDatabase(command);
+        final String collection = readCollection(command);
+        if (collection == null) {
+            return CommandErrors.typeMismatch("findOneAndReplace must be a string");
+        }
+
+        BsonDocument optionError = CrudCommandOptionValidator.validateWriteConcern(command);
+        if (optionError != null) {
+            return optionError;
+        }
+        optionError = CrudCommandOptionValidator.validateReadConcern(command);
+        if (optionError != null) {
+            return optionError;
+        }
+        optionError = CrudCommandOptionValidator.validateHint(command, "hint");
+        if (optionError != null) {
+            return optionError;
+        }
+        optionError = CrudCommandOptionValidator.validateCollation(command, "collation");
+        if (optionError != null) {
+            return optionError;
+        }
+
+        final BsonDocument filter = readRequiredDocument(command, "filter");
+        if (filter == null) {
+            return CommandErrors.typeMismatch("filter must be a document");
+        }
+
+        final BsonDocument replacement = readRequiredDocument(command, "replacement");
+        if (replacement == null) {
+            return CommandErrors.typeMismatch("replacement must be a document");
+        }
+        if (replacement.isEmpty()) {
+            return CommandErrors.badValue("replacement must not be empty");
+        }
+        if (containsTopLevelOperator(replacement)) {
+            return CommandErrors.badValue("replacement document must not contain update operators");
+        }
+
+        final BsonValue sortValue = command.get("sort");
+        final BsonDocument sort;
+        if (sortValue == null) {
+            sort = null;
+        } else if (!sortValue.isDocument()) {
+            return CommandErrors.typeMismatch("sort must be a document");
+        } else {
+            sort = sortValue.asDocument();
+        }
+
+        final BsonValue upsertValue = command.get("upsert");
+        final boolean upsert;
+        if (upsertValue == null) {
+            upsert = false;
+        } else if (!upsertValue.isBoolean()) {
+            return CommandErrors.typeMismatch("upsert must be a boolean");
+        } else {
+            upsert = upsertValue.asBoolean().getValue();
+        }
+
+        final ParsedReturnDocument parsedReturnDocument = parseReturnDocument(command);
+        if (parsedReturnDocument.error() != null) {
+            return parsedReturnDocument.error();
+        }
+
+        final BsonDocument translatedFindAndModify = new BsonDocument()
+                .append("findAndModify", new BsonString(collection))
+                .append("$db", new BsonString(database))
+                .append("query", filter)
+                .append("update", replacement)
+                .append("remove", BsonBoolean.FALSE)
+                .append("new", BsonBoolean.valueOf(parsedReturnDocument.returnNew()))
+                .append("upsert", BsonBoolean.valueOf(upsert));
+        if (sort != null) {
+            translatedFindAndModify.append("sort", sort);
+        }
+
+        appendIfPresent(command, translatedFindAndModify, "hint");
+        appendIfPresent(command, translatedFindAndModify, "collation");
+
+        return findAndModifyCommandHandler.handle(translatedFindAndModify);
+    }
+
+    private static boolean containsTopLevelOperator(final BsonDocument document) {
+        for (final String key : document.keySet()) {
+            if (key.startsWith("$")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static ParsedReturnDocument parseReturnDocument(final BsonDocument command) {
+        final BsonValue returnDocumentValue = command.get("returnDocument");
+        if (returnDocumentValue == null) {
+            final BsonValue newValue = command.get("new");
+            if (newValue == null) {
+                return new ParsedReturnDocument(false, null);
+            }
+            if (!newValue.isBoolean()) {
+                return new ParsedReturnDocument(false, CommandErrors.typeMismatch("new must be a boolean"));
+            }
+            return new ParsedReturnDocument(newValue.asBoolean().getValue(), null);
+        }
+
+        if (!returnDocumentValue.isString()) {
+            return new ParsedReturnDocument(false, CommandErrors.typeMismatch("returnDocument must be a string"));
+        }
+
+        final String value = returnDocumentValue.asString().getValue();
+        if ("before".equals(value)) {
+            return new ParsedReturnDocument(false, null);
+        }
+        if ("after".equals(value)) {
+            return new ParsedReturnDocument(true, null);
+        }
+        return new ParsedReturnDocument(false, CommandErrors.badValue("returnDocument must be 'before' or 'after'"));
+    }
+
+    private static void appendIfPresent(final BsonDocument source, final BsonDocument target, final String key) {
+        if (!source.containsKey(key)) {
+            return;
+        }
+        target.append(key, source.get(key));
+    }
+
+    private static String readDatabase(final BsonDocument command) {
+        final BsonValue value = command.get("$db");
+        if (value == null || !value.isString()) {
+            return "test";
+        }
+        return value.asString().getValue();
+    }
+
+    private static String readCollection(final BsonDocument command) {
+        final BsonValue canonical = command.get("findOneAndReplace");
+        if (canonical != null) {
+            if (canonical.isString()) {
+                return canonical.asString().getValue();
+            }
+            return null;
+        }
+
+        for (final String key : command.keySet()) {
+            if (!"findoneandreplace".equalsIgnoreCase(key)) {
+                continue;
+            }
+            final BsonValue value = command.get(key);
+            if (value != null && value.isString()) {
+                return value.asString().getValue();
+            }
+            return null;
+        }
+        return null;
+    }
+
+    private static BsonDocument readRequiredDocument(final BsonDocument command, final String key) {
+        final BsonValue value = command.get(key);
+        if (value == null || !value.isDocument()) {
+            return null;
+        }
+        return value.asDocument();
+    }
+
+    private record ParsedReturnDocument(boolean returnNew, BsonDocument error) {}
+}

--- a/src/main/java/org/jongodb/command/FindOneAndUpdateCommandHandler.java
+++ b/src/main/java/org/jongodb/command/FindOneAndUpdateCommandHandler.java
@@ -1,0 +1,268 @@
+package org.jongodb.command;
+
+import java.util.Set;
+import org.bson.BsonBoolean;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+
+public final class FindOneAndUpdateCommandHandler implements CommandHandler {
+    private static final Set<String> SUPPORTED_OPERATORS = Set.of("$set", "$inc", "$unset", "$addToSet");
+
+    private final FindAndModifyCommandHandler findAndModifyCommandHandler;
+
+    public FindOneAndUpdateCommandHandler(final CommandStore store) {
+        this.findAndModifyCommandHandler = new FindAndModifyCommandHandler(store);
+    }
+
+    @Override
+    public BsonDocument handle(final BsonDocument command) {
+        final String database = readDatabase(command);
+        final String collection = readCollection(command);
+        if (collection == null) {
+            return CommandErrors.typeMismatch("findOneAndUpdate must be a string");
+        }
+
+        BsonDocument optionError = CrudCommandOptionValidator.validateWriteConcern(command);
+        if (optionError != null) {
+            return optionError;
+        }
+        optionError = CrudCommandOptionValidator.validateReadConcern(command);
+        if (optionError != null) {
+            return optionError;
+        }
+        optionError = CrudCommandOptionValidator.validateHint(command, "hint");
+        if (optionError != null) {
+            return optionError;
+        }
+        optionError = CrudCommandOptionValidator.validateCollation(command, "collation");
+        if (optionError != null) {
+            return optionError;
+        }
+
+        final BsonDocument filter = readRequiredDocument(command, "filter");
+        if (filter == null) {
+            return CommandErrors.typeMismatch("filter must be a document");
+        }
+
+        final BsonDocument update = readRequiredDocument(command, "update");
+        if (update == null) {
+            return CommandErrors.typeMismatch("update must be a document");
+        }
+
+        optionError = validateOperatorUpdateDocument(update);
+        if (optionError != null) {
+            return optionError;
+        }
+
+        final BsonValue sortValue = command.get("sort");
+        final BsonDocument sort;
+        if (sortValue == null) {
+            sort = null;
+        } else if (!sortValue.isDocument()) {
+            return CommandErrors.typeMismatch("sort must be a document");
+        } else {
+            sort = sortValue.asDocument();
+        }
+
+        final BsonValue upsertValue = command.get("upsert");
+        final boolean upsert;
+        if (upsertValue == null) {
+            upsert = false;
+        } else if (!upsertValue.isBoolean()) {
+            return CommandErrors.typeMismatch("upsert must be a boolean");
+        } else {
+            upsert = upsertValue.asBoolean().getValue();
+        }
+
+        final BsonValue arrayFiltersValue = command.get("arrayFilters");
+        if (arrayFiltersValue != null) {
+            if (!arrayFiltersValue.isArray()) {
+                return CommandErrors.typeMismatch("arrayFilters must be an array");
+            }
+            return CommandErrors.badValue("arrayFilters is not supported yet");
+        }
+
+        final ParsedReturnDocument parsedReturnDocument = parseReturnDocument(command);
+        if (parsedReturnDocument.error() != null) {
+            return parsedReturnDocument.error();
+        }
+
+        final BsonDocument translatedFindAndModify = new BsonDocument()
+                .append("findAndModify", new BsonString(collection))
+                .append("$db", new BsonString(database))
+                .append("query", filter)
+                .append("update", update)
+                .append("remove", BsonBoolean.FALSE)
+                .append("new", BsonBoolean.valueOf(parsedReturnDocument.returnNew()))
+                .append("upsert", BsonBoolean.valueOf(upsert));
+        if (sort != null) {
+            translatedFindAndModify.append("sort", sort);
+        }
+
+        appendIfPresent(command, translatedFindAndModify, "hint");
+        appendIfPresent(command, translatedFindAndModify, "collation");
+
+        return findAndModifyCommandHandler.handle(translatedFindAndModify);
+    }
+
+    private static BsonDocument validateOperatorUpdateDocument(final BsonDocument update) {
+        if (update.isEmpty()) {
+            return CommandErrors.badValue("update must not be empty");
+        }
+
+        if (!update.getFirstKey().startsWith("$")) {
+            return CommandErrors.badValue("update document must contain update operators");
+        }
+        for (final String key : update.keySet()) {
+            if (!key.startsWith("$")) {
+                return CommandErrors.badValue("update document must contain update operators");
+            }
+        }
+
+        for (final String key : update.keySet()) {
+            if (!SUPPORTED_OPERATORS.contains(key)) {
+                return CommandErrors.badValue("unsupported update operator: " + key);
+            }
+        }
+
+        final BsonValue setValue = update.get("$set");
+        if (setValue != null && !setValue.isDocument()) {
+            return CommandErrors.typeMismatch("$set must be a document");
+        }
+        BsonDocument pathValidationError = validateUnsupportedPositionalPaths(setValue);
+        if (pathValidationError != null) {
+            return pathValidationError;
+        }
+
+        final BsonValue incValue = update.get("$inc");
+        if (incValue != null && !incValue.isDocument()) {
+            return CommandErrors.typeMismatch("$inc must be a document");
+        }
+        pathValidationError = validateUnsupportedPositionalPaths(incValue);
+        if (pathValidationError != null) {
+            return pathValidationError;
+        }
+
+        final BsonValue unsetValue = update.get("$unset");
+        if (unsetValue != null && !unsetValue.isDocument()) {
+            return CommandErrors.typeMismatch("$unset must be a document");
+        }
+        pathValidationError = validateUnsupportedPositionalPaths(unsetValue);
+        if (pathValidationError != null) {
+            return pathValidationError;
+        }
+
+        final BsonValue addToSetValue = update.get("$addToSet");
+        if (addToSetValue != null && !addToSetValue.isDocument()) {
+            return CommandErrors.typeMismatch("$addToSet must be a document");
+        }
+        pathValidationError = validateUnsupportedPositionalPaths(addToSetValue);
+        if (pathValidationError != null) {
+            return pathValidationError;
+        }
+
+        return null;
+    }
+
+    private static BsonDocument validateUnsupportedPositionalPaths(final BsonValue operatorDefinition) {
+        if (operatorDefinition == null) {
+            return null;
+        }
+
+        for (final String path : operatorDefinition.asDocument().keySet()) {
+            if (isUnsupportedPositionalPath(path)) {
+                return CommandErrors.badValue(
+                        "positional and array filter updates are not supported for path '" + path + "'");
+            }
+        }
+        return null;
+    }
+
+    private static boolean isUnsupportedPositionalPath(final String path) {
+        final String[] segments = path.split("\\.");
+        for (final String segment : segments) {
+            if ("$".equals(segment) || "$[]".equals(segment)) {
+                return true;
+            }
+            if (segment.startsWith("$[") && segment.endsWith("]")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static ParsedReturnDocument parseReturnDocument(final BsonDocument command) {
+        final BsonValue returnDocumentValue = command.get("returnDocument");
+        if (returnDocumentValue == null) {
+            final BsonValue newValue = command.get("new");
+            if (newValue == null) {
+                return new ParsedReturnDocument(false, null);
+            }
+            if (!newValue.isBoolean()) {
+                return new ParsedReturnDocument(false, CommandErrors.typeMismatch("new must be a boolean"));
+            }
+            return new ParsedReturnDocument(newValue.asBoolean().getValue(), null);
+        }
+
+        if (!returnDocumentValue.isString()) {
+            return new ParsedReturnDocument(false, CommandErrors.typeMismatch("returnDocument must be a string"));
+        }
+
+        final String value = returnDocumentValue.asString().getValue();
+        if ("before".equals(value)) {
+            return new ParsedReturnDocument(false, null);
+        }
+        if ("after".equals(value)) {
+            return new ParsedReturnDocument(true, null);
+        }
+        return new ParsedReturnDocument(false, CommandErrors.badValue("returnDocument must be 'before' or 'after'"));
+    }
+
+    private static void appendIfPresent(final BsonDocument source, final BsonDocument target, final String key) {
+        if (!source.containsKey(key)) {
+            return;
+        }
+        target.append(key, source.get(key));
+    }
+
+    private static String readDatabase(final BsonDocument command) {
+        final BsonValue value = command.get("$db");
+        if (value == null || !value.isString()) {
+            return "test";
+        }
+        return value.asString().getValue();
+    }
+
+    private static String readCollection(final BsonDocument command) {
+        final BsonValue canonical = command.get("findOneAndUpdate");
+        if (canonical != null) {
+            if (canonical.isString()) {
+                return canonical.asString().getValue();
+            }
+            return null;
+        }
+
+        for (final String key : command.keySet()) {
+            if (!"findoneandupdate".equalsIgnoreCase(key)) {
+                continue;
+            }
+            final BsonValue value = command.get(key);
+            if (value != null && value.isString()) {
+                return value.asString().getValue();
+            }
+            return null;
+        }
+        return null;
+    }
+
+    private static BsonDocument readRequiredDocument(final BsonDocument command, final String key) {
+        final BsonValue value = command.get(key);
+        if (value == null || !value.isDocument()) {
+            return null;
+        }
+        return value.asDocument();
+    }
+
+    private record ParsedReturnDocument(boolean returnNew, BsonDocument error) {}
+}

--- a/src/main/java/org/jongodb/command/ReplaceOneCommandHandler.java
+++ b/src/main/java/org/jongodb/command/ReplaceOneCommandHandler.java
@@ -1,0 +1,140 @@
+package org.jongodb.command;
+
+import java.util.List;
+import org.bson.BsonArray;
+import org.bson.BsonBoolean;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+
+public final class ReplaceOneCommandHandler implements CommandHandler {
+    private final UpdateCommandHandler updateCommandHandler;
+
+    public ReplaceOneCommandHandler(final CommandStore store) {
+        this.updateCommandHandler = new UpdateCommandHandler(store);
+    }
+
+    @Override
+    public BsonDocument handle(final BsonDocument command) {
+        final String database = readDatabase(command);
+        final String collection = readCollection(command);
+        if (collection == null) {
+            return CommandErrors.typeMismatch("replaceOne must be a string");
+        }
+
+        BsonDocument optionError = CrudCommandOptionValidator.validateWriteConcern(command);
+        if (optionError != null) {
+            return optionError;
+        }
+        optionError = CrudCommandOptionValidator.validateReadConcern(command);
+        if (optionError != null) {
+            return optionError;
+        }
+        optionError = CrudCommandOptionValidator.validateHint(command, "hint");
+        if (optionError != null) {
+            return optionError;
+        }
+        optionError = CrudCommandOptionValidator.validateCollation(command, "collation");
+        if (optionError != null) {
+            return optionError;
+        }
+
+        final BsonDocument filter = readRequiredDocument(command, "filter");
+        if (filter == null) {
+            return CommandErrors.typeMismatch("filter must be a document");
+        }
+
+        final BsonDocument replacement = readRequiredDocument(command, "replacement");
+        if (replacement == null) {
+            return CommandErrors.typeMismatch("replacement must be a document");
+        }
+        if (replacement.isEmpty()) {
+            return CommandErrors.badValue("replacement must not be empty");
+        }
+        if (containsTopLevelOperator(replacement)) {
+            return CommandErrors.badValue("replacement document must not contain update operators");
+        }
+
+        final BsonValue upsertValue = command.get("upsert");
+        final boolean upsert;
+        if (upsertValue == null) {
+            upsert = false;
+        } else if (!upsertValue.isBoolean()) {
+            return CommandErrors.typeMismatch("upsert must be a boolean");
+        } else {
+            upsert = upsertValue.asBoolean().getValue();
+        }
+
+        final BsonDocument updateSpec = new BsonDocument()
+                .append("q", filter)
+                .append("u", replacement)
+                .append("multi", BsonBoolean.FALSE)
+                .append("upsert", BsonBoolean.valueOf(upsert));
+        appendIfPresent(command, updateSpec, "hint");
+        appendIfPresent(command, updateSpec, "collation");
+
+        final BsonDocument translatedUpdateCommand = new BsonDocument()
+                .append("update", new BsonString(collection))
+                .append("$db", new BsonString(database))
+                .append("updates", new BsonArray(List.of(updateSpec)));
+        appendIfPresent(command, translatedUpdateCommand, "ordered");
+        appendIfPresent(command, translatedUpdateCommand, "writeConcern");
+        appendIfPresent(command, translatedUpdateCommand, "readConcern");
+
+        return updateCommandHandler.handle(translatedUpdateCommand);
+    }
+
+    private static boolean containsTopLevelOperator(final BsonDocument document) {
+        for (final String key : document.keySet()) {
+            if (key.startsWith("$")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void appendIfPresent(final BsonDocument source, final BsonDocument target, final String key) {
+        if (!source.containsKey(key)) {
+            return;
+        }
+        target.append(key, source.get(key));
+    }
+
+    private static String readDatabase(final BsonDocument command) {
+        final BsonValue value = command.get("$db");
+        if (value == null || !value.isString()) {
+            return "test";
+        }
+        return value.asString().getValue();
+    }
+
+    private static String readCollection(final BsonDocument command) {
+        final BsonValue canonical = command.get("replaceOne");
+        if (canonical != null) {
+            if (canonical.isString()) {
+                return canonical.asString().getValue();
+            }
+            return null;
+        }
+
+        for (final String key : command.keySet()) {
+            if (!"replaceone".equalsIgnoreCase(key)) {
+                continue;
+            }
+            final BsonValue value = command.get(key);
+            if (value != null && value.isString()) {
+                return value.asString().getValue();
+            }
+            return null;
+        }
+        return null;
+    }
+
+    private static BsonDocument readRequiredDocument(final BsonDocument command, final String key) {
+        final BsonValue value = command.get(key);
+        if (value == null || !value.isDocument()) {
+            return null;
+        }
+        return value.asDocument();
+    }
+}

--- a/src/main/java/org/jongodb/txn/TransactionCommandValidator.java
+++ b/src/main/java/org/jongodb/txn/TransactionCommandValidator.java
@@ -19,7 +19,18 @@ public final class TransactionCommandValidator {
     private static final String LABEL_TRANSIENT_TRANSACTION_ERROR = "TransientTransactionError";
     private static final String LABEL_UNKNOWN_TRANSACTION_COMMIT_RESULT = "UnknownTransactionCommitResult";
     private static final Set<String> TRANSACTIONAL_COMMANDS =
-            Set.of("insert", "update", "delete", "find", "committransaction", "aborttransaction");
+            Set.of(
+                    "insert",
+                    "update",
+                    "delete",
+                    "find",
+                    "findandmodify",
+                    "countdocuments",
+                    "replaceone",
+                    "findoneandupdate",
+                    "findoneandreplace",
+                    "committransaction",
+                    "aborttransaction");
 
     private final SessionTransactionPool sessionPool;
 


### PR DESCRIPTION
## Summary
- add command handlers for:
  - `countDocuments`
  - `replaceOne`
  - `findOneAndUpdate`
  - `findOneAndReplace`
- wire new handlers in `CommandDispatcher`
- extend compatibility matrix for the new command paths
- expand command E2E coverage for payload shape validation, return mode semantics, and unsupported-query error contracts

## Review Findings And Fixes
- **Found during maintainer review (fixed in this PR):** new CRUD commands were not in the transactional command whitelist.
  - Risk: transaction envelope/routing could be bypassed.
  - Fix: include `countdocuments`, `replaceone`, `findoneandupdate`, `findoneandreplace`, `findandmodify` in `TransactionCommandValidator.TRANSACTIONAL_COMMANDS`.
  - Added regression tests in `CommandDispatcherE2ETest` for transaction visibility/commit with the new command paths.

## Remaining Non-blocking Gap
- projection semantics for `findOneAndUpdate`/`findOneAndReplace` remain partial.
- tracked separately in #85.

## Verification
- `/Users/hckim/.local/gradle-8.10.2/bin/gradle --no-daemon test --tests "org.jongodb.command.*"`
- `/Users/hckim/.local/gradle-8.10.2/bin/gradle --no-daemon test --tests "org.jongodb.command.CommandDispatcherE2ETest"`

Closes #83
Related: #85
