### PR TITLE
[impl][scorecard][r4] slice 18: distinct hint subset coverage

### DIFF
--- a/src/test/java/org/jongodb/command/CommandDispatcherE2ETest.java
+++ b/src/test/java/org/jongodb/command/CommandDispatcherE2ETest.java
@@ -300,11 +300,13 @@ class CommandDispatcherE2ETest {
                 "{\"distinct\":\"users\",\"$db\":\"app\",\"key\":\"name\",\"query\":{},\"hint\":\"name_1\"}"));
         assertEquals(1.0, stringHint.get("ok").asNumber().doubleValue());
         assertEquals(2, stringHint.getArray("values").size());
+        assertEquals(0, store.lastFindFilter.size());
 
         final BsonDocument documentHint = dispatcher.dispatch(BsonDocument.parse(
                 "{\"distinct\":\"users\",\"$db\":\"app\",\"key\":\"name\",\"query\":{},\"hint\":{\"name\":1}}"));
         assertEquals(1.0, documentHint.get("ok").asNumber().doubleValue());
         assertEquals(2, documentHint.getArray("values").size());
+        assertEquals(0, store.lastFindFilter.size());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add distinct hint option coverage for accepted string/document subsets
- add invalid empty-document hint regression (`BadValue`) for distinct

## Validation
- `./.tooling/gradle-8.10.2/bin/gradle --no-daemon test --tests org.jongodb.command.CommandDispatcherE2ETest`

Closes #198
