### PR TITLE
feat: add aggregation stage alias subsets for scorecard parity

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -63,13 +63,17 @@ Not implemented:
 Implemented stages:
 - `$match`
 - `$project`
-- `$group` (currently `$sum` accumulator only)
+- `$group` (subset: `$sum`, `$first`, `$addToSet`)
 - `$sort`
 - `$limit`, `$skip`
 - `$unwind` (without `includeArrayIndex`)
 - `$count`
 - `$addFields`
+- `$set` (alias subset of `$addFields`)
+- `$unset` (field removal subset: string / array / document-key form)
 - `$sortByCount`
+- `$replaceRoot`
+- `$replaceWith` (alias-style root replacement subset)
 - `$facet`
 - `$lookup` (local/foreign and pipeline+let subset)
 - `$unionWith`

--- a/docs/COMPATIBILITY_SCORECARD.md
+++ b/docs/COMPATIBILITY_SCORECARD.md
@@ -78,6 +78,7 @@ Notes:
 
 - UTF importer now supports subset adapters for `runCommand` and `clientBulkWrite` (`#229`, `#231`).
 - `arrayFilters` subset and collation semantic subset landed (`#232`, `#235`); rerunning the ledger should reduce/update related unsupported buckets.
+- aggregation stage alias subset landed for `$set`/`$unset`/`$replaceWith` (`#265`, `#266`, `#267`); rerunning the ledger should narrow generic aggregate-stage unsupported buckets.
 - The counts above are from the latest frozen snapshot; rerunning the ledger will shift those categories toward narrower unsupported reasons (for example unsupported command names/options).
 - Profile context matters: this snapshot is strict-profile (`failPoint` policy exclusion enabled). Compat-profile runs track failpoint categories separately.
 - Deployment profile context matters: standalone and single-node-replica-set runs may surface different compatibility deltas in handshake/read-preference/concern paths.
@@ -106,7 +107,10 @@ Notes:
 - `#243`: Spring complex-query matrix alignment with certification pack IDs and dedicated report section - completed.
 - `#232`: `arrayFilters` subset end-to-end (`$set`/`$unset` + `$[identifier]` binding) - completed.
 - `#235`: collation semantic subset (`locale`/`strength`/`caseLevel`) for query/sort/distinct/index interactions - completed.
-- `#104`: aggregate-stage unsupported reduction - remaining.
+- `#265`: aggregate stage alias subset (`$set`/`$unset`) - completed.
+- `#266`: `$replaceWith` stage subset for root replacement - completed.
+- `#267`: aggregation stage subset regression + scorecard mapping update - completed.
+- `#104`: aggregate-stage unsupported reduction - remaining (advanced/non-alias stages).
 
 ## Reproduction
 


### PR DESCRIPTION
## Summary
- add aggregation stage alias subset support in engine pipeline:
  - `$set` as alias subset of `$addFields`
  - `$unset` subset (string, array, document-key forms)
  - `$replaceWith` subset for root replacement expressions
- keep deterministic fail-fast behavior for invalid stage shapes
- extend engine and command E2E tests for new stage subsets and invalid payload behavior
- update compatibility docs and scorecard gap mapping for stage-subset issues

## Validation
- `./.tooling/gradle-8.10.2/bin/gradle --no-daemon test`

Closes #265
Closes #266
Closes #267
