### PR TITLE
feat(command): projection subset for findOneAndUpdate/findOneAndReplace

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -29,8 +29,8 @@ Certification context:
 | `bulkWrite` | Partial | Ordered mode only (`ordered=true`); supports `insertOne/updateOne/updateMany/deleteOne/deleteMany/replaceOne` and stops on first write error |
 | `countDocuments` | Partial | Filter + skip/limit + hint/collation/readConcern shape validation |
 | `replaceOne` | Partial | Rewrites to single replacement `update` path (`multi=false`) |
-| `findOneAndUpdate` | Partial | Rewrites to `findAndModify`; operator updates only |
-| `findOneAndReplace` | Partial | Rewrites to `findAndModify`; replacement updates only |
+| `findOneAndUpdate` | Partial | Rewrites to `findAndModify`; operator updates only; supports projection include/exclude subset (including `_id` override) |
+| `findOneAndReplace` | Partial | Rewrites to `findAndModify`; replacement updates only; supports projection include/exclude subset (including `_id` override) |
 | `commitTransaction`, `abortTransaction` | Supported | Session/txn envelope supported |
 
 ## Query Operators

--- a/src/main/java/org/jongodb/command/FindOneAndReplaceCommandHandler.java
+++ b/src/main/java/org/jongodb/command/FindOneAndReplaceCommandHandler.java
@@ -63,6 +63,16 @@ public final class FindOneAndReplaceCommandHandler implements CommandHandler {
             sort = sortValue.asDocument();
         }
 
+        final BsonValue projectionValue = command.get("projection");
+        final BsonDocument projection;
+        if (projectionValue == null) {
+            projection = null;
+        } else if (!projectionValue.isDocument()) {
+            return CommandErrors.typeMismatch("projection must be a document");
+        } else {
+            projection = projectionValue.asDocument();
+        }
+
         final BsonValue upsertValue = command.get("upsert");
         final boolean upsert;
         if (upsertValue == null) {
@@ -88,6 +98,9 @@ public final class FindOneAndReplaceCommandHandler implements CommandHandler {
                 .append("upsert", BsonBoolean.valueOf(upsert));
         if (sort != null) {
             translatedFindAndModify.append("sort", sort);
+        }
+        if (projection != null) {
+            translatedFindAndModify.append("fields", projection);
         }
 
         appendIfPresent(command, translatedFindAndModify, "hint");

--- a/src/main/java/org/jongodb/command/FindOneAndUpdateCommandHandler.java
+++ b/src/main/java/org/jongodb/command/FindOneAndUpdateCommandHandler.java
@@ -65,6 +65,16 @@ public final class FindOneAndUpdateCommandHandler implements CommandHandler {
             sort = sortValue.asDocument();
         }
 
+        final BsonValue projectionValue = command.get("projection");
+        final BsonDocument projection;
+        if (projectionValue == null) {
+            projection = null;
+        } else if (!projectionValue.isDocument()) {
+            return CommandErrors.typeMismatch("projection must be a document");
+        } else {
+            projection = projectionValue.asDocument();
+        }
+
         final BsonValue upsertValue = command.get("upsert");
         final boolean upsert;
         if (upsertValue == null) {
@@ -98,6 +108,9 @@ public final class FindOneAndUpdateCommandHandler implements CommandHandler {
                 .append("upsert", BsonBoolean.valueOf(upsert));
         if (sort != null) {
             translatedFindAndModify.append("sort", sort);
+        }
+        if (projection != null) {
+            translatedFindAndModify.append("fields", projection);
         }
 
         appendIfPresent(command, translatedFindAndModify, "hint");


### PR DESCRIPTION
## Summary
- add projection subset support for `findOneAndUpdate` and `findOneAndReplace`
- pass projection through wrappers into `findAndModify` path (`fields`)
- implement projection handling in `FindAndModifyCommandHandler` for returned `value`
- support include/exclude subset with `_id` override
- reject mixed include/exclude projection (except `_id`)
- add command E2E coverage for include/exclude nested path behavior and invalid mixed projection
- update compatibility docs

## Review Findings
- no blocking defects found in maintainer review
- known gap: projection path handling is document-focused and does not attempt full array projection parity

## Verification
- `/Users/hckim/.local/gradle-8.10.2/bin/gradle --no-daemon test --tests "org.jongodb.command.CommandDispatcherE2ETest"`
- `/Users/hckim/.local/gradle-8.10.2/bin/gradle --no-daemon test --tests "org.jongodb.command.*"`

Closes #85
