### PR TITLE
fix(r3): restore failure-ledger parity for runOn/file-level and findAndModify

### DIFF
--- a/src/main/java/org/jongodb/command/FindAndModifyCommandHandler.java
+++ b/src/main/java/org/jongodb/command/FindAndModifyCommandHandler.java
@@ -151,7 +151,7 @@ public final class FindAndModifyCommandHandler implements CommandHandler {
             final BsonDocument selected,
             final ProjectionSpec projectionSpec) {
         if (selected == null) {
-            return successResponse(0, false, null, null);
+            return removeSuccessResponse(0, null);
         }
 
         final int deleted = store.delete(
@@ -159,7 +159,7 @@ public final class FindAndModifyCommandHandler implements CommandHandler {
                 collection,
                 List.of(new CommandStore.DeleteRequest(singleDocumentFilter(selected), 1)));
         final BsonDocument value = deleted > 0 ? applyProjection(selected, projectionSpec) : null;
-        return successResponse(deleted > 0 ? 1 : 0, false, null, value);
+        return removeSuccessResponse(deleted > 0 ? 1 : 0, value);
     }
 
     private BsonDocument handleUpdate(
@@ -368,6 +368,13 @@ public final class FindAndModifyCommandHandler implements CommandHandler {
 
         return new BsonDocument()
                 .append("lastErrorObject", lastErrorObject)
+                .append("value", value == null ? BsonNull.VALUE : value)
+                .append("ok", new BsonDouble(1.0));
+    }
+
+    private static BsonDocument removeSuccessResponse(final int n, final BsonDocument value) {
+        return new BsonDocument()
+                .append("lastErrorObject", new BsonDocument("n", new BsonInt32(n)))
                 .append("value", value == null ? BsonNull.VALUE : value)
                 .append("ok", new BsonDouble(1.0));
     }

--- a/src/main/java/org/jongodb/testkit/ScenarioBsonCodec.java
+++ b/src/main/java/org/jongodb/testkit/ScenarioBsonCodec.java
@@ -345,6 +345,7 @@ final class ScenarioBsonCodec {
         appendIfPresent(source, translated, "upsert");
         appendIfPresent(source, translated, "hint");
         appendIfPresent(source, translated, "collation");
+        appendIfPresent(source, translated, "arrayFilters");
         copyFields(
                 source,
                 translated,

--- a/src/test/java/org/jongodb/command/FindAndModifyCommandE2ETest.java
+++ b/src/test/java/org/jongodb/command/FindAndModifyCommandE2ETest.java
@@ -1,6 +1,7 @@
 package org.jongodb.command;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.bson.BsonDocument;
 import org.jongodb.engine.InMemoryEngineStore;
@@ -44,6 +45,7 @@ class FindAndModifyCommandE2ETest {
 
         assertEquals(1.0, removeResponse.get("ok").asNumber().doubleValue());
         assertEquals(1, removeResponse.getDocument("lastErrorObject").getInt32("n").getValue());
+        assertFalse(removeResponse.getDocument("lastErrorObject").containsKey("updatedExisting"));
         assertEquals("alpha", removeResponse.get("value").asDocument().getString("name").getValue());
 
         final BsonDocument countAfter = dispatcher.dispatch(BsonDocument.parse(

--- a/src/test/java/org/jongodb/testkit/ScenarioBsonCodecTest.java
+++ b/src/test/java/org/jongodb/testkit/ScenarioBsonCodecTest.java
@@ -133,6 +133,8 @@ class ScenarioBsonCodecTest {
                 Map.of("_id", 1),
                 "update",
                 Map.of("$set", Map.of("name", "after")),
+                "arrayFilters",
+                java.util.List.of(Map.of("elem.name", "before")),
                 "returnDocument",
                 "after"
             )
@@ -142,6 +144,12 @@ class ScenarioBsonCodecTest {
 
         assertEquals("users", commandDocument.getString("findAndModify").getValue());
         assertEquals(1, commandDocument.getDocument("query").getInt32("_id").getValue());
+        assertTrue(commandDocument.containsKey("arrayFilters"));
+        assertEquals("before", commandDocument.getArray("arrayFilters")
+                .get(0)
+                .asDocument()
+                .getString("elem.name")
+                .getValue());
         assertTrue(commandDocument.getBoolean("new").getValue());
     }
 }


### PR DESCRIPTION
## Summary
- align remove-mode `findAndModify` response shape with real mongod by omitting `lastErrorObject.updatedExisting`
- include `arrayFilters` in real-mongod translation for `findOneAndUpdate`
- evaluate file-level `runOnRequirements` using detected server context while preserving existing test-level skip behavior
- classify update pipeline forms outside the supported `$set/$unset` literal subset as importer-level unsupported
- add regression coverage for all above paths in command/testkit tests

Closes #271

## Validation
- `./.tooling/gradle-8.10.2/bin/gradle --no-daemon test --tests org.jongodb.testkit.UnifiedSpecImporterTest --tests org.jongodb.testkit.UnifiedSpecCorpusRunnerTest --tests org.jongodb.testkit.ScenarioBsonCodecTest --tests org.jongodb.command.FindAndModifyCommandE2ETest`
- local R3 ledger with pinned specs ref `99704fa8860777da1d919ef765af1e41e75f5859` and replica set fixture:
  - `failureCount=0`
  - suite import summary: `crud=282`, `transactions=164`, `sessions=16`
