### PR TITLE
feat: implement arrayFilters + collation subset support (#232, #235)

### DIFF
--- a/docs/COMPATIBILITY_SCORECARD.md
+++ b/docs/COMPATIBILITY_SCORECARD.md
@@ -66,7 +66,7 @@ Current ledger gate status:
 | `unsupported-by-policy UTF operation: failPoint` | 136 |
 | `unsupported UTF operation: clientBulkWrite` | 92 |
 | `unsupported UTF operation: targetedFailPoint` | 58 |
-| `unsupported UTF update option: arrayFilters` | 32 |
+| `unsupported UTF update option: arrayFilters` | 32 *(historical snapshot; subset implemented in #232)* |
 | `unsupported UTF aggregate stage in pipeline` | 28 |
 | `unsupported UTF operation: findOneAndDelete` | 26 |
 | `unsupported UTF operation: distinct` | 26 |
@@ -77,6 +77,7 @@ Current ledger gate status:
 Notes:
 
 - UTF importer now supports subset adapters for `runCommand` and `clientBulkWrite` (`#229`, `#231`).
+- `arrayFilters` subset and collation semantic subset landed (`#232`, `#235`); rerunning the ledger should reduce/update related unsupported buckets.
 - The counts above are from the latest frozen snapshot; rerunning the ledger will shift those categories toward narrower unsupported reasons (for example unsupported command names/options).
 - Profile context matters: this snapshot is strict-profile (`failPoint` policy exclusion enabled). Compat-profile runs track failpoint categories separately.
 - Deployment profile context matters: standalone and single-node-replica-set runs may surface different compatibility deltas in handshake/read-preference/concern paths.
@@ -103,6 +104,8 @@ Notes:
 - `#242`: CI quality gate for complex-query certification - completed.
 - `#241`: join-heavy pipeline parity for certification subset (`$lookup` + composed downstream with cursor contract) - completed.
 - `#243`: Spring complex-query matrix alignment with certification pack IDs and dedicated report section - completed.
+- `#232`: `arrayFilters` subset end-to-end (`$set`/`$unset` + `$[identifier]` binding) - completed.
+- `#235`: collation semantic subset (`locale`/`strength`/`caseLevel`) for query/sort/distinct/index interactions - completed.
 - `#104`: aggregate-stage unsupported reduction - remaining.
 
 ## Reproduction

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -54,9 +54,9 @@ Primary measures:
 
 ## Planned Next
 
-- Expand collation semantics beyond metadata round-trip.
+- Expand collation semantics beyond current subset (`locale`/`strength`/`caseLevel`).
 - Implement TTL runtime behavior beyond index metadata registration.
-- Expand update/operator coverage (`arrayFilters`, positional updates, pipeline updates).
+- Expand update/operator coverage beyond current `arrayFilters` subset (advanced positional/pipeline expressions).
 - Expand supported transaction operations in unified suites while preserving deterministic behavior.
 
 ## Out of Scope (Current Phase)

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -10,8 +10,8 @@ Source artifact: `build/reports/r2-compatibility/r2-support-manifest.json`.
 | Status | Count |
 | --- | --- |
 | Supported | 7 |
-| Partial | 5 |
-| Unsupported | 1 |
+| Partial | 6 |
+| Unsupported | 0 |
 
 ## Feature-Level Matrix
 
@@ -25,7 +25,7 @@ Source artifact: `build/reports/r2-compatibility/r2-support-manifest.json`.
 | `aggregation.expression-operators` | aggregation | Partial | Limited expression coverage |
 | `index.unique-sparse-partial` | index | Supported | Unique/sparse/partial |
 | `index.collation-metadata` | index | Supported | Collation metadata round-trip |
-| `index.collation-semantic` | index | Unsupported | Locale-aware comparison semantics |
+| `index.collation-semantic` | index | Partial | Subset: locale/strength/caseLevel on query-sort-distinct and unique index checks |
 | `transactions-single-session` | transaction | Supported | Session + txn flow with namespace-aware commit merge and deterministic same-`_id` resolution |
 | `transactions-retryable-advanced` | transaction | Partial | Deterministic retry contract for commit/abort replay and transaction error-label semantics (`TransientTransactionError`, `UnknownTransactionCommitResult`) within single-process scope |
 | `deployment.single-node-replicaset-profile` | deployment | Partial | Optional single-node replica-set semantic profile (replica-set URI/hello shape, primary-only readPreference contract, constrained concern levels) |

--- a/src/main/java/org/jongodb/command/AggregateCommandHandler.java
+++ b/src/main/java/org/jongodb/command/AggregateCommandHandler.java
@@ -8,6 +8,7 @@ import org.bson.BsonDouble;
 import org.bson.BsonInt64;
 import org.bson.BsonString;
 import org.bson.BsonValue;
+import org.jongodb.engine.CollationSupport;
 
 public final class AggregateCommandHandler implements CommandHandler {
     private final CommandStore store;
@@ -38,6 +39,7 @@ public final class AggregateCommandHandler implements CommandHandler {
         if (optionError != null) {
             return optionError;
         }
+        final CollationSupport.Config collation = CrudCommandOptionValidator.collationOrSimple(command, "collation");
 
         final BsonValue pipelineValue = command.get("pipeline");
         if (pipelineValue == null || !pipelineValue.isArray()) {
@@ -73,7 +75,7 @@ public final class AggregateCommandHandler implements CommandHandler {
 
         final List<BsonDocument> aggregatedDocuments;
         try {
-            aggregatedDocuments = store.aggregate(database, collection, List.copyOf(pipeline));
+            aggregatedDocuments = store.aggregate(database, collection, List.copyOf(pipeline), collation);
         } catch (final IllegalArgumentException exception) {
             return CommandExceptionMapper.fromIllegalArgument(exception);
         }

--- a/src/main/java/org/jongodb/command/CommandDispatcher.java
+++ b/src/main/java/org/jongodb/command/CommandDispatcher.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
 import org.bson.BsonDocument;
+import org.jongodb.engine.CollationSupport;
 import org.jongodb.engine.WriteConflictException;
 import org.jongodb.txn.SessionTransactionPool;
 import org.jongodb.txn.SessionTransactionPool.TerminalState;
@@ -181,9 +182,27 @@ public final class CommandDispatcher {
         }
 
         @Override
+        public java.util.List<BsonDocument> find(
+                final String database,
+                final String collection,
+                final BsonDocument filter,
+                final CollationSupport.Config collation) {
+            return delegate().find(database, collection, filter, collation);
+        }
+
+        @Override
         public java.util.List<BsonDocument> aggregate(
                 final String database, final String collection, final java.util.List<BsonDocument> pipeline) {
             return delegate().aggregate(database, collection, pipeline);
+        }
+
+        @Override
+        public java.util.List<BsonDocument> aggregate(
+                final String database,
+                final String collection,
+                final java.util.List<BsonDocument> pipeline,
+                final CollationSupport.Config collation) {
+            return delegate().aggregate(database, collection, pipeline, collation);
         }
 
         @Override

--- a/src/main/java/org/jongodb/command/CountDocumentsCommandHandler.java
+++ b/src/main/java/org/jongodb/command/CountDocumentsCommandHandler.java
@@ -5,6 +5,7 @@ import org.bson.BsonDocument;
 import org.bson.BsonDouble;
 import org.bson.BsonInt64;
 import org.bson.BsonValue;
+import org.jongodb.engine.CollationSupport;
 
 public final class CountDocumentsCommandHandler implements CommandHandler {
     private final CommandStore store;
@@ -33,6 +34,7 @@ public final class CountDocumentsCommandHandler implements CommandHandler {
         if (optionError != null) {
             return optionError;
         }
+        final CollationSupport.Config collation = CrudCommandOptionValidator.collationOrSimple(command, "collation");
 
         final BsonValue filterValue = command.containsKey("filter") ? command.get("filter") : command.get("query");
         final BsonDocument filter;
@@ -76,7 +78,7 @@ public final class CountDocumentsCommandHandler implements CommandHandler {
 
         final List<BsonDocument> matches;
         try {
-            matches = store.find(database, collection, filter);
+            matches = store.find(database, collection, filter, collation);
         } catch (final IllegalArgumentException exception) {
             return CommandExceptionMapper.fromIllegalArgument(exception);
         }

--- a/src/main/java/org/jongodb/command/UpdateArrayFiltersSubset.java
+++ b/src/main/java/org/jongodb/command/UpdateArrayFiltersSubset.java
@@ -1,0 +1,274 @@
+package org.jongodb.command;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonValue;
+
+final class UpdateArrayFiltersSubset {
+    private static final Pattern IDENTIFIER_PATTERN = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*");
+
+    private UpdateArrayFiltersSubset() {}
+
+    static ParseResult parse(final BsonValue value) {
+        if (value == null) {
+            return ParseResult.ok(ParsedArrayFilters.empty());
+        }
+        if (!value.isArray()) {
+            return ParseResult.error(CommandErrors.typeMismatch("arrayFilters must be an array"));
+        }
+
+        final BsonArray rawFilters = value.asArray();
+        if (rawFilters.isEmpty()) {
+            return ParseResult.error(CommandErrors.badValue("arrayFilters must not be empty"));
+        }
+
+        final List<BsonDocument> filters = new ArrayList<>(rawFilters.size());
+        final Set<String> identifiers = new LinkedHashSet<>();
+        for (int index = 0; index < rawFilters.size(); index++) {
+            final BsonValue item = rawFilters.get(index);
+            if (!item.isDocument()) {
+                return ParseResult.error(CommandErrors.typeMismatch("arrayFilters entries must be documents"));
+            }
+
+            final BsonDocument filter = item.asDocument();
+            if (filter.isEmpty()) {
+                return ParseResult.error(CommandErrors.badValue("arrayFilters entries must not be empty"));
+            }
+
+            final String identifier = extractIdentifier(filter);
+            if (identifier == null) {
+                return ParseResult.error(CommandErrors.badValue(
+                        "arrayFilters entries must use '<identifier>.<fieldPath>' keys in the supported subset"));
+            }
+            if (!identifiers.add(identifier)) {
+                return ParseResult.error(
+                        CommandErrors.badValue("duplicate array filter identifier '" + identifier + "'"));
+            }
+            filters.add(filter.clone());
+        }
+
+        return ParseResult.ok(new ParsedArrayFilters(filters, identifiers));
+    }
+
+    static BsonDocument validateUpdatePaths(
+            final BsonDocument updateDocument, final ParsedArrayFilters parsedArrayFilters) {
+        Objects.requireNonNull(updateDocument, "updateDocument");
+        Objects.requireNonNull(parsedArrayFilters, "parsedArrayFilters");
+
+        final Set<String> usedIdentifiers = new LinkedHashSet<>();
+        for (final String operator : updateDocument.keySet()) {
+            final BsonValue operatorDefinition = updateDocument.get(operator);
+            if (operatorDefinition == null || !operatorDefinition.isDocument()) {
+                continue;
+            }
+
+            for (final String path : operatorDefinition.asDocument().keySet()) {
+                final PathAnalysis analysis = analyzeUpdatePath(path);
+                if (analysis.error() != null) {
+                    return CommandErrors.badValue(analysis.error());
+                }
+                if (analysis.unsupportedPositionalPath()) {
+                    return CommandErrors.badValue(
+                            "positional and array filter updates are not supported for path '" + path + "'");
+                }
+                if (analysis.identifiers().isEmpty()) {
+                    continue;
+                }
+
+                if (parsedArrayFilters.isEmpty()) {
+                    return CommandErrors.badValue("arrayFilters must be specified for path '" + path + "'");
+                }
+                if (!"$set".equals(operator) && !"$unset".equals(operator)) {
+                    return CommandErrors.badValue(
+                            "arrayFilters currently support only $set/$unset for path '" + path + "'");
+                }
+
+                for (final String identifier : analysis.identifiers()) {
+                    if (!parsedArrayFilters.identifiers().contains(identifier)) {
+                        return CommandErrors.badValue("no array filter found for identifier '" + identifier + "'");
+                    }
+                    usedIdentifiers.add(identifier);
+                }
+            }
+        }
+
+        if (!parsedArrayFilters.isEmpty()) {
+            if (usedIdentifiers.isEmpty()) {
+                return CommandErrors.badValue("arrayFilters specified but no array filter identifier used in update paths");
+            }
+            for (final String identifier : parsedArrayFilters.identifiers()) {
+                if (!usedIdentifiers.contains(identifier)) {
+                    return CommandErrors.badValue(
+                            "array filter identifier '" + identifier + "' was not used in update paths");
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static String extractIdentifier(final BsonDocument filterDocument) {
+        String identifier = null;
+        for (final String key : filterDocument.keySet()) {
+            if (key.startsWith("$")) {
+                return null;
+            }
+            final int separator = key.indexOf('.');
+            if (separator <= 0 || separator == key.length() - 1) {
+                return null;
+            }
+
+            final String candidateIdentifier = key.substring(0, separator);
+            if (!isValidIdentifier(candidateIdentifier)) {
+                return null;
+            }
+            if (!isValidFieldPath(key.substring(separator + 1))) {
+                return null;
+            }
+            if (identifier == null) {
+                identifier = candidateIdentifier;
+            } else if (!identifier.equals(candidateIdentifier)) {
+                return null;
+            }
+        }
+        return identifier;
+    }
+
+    private static PathAnalysis analyzeUpdatePath(final String path) {
+        if (path == null || path.isBlank()) {
+            return PathAnalysis.error("field path must not be blank");
+        }
+
+        final String[] segments = path.split("\\.");
+        final Set<String> identifiers = new LinkedHashSet<>();
+        for (final String segment : segments) {
+            if (segment.isEmpty()) {
+                return PathAnalysis.error("field path must not contain empty segments");
+            }
+            if ("$".equals(segment) || "$[]".equals(segment)) {
+                return PathAnalysis.unsupportedPositional();
+            }
+
+            if (!segment.startsWith("$[") && !segment.endsWith("]")) {
+                continue;
+            }
+            if (!segment.startsWith("$[") || !segment.endsWith("]") || segment.length() <= 3) {
+                return PathAnalysis.error("invalid array filter identifier segment in path '" + path + "'");
+            }
+
+            final String identifier = segment.substring(2, segment.length() - 1);
+            if (!isValidIdentifier(identifier)) {
+                return PathAnalysis.error("invalid array filter identifier '" + identifier + "'");
+            }
+            identifiers.add(identifier);
+        }
+
+        return new PathAnalysis(List.copyOf(identifiers), false, null);
+    }
+
+    private static boolean isValidIdentifier(final String value) {
+        return IDENTIFIER_PATTERN.matcher(value).matches();
+    }
+
+    private static boolean isValidFieldPath(final String path) {
+        final String[] segments = path.split("\\.");
+        for (final String segment : segments) {
+            if (segment.isEmpty() || "$".equals(segment) || "$[]".equals(segment)) {
+                return false;
+            }
+            if (segment.startsWith("$[")) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static final class ParseResult {
+        private final ParsedArrayFilters parsed;
+        private final BsonDocument error;
+
+        private ParseResult(final ParsedArrayFilters parsed, final BsonDocument error) {
+            this.parsed = parsed;
+            this.error = error;
+        }
+
+        static ParseResult ok(final ParsedArrayFilters parsed) {
+            return new ParseResult(parsed, null);
+        }
+
+        static ParseResult error(final BsonDocument error) {
+            return new ParseResult(ParsedArrayFilters.empty(), Objects.requireNonNull(error, "error"));
+        }
+
+        ParsedArrayFilters parsed() {
+            return parsed;
+        }
+
+        BsonDocument error() {
+            return error;
+        }
+    }
+
+    static final class ParsedArrayFilters {
+        private static final ParsedArrayFilters EMPTY = new ParsedArrayFilters(List.of(), Set.of());
+
+        private final List<BsonDocument> filters;
+        private final Set<String> identifiers;
+
+        ParsedArrayFilters(final List<BsonDocument> filters, final Set<String> identifiers) {
+            this.filters = copyFilters(filters);
+            this.identifiers = Set.copyOf(identifiers);
+        }
+
+        static ParsedArrayFilters empty() {
+            return EMPTY;
+        }
+
+        List<BsonDocument> filters() {
+            return filters;
+        }
+
+        Set<String> identifiers() {
+            return identifiers;
+        }
+
+        boolean isEmpty() {
+            return filters.isEmpty();
+        }
+
+        BsonArray toBsonArray() {
+            final BsonArray array = new BsonArray();
+            for (final BsonDocument filter : filters) {
+                array.add(filter.clone());
+            }
+            return array;
+        }
+
+        private static List<BsonDocument> copyFilters(final List<BsonDocument> filters) {
+            if (filters == null || filters.isEmpty()) {
+                return List.of();
+            }
+            final List<BsonDocument> copied = new ArrayList<>(filters.size());
+            for (final BsonDocument filter : filters) {
+                copied.add(Objects.requireNonNull(filter, "arrayFilters entries must not be null").clone());
+            }
+            return List.copyOf(copied);
+        }
+    }
+
+    private record PathAnalysis(List<String> identifiers, boolean unsupportedPositionalPath, String error) {
+        static PathAnalysis unsupportedPositional() {
+            return new PathAnalysis(List.of(), true, null);
+        }
+
+        static PathAnalysis error(final String message) {
+            return new PathAnalysis(List.of(), false, Objects.requireNonNull(message, "message"));
+        }
+    }
+}

--- a/src/main/java/org/jongodb/engine/CollationSupport.java
+++ b/src/main/java/org/jongodb/engine/CollationSupport.java
@@ -1,0 +1,259 @@
+package org.jongodb.engine;
+
+import java.lang.reflect.Array;
+import java.text.Collator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import org.bson.BsonDocument;
+import org.bson.BsonValue;
+import org.bson.Document;
+
+public final class CollationSupport {
+    private static final Set<String> SUPPORTED_OPTIONS = Set.of("locale", "strength", "caseLevel");
+
+    private CollationSupport() {}
+
+    public static boolean isSupportedOption(final String optionName) {
+        return SUPPORTED_OPTIONS.contains(optionName);
+    }
+
+    public static final class Config {
+        private static final Config SIMPLE = new Config("simple", 3, false, true, null);
+
+        private final String localeTag;
+        private final int strength;
+        private final boolean caseLevel;
+        private final boolean simpleBinary;
+        private final Collator collator;
+
+        private Config(
+                final String localeTag,
+                final int strength,
+                final boolean caseLevel,
+                final boolean simpleBinary,
+                final Collator collator) {
+            this.localeTag = localeTag;
+            this.strength = strength;
+            this.caseLevel = caseLevel;
+            this.simpleBinary = simpleBinary;
+            this.collator = collator;
+        }
+
+        public static Config simple() {
+            return SIMPLE;
+        }
+
+        public static Config fromBsonDocument(final BsonDocument collation) {
+            if (collation == null || collation.isEmpty()) {
+                return SIMPLE;
+            }
+
+            final String locale = readLocale(collation.get("locale"));
+            final int strength = readStrength(collation.get("strength"));
+            final boolean caseLevel = readCaseLevel(collation.get("caseLevel"));
+            return create(locale, strength, caseLevel);
+        }
+
+        public static Config fromDocument(final Document collation) {
+            if (collation == null || collation.isEmpty()) {
+                return SIMPLE;
+            }
+
+            final String locale = readLocale(collation.get("locale"));
+            final int strength = readStrength(collation.get("strength"));
+            final boolean caseLevel = readCaseLevel(collation.get("caseLevel"));
+            return create(locale, strength, caseLevel);
+        }
+
+        public String localeTag() {
+            return localeTag;
+        }
+
+        public int strength() {
+            return strength;
+        }
+
+        public boolean caseLevel() {
+            return caseLevel;
+        }
+
+        public int compareStrings(final String left, final String right) {
+            if (simpleBinary) {
+                return left.compareTo(right);
+            }
+            final int compared = collator.compare(left, right);
+            if (compared != 0) {
+                return compared;
+            }
+            if (caseLevel && !left.equals(right)) {
+                return left.compareTo(right);
+            }
+            return 0;
+        }
+
+        public boolean valuesEqual(final Object left, final Object right) {
+            if (left == right) {
+                return true;
+            }
+            if (left == null || right == null) {
+                return false;
+            }
+            if (left instanceof String leftString && right instanceof String rightString) {
+                return compareStrings(leftString, rightString) == 0;
+            }
+            if (left instanceof Map<?, ?> leftMap && right instanceof Map<?, ?> rightMap) {
+                if (leftMap.size() != rightMap.size()) {
+                    return false;
+                }
+                for (final Map.Entry<?, ?> entry : leftMap.entrySet()) {
+                    final Object key = entry.getKey();
+                    if (!rightMap.containsKey(key)) {
+                        return false;
+                    }
+                    if (!valuesEqual(entry.getValue(), rightMap.get(key))) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            if (left instanceof List<?> leftList && right instanceof List<?> rightList) {
+                if (leftList.size() != rightList.size()) {
+                    return false;
+                }
+                for (int i = 0; i < leftList.size(); i++) {
+                    if (!valuesEqual(leftList.get(i), rightList.get(i))) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            if (left.getClass().isArray() && right.getClass().isArray()) {
+                final int leftLength = Array.getLength(left);
+                final int rightLength = Array.getLength(right);
+                if (leftLength != rightLength) {
+                    return false;
+                }
+                for (int i = 0; i < leftLength; i++) {
+                    if (!valuesEqual(Array.get(left, i), Array.get(right, i))) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            return Objects.deepEquals(left, right);
+        }
+
+        private static Config create(final String locale, final int strength, final boolean caseLevel) {
+            if ("simple".equalsIgnoreCase(locale)) {
+                return SIMPLE;
+            }
+
+            final Locale parsedLocale = Locale.forLanguageTag(locale);
+            final Collator collator = Collator.getInstance(parsedLocale);
+            collator.setStrength(toCollatorStrength(strength));
+            collator.setDecomposition(Collator.CANONICAL_DECOMPOSITION);
+            return new Config(parsedLocale.toLanguageTag(), strength, caseLevel, false, collator);
+        }
+
+        private static String readLocale(final Object localeValue) {
+            if (localeValue == null) {
+                return "simple";
+            }
+            if (localeValue instanceof BsonValue bsonValue) {
+                if (!bsonValue.isString()) {
+                    throw new IllegalArgumentException("collation.locale must be a string");
+                }
+                final String locale = bsonValue.asString().getValue();
+                if (locale == null || locale.isBlank()) {
+                    throw new IllegalArgumentException("collation.locale must not be blank");
+                }
+                return locale;
+            }
+            if (localeValue instanceof String locale) {
+                if (locale.isBlank()) {
+                    throw new IllegalArgumentException("collation.locale must not be blank");
+                }
+                return locale;
+            }
+            throw new IllegalArgumentException("collation.locale must be a string");
+        }
+
+        private static int readStrength(final Object strengthValue) {
+            if (strengthValue == null) {
+                return 3;
+            }
+
+            final Long parsed = parseIntegralLong(strengthValue);
+            if (parsed == null) {
+                throw new IllegalArgumentException("collation.strength must be an integer");
+            }
+            if (parsed < 1 || parsed > 4) {
+                throw new IllegalArgumentException("collation.strength must be between 1 and 4");
+            }
+            return parsed.intValue();
+        }
+
+        private static boolean readCaseLevel(final Object caseLevelValue) {
+            if (caseLevelValue == null) {
+                return false;
+            }
+            if (caseLevelValue instanceof BsonValue bsonValue) {
+                if (!bsonValue.isBoolean()) {
+                    throw new IllegalArgumentException("collation.caseLevel must be a boolean");
+                }
+                return bsonValue.asBoolean().getValue();
+            }
+            if (caseLevelValue instanceof Boolean booleanValue) {
+                return booleanValue;
+            }
+            throw new IllegalArgumentException("collation.caseLevel must be a boolean");
+        }
+
+        private static int toCollatorStrength(final int strength) {
+            return switch (strength) {
+                case 1 -> Collator.PRIMARY;
+                case 2 -> Collator.SECONDARY;
+                case 3 -> Collator.TERTIARY;
+                case 4 -> Collator.IDENTICAL;
+                default -> throw new IllegalArgumentException("collation.strength must be between 1 and 4");
+            };
+        }
+
+        private static Long parseIntegralLong(final Object value) {
+            if (value instanceof BsonValue bsonValue) {
+                if (bsonValue.isInt32()) {
+                    return (long) bsonValue.asInt32().getValue();
+                }
+                if (bsonValue.isInt64()) {
+                    return bsonValue.asInt64().getValue();
+                }
+                if (bsonValue.isDouble()) {
+                    final double doubleValue = bsonValue.asDouble().getValue();
+                    if (!Double.isFinite(doubleValue) || Math.rint(doubleValue) != doubleValue) {
+                        return null;
+                    }
+                    if (doubleValue < Long.MIN_VALUE || doubleValue > Long.MAX_VALUE) {
+                        return null;
+                    }
+                    return (long) doubleValue;
+                }
+                return null;
+            }
+
+            if (value instanceof Number numberValue) {
+                final double doubleValue = numberValue.doubleValue();
+                if (!Double.isFinite(doubleValue) || Math.rint(doubleValue) != doubleValue) {
+                    return null;
+                }
+                if (doubleValue < Long.MIN_VALUE || doubleValue > Long.MAX_VALUE) {
+                    return null;
+                }
+                return (long) doubleValue;
+            }
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/jongodb/engine/CollectionStore.java
+++ b/src/main/java/org/jongodb/engine/CollectionStore.java
@@ -17,11 +17,27 @@ public interface CollectionStore {
 
     List<Document> find(Document filter);
 
+    default List<Document> find(final Document filter, final CollationSupport.Config collation) {
+        return find(filter);
+    }
+
     default List<Document> aggregate(final List<Document> pipeline) {
         throw new UnsupportedOperationException("aggregate is not supported");
     }
 
     UpdateManyResult update(Document filter, Document update, boolean multi, boolean upsert);
+
+    default UpdateManyResult update(
+            final Document filter,
+            final Document update,
+            final boolean multi,
+            final boolean upsert,
+            final List<Document> arrayFilters) {
+        if (arrayFilters != null && !arrayFilters.isEmpty()) {
+            throw new IllegalArgumentException("arrayFilters is not supported yet");
+        }
+        return update(filter, update, multi, upsert);
+    }
 
     default UpdateManyResult updateMany(final Document filter, final Document update) {
         return update(filter, update, true, false);

--- a/src/main/java/org/jongodb/testkit/R2CompatibilityScorecard.java
+++ b/src/main/java/org/jongodb/testkit/R2CompatibilityScorecard.java
@@ -480,7 +480,11 @@ public final class R2CompatibilityScorecard {
                     new SupportEntry("aggregation.expression-operators", "aggregation", SupportStatus.PARTIAL, "Limited expression coverage"),
                     new SupportEntry("index.unique-sparse-partial", "index", SupportStatus.SUPPORTED, "Unique/sparse/partial"),
                     new SupportEntry("index.collation-metadata", "index", SupportStatus.SUPPORTED, "Collation metadata round-trip"),
-                    new SupportEntry("index.collation-semantic", "index", SupportStatus.UNSUPPORTED, "Locale-aware comparison semantics"),
+                    new SupportEntry(
+                            "index.collation-semantic",
+                            "index",
+                            SupportStatus.PARTIAL,
+                            "Subset: locale/strength/caseLevel on query-sort-distinct and unique index checks"),
                     new SupportEntry("transactions-single-session", "transaction", SupportStatus.SUPPORTED, "Session + txn command flow"),
                     new SupportEntry("transactions-retryable-advanced", "transaction", SupportStatus.PARTIAL, "Partial compatibility"),
                     new SupportEntry("protocol-unsupported-contract", "protocol", SupportStatus.SUPPORTED, "NotImplemented + UnsupportedFeature labels")));

--- a/src/main/java/org/jongodb/testkit/UnifiedSpecImporter.java
+++ b/src/main/java/org/jongodb/testkit/UnifiedSpecImporter.java
@@ -426,9 +426,6 @@ public final class UnifiedSpecImporter {
         if (rawUpdate == null) {
             throw new IllegalArgumentException("update operation requires update/replacement argument");
         }
-        if (arguments.containsKey("arrayFilters")) {
-            throw new UnsupportedOperationException("unsupported UTF update option: arrayFilters");
-        }
         if (multi && isReplacementDocument(rawUpdate)) {
             throw new UnsupportedOperationException("unsupported UTF replacement update with multi=true");
         }
@@ -522,10 +519,6 @@ public final class UnifiedSpecImporter {
         if (updateValue == null) {
             throw new IllegalArgumentException("findOneAndUpdate operation requires update argument");
         }
-        if (arguments.containsKey("arrayFilters")) {
-            throw new UnsupportedOperationException("unsupported UTF update option: arrayFilters");
-        }
-
         final Map<String, Object> payload = commandEnvelope("findOneAndUpdate", database, collection);
         payload.put("filter", deepCopyValue(arguments.getOrDefault("filter", Map.of())));
         payload.put("update", deepCopyValue(updateValue));
@@ -535,6 +528,7 @@ public final class UnifiedSpecImporter {
         copyNormalizedReturnDocumentIfPresent(arguments, payload);
         copyIfPresent(arguments, payload, "hint");
         copyIfPresent(arguments, payload, "collation");
+        copyIfPresent(arguments, payload, "arrayFilters");
         return new ScenarioCommand("findOneAndUpdate", immutableMap(payload));
     }
 
@@ -635,9 +629,6 @@ public final class UnifiedSpecImporter {
         final Object updateValue = operationArguments.get("update");
         if (updateValue == null) {
             throw new IllegalArgumentException("bulkWrite update operation requires update argument");
-        }
-        if (operationArguments.containsKey("arrayFilters")) {
-            throw new UnsupportedOperationException("unsupported UTF update option: arrayFilters");
         }
         if (multi && isReplacementDocument(updateValue)) {
             throw new UnsupportedOperationException("unsupported UTF replacement update with multi=true");

--- a/src/test/java/org/jongodb/engine/QueryMatcherTest.java
+++ b/src/test/java/org/jongodb/engine/QueryMatcherTest.java
@@ -382,6 +382,20 @@ class QueryMatcherTest {
     }
 
     @Test
+    void supportsCollationSubsetForStringEqualityAndComparison() {
+        final Document document = new Document("name", "Alpha").append("city", "ä");
+        final Document uppercaseDocument = new Document("name", "ALPHA");
+        final CollationSupport.Config collation =
+                CollationSupport.Config.fromDocument(new Document("locale", "en").append("strength", 1));
+
+        assertTrue(QueryMatcher.matches(document, new Document("name", "alpha"), collation));
+        assertTrue(QueryMatcher.matches(document, new Document("name", new Document("$gte", "a")), collation));
+        assertTrue(QueryMatcher.matches(uppercaseDocument, new Document("name", new Document("$gte", "a")), collation));
+        assertTrue(QueryMatcher.matches(document, new Document("city", new Document("$lt", "z")), collation));
+        assertFalse(QueryMatcher.matches(document, new Document("name", "beta"), collation));
+    }
+
+    @Test
     void rejectsUnsupportedOperatorsOrInvalidOperands() {
         Document document = new Document("score", 10);
 

--- a/src/test/java/org/jongodb/testkit/UnifiedSpecImporterTest.java
+++ b/src/test/java/org/jongodb/testkit/UnifiedSpecImporterTest.java
@@ -210,7 +210,7 @@ class UnifiedSpecImporterTest {
     }
 
     @Test
-    void marksKnownUnsupportedQueryUpdateFeaturesAsUnsupported() throws IOException {
+    void importsArrayFiltersUpdateSubsetWhileKeepingOtherUnsupportedCasesSkipped() throws IOException {
         Files.writeString(
                 tempDir.resolve("unsupported-query-update.json"),
                 """
@@ -250,10 +250,18 @@ class UnifiedSpecImporterTest {
         final UnifiedSpecImporter importer = new UnifiedSpecImporter();
         final UnifiedSpecImporter.ImportResult result = importer.importCorpus(tempDir);
 
-        assertEquals(0, result.importedCount());
-        assertEquals(2, result.unsupportedCount());
+        assertEquals(1, result.importedCount());
+        assertEquals(1, result.unsupportedCount());
         assertTrue(result.skippedCases().stream().allMatch(skipped ->
                 skipped.kind() == UnifiedSpecImporter.SkipKind.UNSUPPORTED));
+
+        final Scenario scenario = result.importedScenarios().get(0).scenario();
+        assertEquals("update", scenario.commands().get(0).commandName());
+        final Object updatesValue = scenario.commands().get(0).payload().get("updates");
+        assertTrue(updatesValue instanceof List<?>);
+        final Object updateEntry = ((List<?>) updatesValue).get(0);
+        assertTrue(updateEntry instanceof java.util.Map<?, ?>);
+        assertTrue(((java.util.Map<?, ?>) updateEntry).containsKey("arrayFilters"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- implement `arrayFilters` subset support for update paths using `$[identifier]` under `$set`/`$unset`
- wire `arrayFilters` through `update`, `findOneAndUpdate`, `findAndModify`, `bulkWrite`, and importer paths
- add collation subset support (`locale`, `strength`, `caseLevel`) across find/distinct/count/aggregate and sort/match logic
- apply collation-aware unique index checks and deep equality semantics
- update compatibility docs/scorecard/support matrix for #232 and #235
- fix `RoutingCommandStore` to delegate collation-aware `find`/`aggregate` overloads

## Validation
- `./.tooling/gradle-8.10.2/bin/gradle --no-daemon test`

Closes #232
Closes #235
