### PR TITLE
chore(publish): refine Central metadata description

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,7 +56,7 @@ publishing {
                 name.set(providers.gradleProperty("pomName").orElse("jongodb"))
                 description.set(
                     providers.gradleProperty("pomDescription")
-                        .orElse("In-memory MongoDB-compatible command engine for integration testing.")
+                        .orElse("In-memory MongoDB-compatible backend for fast Spring integration tests.")
                 )
                 url.set(providers.gradleProperty("pomUrl").orElse("https://github.com/midagedev/jongodb"))
 

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -1,6 +1,6 @@
 project:
   name: jongodb
-  description: In-memory MongoDB-compatible command engine for integration testing.
+  description: In-memory MongoDB-compatible backend for fast Spring integration tests.
   links:
     homepage: https://github.com/midagedev/jongodb
   authors:


### PR DESCRIPTION
## Summary
- refine POM default description used for Maven Central metadata
- align `jreleaser.yml` project description with the same text

## Why
Improves artifact page copy on Central for clearer Spring integration-test positioning.

Closes #90
