### PR TITLE
ci(node): add npm release workflow draft (#111)

### DIFF
--- a/.github/workflows/npm-node-release.yml
+++ b/.github/workflows/npm-node-release.yml
@@ -20,6 +20,10 @@ permissions:
   contents: read
   id-token: write
 
+concurrency:
+  group: node-release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   verify:
     name: Verify Node package
@@ -72,17 +76,25 @@ jobs:
         id: meta
         shell: bash
         run: |
+          PUBLISH_INPUT="${{ inputs.publish }}"
+
           if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
             VERSION="${GITHUB_REF_NAME#node-v}"
           else
             VERSION="${{ inputs.version }}"
           fi
 
-          if [[ -z "$VERSION" ]]; then
-            echo "No version input provided. Publish job will run in dry-run mode."
-          elif [[ "$VERSION" == *"-SNAPSHOT" ]]; then
+          if [[ "$VERSION" == *"-SNAPSHOT" ]]; then
             echo "Version must not end with -SNAPSHOT: $VERSION"
             exit 1
+          fi
+
+          if [[ -z "$VERSION" ]]; then
+            if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && "$PUBLISH_INPUT" == "true" ]]; then
+              echo "Manual publish requires an explicit version input."
+              exit 1
+            fi
+            echo "No version input provided. Publish job will run in dry-run mode."
           fi
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -37,9 +37,10 @@ Use this when publishing `@jongodb/memory-server`:
 
 1. Confirm `Node Adapter Release` workflow verify job is green.
 2. Confirm package version is set explicitly (tag `node-vX.Y.Z` or manual input).
-3. Run `npm publish --dry-run` and review package contents.
-4. Publish only when `NPM_TOKEN` is configured and verify npm registry visibility.
-5. Update README usage examples with the released package version.
+3. For manual workflow runs, never set `publish=true` with empty `version` (workflow blocks this).
+4. Run `npm publish --dry-run` and review package contents.
+5. Publish only when `NPM_TOKEN` is configured and verify npm registry visibility.
+6. Update README usage examples with the released package version.
 
 ## Release History
 


### PR DESCRIPTION
## Summary
- add Node adapter publish workflow draft (`workflow_dispatch` + `node-v*` tag)
- include verify gate (build/typecheck/test) and publish dry-run path
- add Node adapter release gate section in release checklist

## Notes
- This PR depends on `#107` because the verify job expects workspace package files.
- `npm publish` only executes when `NPM_TOKEN` exists and publish trigger is enabled.

## Issue
Closes #111
Part of #106
Depends on #107
