### PR TITLE
feat(command): add ordered bulkWrite core subset

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -26,6 +26,7 @@ Certification context:
 | `listIndexes` | Partial | Metadata round-trip |
 | `update` | Partial | Operator set intentionally limited |
 | `delete` | Supported | `limit` 0/1 behavior |
+| `bulkWrite` | Partial | Ordered mode only (`ordered=true`); supports `insertOne/updateOne/updateMany/deleteOne/deleteMany/replaceOne` and stops on first write error |
 | `countDocuments` | Partial | Filter + skip/limit + hint/collation/readConcern shape validation |
 | `replaceOne` | Partial | Rewrites to single replacement `update` path (`multi=false`) |
 | `findOneAndUpdate` | Partial | Rewrites to `findAndModify`; operator updates only |
@@ -82,6 +83,7 @@ Supported:
 - operator updates: `$set`, `$inc`, `$unset`
 - replacement updates (with `multi=false`)
 - upsert for operator and replacement forms
+- same update constraints apply to `bulkWrite` update/replace operations
 
 Not supported:
 - `arrayFilters`
@@ -96,6 +98,7 @@ The R3 failure-ledger runner currently treats the following UTF cases as unsuppo
 differential parity counts:
 
 - unordered `insertMany` (`ordered=false`)
+- unordered `bulkWrite` (`ordered=false`)
 - documents containing dot or dollar-prefixed field paths in insert payloads
 - update operations using `arrayFilters`
 - update pipeline form (`u` as an array pipeline)

--- a/src/main/java/org/jongodb/command/BulkWriteCommandHandler.java
+++ b/src/main/java/org/jongodb/command/BulkWriteCommandHandler.java
@@ -1,0 +1,397 @@
+package org.jongodb.command;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import org.bson.BsonArray;
+import org.bson.BsonBoolean;
+import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.BsonInt32;
+import org.bson.BsonNumber;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+
+public final class BulkWriteCommandHandler implements CommandHandler {
+    private static final Set<String> SUPPORTED_OPERATIONS =
+            Set.of("insertone", "updateone", "updatemany", "deleteone", "deletemany", "replaceone");
+
+    private final InsertCommandHandler insertCommandHandler;
+    private final UpdateCommandHandler updateCommandHandler;
+    private final DeleteCommandHandler deleteCommandHandler;
+    private final ReplaceOneCommandHandler replaceOneCommandHandler;
+
+    public BulkWriteCommandHandler(final CommandStore store) {
+        this.insertCommandHandler = new InsertCommandHandler(store);
+        this.updateCommandHandler = new UpdateCommandHandler(store);
+        this.deleteCommandHandler = new DeleteCommandHandler(store);
+        this.replaceOneCommandHandler = new ReplaceOneCommandHandler(store);
+    }
+
+    @Override
+    public BsonDocument handle(final BsonDocument command) {
+        final String database = readDatabase(command);
+        final String collection = readCollection(command);
+        if (collection == null) {
+            return CommandErrors.typeMismatch("bulkWrite must be a string");
+        }
+
+        BsonDocument optionError = CrudCommandOptionValidator.validateOrdered(command);
+        if (optionError != null) {
+            return optionError;
+        }
+        optionError = CrudCommandOptionValidator.validateWriteConcern(command);
+        if (optionError != null) {
+            return optionError;
+        }
+        optionError = CrudCommandOptionValidator.validateReadConcern(command);
+        if (optionError != null) {
+            return optionError;
+        }
+
+        final boolean ordered = !command.containsKey("ordered")
+                || command.getBoolean("ordered").getValue();
+        if (!ordered) {
+            return CommandErrors.badValue("bulkWrite currently supports ordered=true only");
+        }
+
+        final ParsedOperations parsedOperations = parseOperations(command);
+        if (parsedOperations.error() != null) {
+            return parsedOperations.error();
+        }
+
+        int insertedCount = 0;
+        int matchedCount = 0;
+        int modifiedCount = 0;
+        int deletedCount = 0;
+        int upsertedCount = 0;
+        final BsonArray upserted = new BsonArray();
+        final BsonArray writeErrors = new BsonArray();
+
+        for (final OperationEntry operation : parsedOperations.operations()) {
+            final BsonDocument response = executeOperation(operation, database, collection);
+            if (!isSuccessful(response)) {
+                writeErrors.add(writeError(operation.index(), response));
+                break;
+            }
+
+            final OperationCounts operationCounts = countsForOperation(operation.name(), operation.index(), response);
+            insertedCount += operationCounts.insertedCount();
+            matchedCount += operationCounts.matchedCount();
+            modifiedCount += operationCounts.modifiedCount();
+            deletedCount += operationCounts.deletedCount();
+            upsertedCount += operationCounts.upsertedCount();
+            for (final BsonDocument upsertedDocument : operationCounts.upsertedEntries()) {
+                upserted.add(upsertedDocument);
+            }
+        }
+
+        final BsonDocument result = new BsonDocument()
+                .append("nInserted", new BsonInt32(insertedCount))
+                .append("nMatched", new BsonInt32(matchedCount))
+                .append("nModified", new BsonInt32(modifiedCount))
+                .append("nDeleted", new BsonInt32(deletedCount))
+                .append("nUpserted", new BsonInt32(upsertedCount));
+        if (!upserted.isEmpty()) {
+            result.append("upserted", upserted);
+        }
+        if (!writeErrors.isEmpty()) {
+            result.append("writeErrors", writeErrors);
+        }
+        return result.append("ok", new BsonDouble(1.0));
+    }
+
+    private BsonDocument executeOperation(final OperationEntry operation, final String database, final String collection) {
+        return switch (operation.name()) {
+            case "insertone" -> executeInsertOne(operation.specification(), database, collection);
+            case "updateone" -> executeUpdate(operation.specification(), database, collection, false);
+            case "updatemany" -> executeUpdate(operation.specification(), database, collection, true);
+            case "deleteone" -> executeDelete(operation.specification(), database, collection, 1);
+            case "deletemany" -> executeDelete(operation.specification(), database, collection, 0);
+            case "replaceone" -> executeReplaceOne(operation.specification(), database, collection);
+            default -> CommandErrors.badValue("unsupported bulkWrite operation: " + operation.name());
+        };
+    }
+
+    private BsonDocument executeInsertOne(
+            final BsonDocument operation,
+            final String database,
+            final String collection) {
+        final BsonDocument document = readRequiredDocument(operation, "document");
+        if (document == null) {
+            return CommandErrors.typeMismatch("document must be a document");
+        }
+
+        final BsonDocument translatedCommand = new BsonDocument()
+                .append("insert", new BsonString(collection))
+                .append("$db", new BsonString(database))
+                .append("documents", new BsonArray(List.of(document)));
+        return insertCommandHandler.handle(translatedCommand);
+    }
+
+    private BsonDocument executeUpdate(
+            final BsonDocument operation,
+            final String database,
+            final String collection,
+            final boolean multi) {
+        final BsonDocument filter = readRequiredDocument(operation, "filter");
+        if (filter == null) {
+            return CommandErrors.typeMismatch("filter must be a document");
+        }
+
+        final BsonValue updateValue = operation.get("update");
+        if (updateValue == null) {
+            return CommandErrors.typeMismatch("update must be a document");
+        }
+        if (updateValue.isArray()) {
+            return CommandErrors.badValue("update pipeline is not supported yet");
+        }
+        if (!updateValue.isDocument()) {
+            return CommandErrors.typeMismatch("update must be a document");
+        }
+
+        final BsonValue upsertValue = operation.get("upsert");
+        final boolean upsert;
+        if (upsertValue == null) {
+            upsert = false;
+        } else if (!upsertValue.isBoolean()) {
+            return CommandErrors.typeMismatch("upsert must be a boolean");
+        } else {
+            upsert = upsertValue.asBoolean().getValue();
+        }
+
+        final BsonDocument updateSpec = new BsonDocument()
+                .append("q", filter)
+                .append("u", updateValue.asDocument())
+                .append("multi", BsonBoolean.valueOf(multi))
+                .append("upsert", BsonBoolean.valueOf(upsert));
+        appendIfPresent(operation, updateSpec, "hint");
+        appendIfPresent(operation, updateSpec, "collation");
+        appendIfPresent(operation, updateSpec, "arrayFilters");
+
+        final BsonDocument translatedCommand = new BsonDocument()
+                .append("update", new BsonString(collection))
+                .append("$db", new BsonString(database))
+                .append("updates", new BsonArray(List.of(updateSpec)));
+        return updateCommandHandler.handle(translatedCommand);
+    }
+
+    private BsonDocument executeDelete(
+            final BsonDocument operation,
+            final String database,
+            final String collection,
+            final int limit) {
+        final BsonDocument filter = readRequiredDocument(operation, "filter");
+        if (filter == null) {
+            return CommandErrors.typeMismatch("filter must be a document");
+        }
+
+        final BsonDocument deleteSpec = new BsonDocument()
+                .append("q", filter)
+                .append("limit", new BsonInt32(limit));
+        appendIfPresent(operation, deleteSpec, "hint");
+        appendIfPresent(operation, deleteSpec, "collation");
+
+        final BsonDocument translatedCommand = new BsonDocument()
+                .append("delete", new BsonString(collection))
+                .append("$db", new BsonString(database))
+                .append("deletes", new BsonArray(List.of(deleteSpec)));
+        return deleteCommandHandler.handle(translatedCommand);
+    }
+
+    private BsonDocument executeReplaceOne(
+            final BsonDocument operation,
+            final String database,
+            final String collection) {
+        final BsonDocument translatedCommand = new BsonDocument()
+                .append("replaceOne", new BsonString(collection))
+                .append("$db", new BsonString(database));
+        appendIfPresent(operation, translatedCommand, "filter");
+        appendIfPresent(operation, translatedCommand, "replacement");
+        appendIfPresent(operation, translatedCommand, "upsert");
+        appendIfPresent(operation, translatedCommand, "hint");
+        appendIfPresent(operation, translatedCommand, "collation");
+        return replaceOneCommandHandler.handle(translatedCommand);
+    }
+
+    private static OperationCounts countsForOperation(
+            final String operationName,
+            final int operationIndex,
+            final BsonDocument response) {
+        return switch (operationName) {
+            case "insertone" -> new OperationCounts(readCount(response, "n"), 0, 0, 0, 0, List.of());
+            case "deleteone", "deletemany" -> new OperationCounts(0, 0, 0, readCount(response, "n"), 0, List.of());
+            case "updateone", "updatemany", "replaceone" -> updateCounts(operationIndex, response);
+            default -> new OperationCounts(0, 0, 0, 0, 0, List.of());
+        };
+    }
+
+    private static OperationCounts updateCounts(final int operationIndex, final BsonDocument response) {
+        final int n = readCount(response, "n");
+        final int nModified = readCount(response, "nModified");
+        final BsonArray upsertedArray =
+                response.containsKey("upserted") && response.get("upserted").isArray()
+                        ? response.getArray("upserted")
+                        : new BsonArray();
+        final int upsertedCount = upsertedArray.size();
+        final int matchedCount = Math.max(0, n - upsertedCount);
+
+        final List<BsonDocument> mappedUpserts = new ArrayList<>(upsertedCount);
+        for (final BsonValue upsertedValue : upsertedArray) {
+            if (!upsertedValue.isDocument()) {
+                continue;
+            }
+            final BsonValue idValue = upsertedValue.asDocument().get("_id");
+            if (idValue == null) {
+                continue;
+            }
+            mappedUpserts.add(new BsonDocument()
+                    .append("index", new BsonInt32(operationIndex))
+                    .append("_id", idValue));
+        }
+
+        return new OperationCounts(0, matchedCount, nModified, 0, mappedUpserts.size(), List.copyOf(mappedUpserts));
+    }
+
+    private static ParsedOperations parseOperations(final BsonDocument command) {
+        final BsonValue operationsValue = command.get("operations");
+        final BsonValue requestsValue = command.get("requests");
+        if (operationsValue != null && requestsValue != null) {
+            return ParsedOperations.error(CommandErrors.badValue("operations and requests cannot both be specified"));
+        }
+
+        final BsonValue effectiveOperationsValue = operationsValue == null ? requestsValue : operationsValue;
+        if (effectiveOperationsValue == null || !effectiveOperationsValue.isArray()) {
+            return ParsedOperations.error(CommandErrors.typeMismatch("operations must be an array"));
+        }
+
+        final BsonArray operationsArray = effectiveOperationsValue.asArray();
+        if (operationsArray.isEmpty()) {
+            return ParsedOperations.error(CommandErrors.badValue("operations must not be empty"));
+        }
+
+        final List<OperationEntry> operations = new ArrayList<>(operationsArray.size());
+        for (int index = 0; index < operationsArray.size(); index++) {
+            final BsonValue operationValue = operationsArray.get(index);
+            if (!operationValue.isDocument()) {
+                return ParsedOperations.error(
+                        CommandErrors.typeMismatch("all entries in operations must be BSON documents"));
+            }
+
+            final BsonDocument operationDocument = operationValue.asDocument();
+            if (operationDocument.size() != 1) {
+                return ParsedOperations.error(
+                        CommandErrors.badValue("each bulkWrite operation must contain exactly one operation"));
+            }
+
+            final String operationName = operationDocument.getFirstKey();
+            final String normalizedOperationName = operationName.toLowerCase(Locale.ROOT);
+            if (!SUPPORTED_OPERATIONS.contains(normalizedOperationName)) {
+                return ParsedOperations.error(CommandErrors.badValue("unsupported bulkWrite operation: " + operationName));
+            }
+
+            final BsonValue specificationValue = operationDocument.get(operationName);
+            if (specificationValue == null || !specificationValue.isDocument()) {
+                return ParsedOperations.error(CommandErrors.typeMismatch(operationName + " must be a document"));
+            }
+            operations.add(new OperationEntry(index, normalizedOperationName, specificationValue.asDocument()));
+        }
+        return new ParsedOperations(List.copyOf(operations), null);
+    }
+
+    private static BsonDocument writeError(final int index, final BsonDocument response) {
+        final BsonDocument writeError = new BsonDocument()
+                .append("index", new BsonInt32(index));
+
+        final BsonValue code = response.get("code");
+        if (code instanceof BsonNumber numberValue) {
+            writeError.append("code", new BsonInt32(numberValue.intValue()));
+        }
+        final BsonValue codeName = response.get("codeName");
+        if (codeName != null && codeName.isString()) {
+            writeError.append("codeName", codeName.asString());
+        }
+        final BsonValue message = response.get("errmsg");
+        if (message != null && message.isString()) {
+            writeError.append("errmsg", message.asString());
+        }
+        return writeError;
+    }
+
+    private static int readCount(final BsonDocument response, final String fieldName) {
+        final BsonValue value = response.get(fieldName);
+        if (!(value instanceof BsonNumber numberValue)) {
+            return 0;
+        }
+        return numberValue.intValue();
+    }
+
+    private static boolean isSuccessful(final BsonDocument response) {
+        final BsonValue okValue = response.get("ok");
+        return okValue != null
+                && okValue.isNumber()
+                && okValue.asNumber().doubleValue() == 1.0d;
+    }
+
+    private static void appendIfPresent(final BsonDocument source, final BsonDocument target, final String key) {
+        if (!source.containsKey(key)) {
+            return;
+        }
+        target.append(key, source.get(key));
+    }
+
+    private static BsonDocument readRequiredDocument(final BsonDocument command, final String key) {
+        final BsonValue value = command.get(key);
+        if (value == null || !value.isDocument()) {
+            return null;
+        }
+        return value.asDocument();
+    }
+
+    private static String readDatabase(final BsonDocument command) {
+        final BsonValue value = command.get("$db");
+        if (value == null || !value.isString()) {
+            return "test";
+        }
+        return value.asString().getValue();
+    }
+
+    private static String readCollection(final BsonDocument command) {
+        final BsonValue canonical = command.get("bulkWrite");
+        if (canonical != null) {
+            if (canonical.isString()) {
+                return canonical.asString().getValue();
+            }
+            return null;
+        }
+
+        for (final String key : command.keySet()) {
+            if (!"bulkwrite".equalsIgnoreCase(key)) {
+                continue;
+            }
+            final BsonValue value = command.get(key);
+            if (value != null && value.isString()) {
+                return value.asString().getValue();
+            }
+            return null;
+        }
+        return null;
+    }
+
+    private record ParsedOperations(List<OperationEntry> operations, BsonDocument error) {
+        private static ParsedOperations error(final BsonDocument error) {
+            return new ParsedOperations(List.of(), error);
+        }
+    }
+
+    private record OperationEntry(int index, String name, BsonDocument specification) {}
+
+    private record OperationCounts(
+            int insertedCount,
+            int matchedCount,
+            int modifiedCount,
+            int deletedCount,
+            int upsertedCount,
+            List<BsonDocument> upsertedEntries) {}
+}

--- a/src/main/java/org/jongodb/command/CommandDispatcher.java
+++ b/src/main/java/org/jongodb/command/CommandDispatcher.java
@@ -42,6 +42,7 @@ public final class CommandDispatcher {
         configuredHandlers.put("listindexes", new ListIndexesCommandHandler(routedStore, cursorRegistry));
         configuredHandlers.put("update", new UpdateCommandHandler(routedStore));
         configuredHandlers.put("delete", new DeleteCommandHandler(routedStore));
+        configuredHandlers.put("bulkwrite", new BulkWriteCommandHandler(routedStore));
         configuredHandlers.put("findandmodify", new FindAndModifyCommandHandler(routedStore));
         configuredHandlers.put("countdocuments", new CountDocumentsCommandHandler(routedStore));
         configuredHandlers.put("replaceone", new ReplaceOneCommandHandler(routedStore));

--- a/src/main/java/org/jongodb/txn/TransactionCommandValidator.java
+++ b/src/main/java/org/jongodb/txn/TransactionCommandValidator.java
@@ -23,6 +23,7 @@ public final class TransactionCommandValidator {
                     "insert",
                     "update",
                     "delete",
+                    "bulkwrite",
                     "find",
                     "findandmodify",
                     "countdocuments",

--- a/src/test/java/org/jongodb/command/BulkWriteCommandE2ETest.java
+++ b/src/test/java/org/jongodb/command/BulkWriteCommandE2ETest.java
@@ -1,0 +1,255 @@
+package org.jongodb.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.bson.BsonDocument;
+import org.jongodb.engine.InMemoryEngineStore;
+import org.junit.jupiter.api.Test;
+
+class BulkWriteCommandE2ETest {
+    @Test
+    void bulkWriteCommandSupportsOrderedSubsetAndReturnsDeterministicCounters() {
+        final CommandDispatcher dispatcher = new CommandDispatcher(new EngineBackedCommandStore(new InMemoryEngineStore()));
+
+        final BsonDocument response = dispatcher.dispatch(BsonDocument.parse(
+                """
+                {
+                  "bulkWrite": "users",
+                  "$db": "app",
+                  "ordered": true,
+                  "operations": [
+                    {"insertOne": {"document": {"_id": 1, "name": "alpha"}}},
+                    {"updateOne": {"filter": {"_id": 1}, "update": {"$set": {"tier": 1}}}},
+                    {"updateMany": {"filter": {"tier": 1}, "update": {"$set": {"active": true}}}},
+                    {"replaceOne": {"filter": {"_id": 2}, "replacement": {"name": "beta"}, "upsert": true}},
+                    {"deleteOne": {"filter": {"_id": 1}}},
+                    {"deleteMany": {"filter": {"name": "beta"}}}
+                  ]
+                }
+                """));
+
+        assertEquals(1.0, response.get("ok").asNumber().doubleValue());
+        assertEquals(1, response.getInt32("nInserted").getValue());
+        assertEquals(2, response.getInt32("nMatched").getValue());
+        assertEquals(2, response.getInt32("nModified").getValue());
+        assertEquals(2, response.getInt32("nDeleted").getValue());
+        assertEquals(1, response.getInt32("nUpserted").getValue());
+        assertEquals(1, response.getArray("upserted").size());
+        assertEquals(
+                3,
+                response.getArray("upserted").get(0).asDocument().getInt32("index").getValue());
+        assertEquals(
+                2,
+                response.getArray("upserted").get(0).asDocument().getInt32("_id").getValue());
+        assertEquals(
+                List.of("nInserted", "nMatched", "nModified", "nDeleted", "nUpserted", "upserted", "ok"),
+                new ArrayList<>(response.keySet()));
+
+        final BsonDocument finalState =
+                dispatcher.dispatch(BsonDocument.parse("{\"find\":\"users\",\"$db\":\"app\",\"filter\":{}}"));
+        assertEquals(0, finalState.getDocument("cursor").getArray("firstBatch").size());
+    }
+
+    @Test
+    void bulkWriteCommandStopsAtFirstWriteErrorWhenOrdered() {
+        final CommandDispatcher dispatcher = new CommandDispatcher(new EngineBackedCommandStore(new InMemoryEngineStore()));
+
+        final BsonDocument createIndexResponse = dispatcher.dispatch(BsonDocument.parse(
+                "{\"createIndexes\":\"users\",\"$db\":\"app\",\"indexes\":[{\"name\":\"email_1\",\"key\":{\"email\":1},\"unique\":true}]}"));
+        assertEquals(1.0, createIndexResponse.get("ok").asNumber().doubleValue());
+
+        final BsonDocument response = dispatcher.dispatch(BsonDocument.parse(
+                """
+                {
+                  "bulkWrite": "users",
+                  "$db": "app",
+                  "ordered": true,
+                  "operations": [
+                    {"insertOne": {"document": {"_id": 1, "email": "ada@example.com"}}},
+                    {"insertOne": {"document": {"_id": 2, "email": "ada@example.com"}}},
+                    {"insertOne": {"document": {"_id": 3, "email": "linus@example.com"}}}
+                  ]
+                }
+                """));
+
+        assertEquals(1.0, response.get("ok").asNumber().doubleValue());
+        assertEquals(1, response.getInt32("nInserted").getValue());
+        assertEquals(0, response.getInt32("nMatched").getValue());
+        assertEquals(0, response.getInt32("nModified").getValue());
+        assertEquals(0, response.getInt32("nDeleted").getValue());
+        assertEquals(0, response.getInt32("nUpserted").getValue());
+        assertEquals(1, response.getArray("writeErrors").size());
+        assertEquals(
+                1,
+                response.getArray("writeErrors")
+                        .get(0)
+                        .asDocument()
+                        .getInt32("index")
+                        .getValue());
+        assertEquals(
+                11000,
+                response.getArray("writeErrors")
+                        .get(0)
+                        .asDocument()
+                        .getInt32("code")
+                        .getValue());
+        assertEquals(
+                "DuplicateKey",
+                response.getArray("writeErrors")
+                        .get(0)
+                        .asDocument()
+                        .getString("codeName")
+                        .getValue());
+        assertNotNull(response.getArray("writeErrors").get(0).asDocument().getString("errmsg"));
+        assertEquals(
+                List.of("nInserted", "nMatched", "nModified", "nDeleted", "nUpserted", "writeErrors", "ok"),
+                new ArrayList<>(response.keySet()));
+
+        final BsonDocument finalState =
+                dispatcher.dispatch(BsonDocument.parse("{\"find\":\"users\",\"$db\":\"app\",\"filter\":{}}"));
+        assertEquals(1, finalState.getDocument("cursor").getArray("firstBatch").size());
+        assertEquals(
+                1,
+                finalState.getDocument("cursor")
+                        .getArray("firstBatch")
+                        .get(0)
+                        .asDocument()
+                        .getInt32("_id")
+                        .getValue());
+    }
+
+    @Test
+    void bulkWriteCommandRejectsOrderedFalse() {
+        final CommandDispatcher dispatcher = new CommandDispatcher(new EngineBackedCommandStore(new InMemoryEngineStore()));
+
+        final BsonDocument response = dispatcher.dispatch(BsonDocument.parse(
+                "{\"bulkWrite\":\"users\",\"$db\":\"app\",\"ordered\":false,\"operations\":[{\"insertOne\":{\"document\":{\"_id\":1}}}]}"));
+
+        assertCommandError(response, "BadValue");
+    }
+
+    @Test
+    void bulkWriteCommandRejectsUnsupportedOperationName() {
+        final CommandDispatcher dispatcher = new CommandDispatcher(new EngineBackedCommandStore(new InMemoryEngineStore()));
+
+        final BsonDocument response = dispatcher.dispatch(BsonDocument.parse(
+                "{\"bulkWrite\":\"users\",\"$db\":\"app\",\"operations\":[{\"renameCollection\":{\"from\":\"users\",\"to\":\"users2\"}}]}"));
+
+        assertCommandError(response, "BadValue");
+    }
+
+    @Test
+    void bulkWriteCommandReportsOperationValidationErrorsInWriteErrorsAndStops() {
+        final CommandDispatcher dispatcher = new CommandDispatcher(new EngineBackedCommandStore(new InMemoryEngineStore()));
+
+        final BsonDocument response = dispatcher.dispatch(BsonDocument.parse(
+                """
+                {
+                  "bulkWrite": "users",
+                  "$db": "app",
+                  "operations": [
+                    {"insertOne": {"document": {"_id": 1}}},
+                    {"updateMany": {"filter": {}, "update": {"$set": {"a": 1}}, "arrayFilters": []}},
+                    {"deleteMany": {"filter": {}}}
+                  ]
+                }
+                """));
+
+        assertEquals(1.0, response.get("ok").asNumber().doubleValue());
+        assertEquals(1, response.getInt32("nInserted").getValue());
+        assertEquals(0, response.getInt32("nMatched").getValue());
+        assertEquals(0, response.getInt32("nModified").getValue());
+        assertEquals(0, response.getInt32("nDeleted").getValue());
+        assertEquals(0, response.getInt32("nUpserted").getValue());
+        assertEquals(1, response.getArray("writeErrors").size());
+        assertEquals(
+                1,
+                response.getArray("writeErrors")
+                        .get(0)
+                        .asDocument()
+                        .getInt32("index")
+                        .getValue());
+        assertEquals(
+                14,
+                response.getArray("writeErrors")
+                        .get(0)
+                        .asDocument()
+                        .getInt32("code")
+                        .getValue());
+        assertEquals(
+                "BadValue",
+                response.getArray("writeErrors")
+                        .get(0)
+                        .asDocument()
+                        .getString("codeName")
+                        .getValue());
+        assertNotNull(response.getArray("writeErrors").get(0).asDocument().getString("errmsg"));
+
+        final BsonDocument finalState =
+                dispatcher.dispatch(BsonDocument.parse("{\"find\":\"users\",\"$db\":\"app\",\"filter\":{}}"));
+        assertEquals(1, finalState.getDocument("cursor").getArray("firstBatch").size());
+        assertEquals(
+                1,
+                finalState.getDocument("cursor")
+                        .getArray("firstBatch")
+                        .get(0)
+                        .asDocument()
+                        .getInt32("_id")
+                        .getValue());
+    }
+
+    @Test
+    void bulkWriteCommandUsesTransactionalSnapshotAndCommit() {
+        final CommandDispatcher dispatcher = new CommandDispatcher(new EngineBackedCommandStore(new InMemoryEngineStore()));
+
+        final BsonDocument transactionalBulkWrite = dispatcher.dispatch(BsonDocument.parse(
+                """
+                {
+                  "bulkWrite": "users",
+                  "$db": "app",
+                  "operations": [{"insertOne": {"document": {"_id": 1, "name": "txn"}}}],
+                  "lsid": {"id": "session-bulk"},
+                  "txnNumber": 1,
+                  "autocommit": false,
+                  "startTransaction": true
+                }
+                """));
+        assertEquals(1.0, transactionalBulkWrite.get("ok").asNumber().doubleValue());
+
+        final BsonDocument outsideBeforeCommit =
+                dispatcher.dispatch(BsonDocument.parse("{\"find\":\"users\",\"$db\":\"app\",\"filter\":{}}"));
+        assertEquals(0, outsideBeforeCommit.getDocument("cursor").getArray("firstBatch").size());
+
+        final BsonDocument insideTransaction = dispatcher.dispatch(BsonDocument.parse(
+                "{\"find\":\"users\",\"$db\":\"app\",\"filter\":{},\"lsid\":{\"id\":\"session-bulk\"},\"txnNumber\":1,\"autocommit\":false}"));
+        assertEquals(1, insideTransaction.getDocument("cursor").getArray("firstBatch").size());
+
+        final BsonDocument commitResponse = dispatcher.dispatch(BsonDocument.parse(
+                "{\"commitTransaction\":1,\"$db\":\"app\",\"lsid\":{\"id\":\"session-bulk\"},\"txnNumber\":1,\"autocommit\":false}"));
+        assertEquals(1.0, commitResponse.get("ok").asNumber().doubleValue());
+
+        final BsonDocument outsideAfterCommit =
+                dispatcher.dispatch(BsonDocument.parse("{\"find\":\"users\",\"$db\":\"app\",\"filter\":{}}"));
+        assertEquals(1, outsideAfterCommit.getDocument("cursor").getArray("firstBatch").size());
+        assertEquals(
+                "txn",
+                outsideAfterCommit
+                        .getDocument("cursor")
+                        .getArray("firstBatch")
+                        .get(0)
+                        .asDocument()
+                        .getString("name")
+                        .getValue());
+    }
+
+    private static void assertCommandError(final BsonDocument response, final String codeName) {
+        assertEquals(0.0, response.get("ok").asNumber().doubleValue());
+        assertEquals(14, response.getInt32("code").getValue());
+        assertEquals(codeName, response.getString("codeName").getValue());
+        assertTrue(response.containsKey("errmsg"));
+    }
+}


### PR DESCRIPTION
## Summary
- add `bulkWrite` command support (ordered subset only)
- supported operations in this slice:
  - `insertOne`
  - `updateOne`
  - `updateMany`
  - `deleteOne`
  - `deleteMany`
  - `replaceOne`
- stop on first write error when `ordered=true`
- return deterministic counters and `writeErrors` payload
- add transaction envelope support for `bulkWrite`
- add UTF importer mapping for `bulkWrite` operation (`ordered=true` path)
- add command E2E tests + importer tests

## Review Findings
- no blocking defects found after maintainer review + rerun
- known non-blocking risk: UTF importer emits a project-specific `bulkWrite` command shape for differential harness use; real mongod parity for every option branch is not fully claimed in this PR

## Verification
- `/Users/hckim/.local/gradle-8.10.2/bin/gradle --no-daemon test --tests "org.jongodb.command.BulkWriteCommandE2ETest" --tests "org.jongodb.testkit.UnifiedSpecImporterTest"`
- `/Users/hckim/.local/gradle-8.10.2/bin/gradle --no-daemon test --tests "org.jongodb.command.*"`

Closes #84
