### PR TITLE
feat: support aggregate  terminal subset

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -77,13 +77,14 @@ Implemented stages:
 - `$facet`
 - `$lookup` (local/foreign and pipeline+let subset)
 - `$unionWith`
+- `$out` (terminal string-target subset: replaces target collection contents and returns empty result set)
 
 Not implemented or partial:
 - unsupported stages return deterministic fail-fast
 - many advanced expression operators are still missing
 - `$group` accumulators other than `$sum` are not available
 - `$unwind.includeArrayIndex` is not available
-- `$out`, `$merge`, `$listLocalSessions` stages are excluded from current differential corpus
+- `$merge`, `$listLocalSessions` stages are excluded from current differential corpus
 - `bypassDocumentValidation` for aggregate is excluded from current differential corpus
 
 ## Update Semantics

--- a/docs/COMPATIBILITY_SCORECARD.md
+++ b/docs/COMPATIBILITY_SCORECARD.md
@@ -79,6 +79,7 @@ Notes:
 - UTF importer now supports subset adapters for `runCommand` and `clientBulkWrite` (`#229`, `#231`).
 - `arrayFilters` subset and collation semantic subset landed (`#232`, `#235`); rerunning the ledger should reduce/update related unsupported buckets.
 - aggregation stage alias subset landed for `$set`/`$unset`/`$replaceWith` (`#265`, `#266`, `#267`); rerunning the ledger should narrow generic aggregate-stage unsupported buckets.
+- aggregation `$out` terminal subset landed (`#269`); rerunning the ledger should reduce aggregate-stage unsupported buckets tied to `$out` pipeline coverage.
 - The counts above are from the latest frozen snapshot; rerunning the ledger will shift those categories toward narrower unsupported reasons (for example unsupported command names/options).
 - Profile context matters: this snapshot is strict-profile (`failPoint` policy exclusion enabled). Compat-profile runs track failpoint categories separately.
 - Deployment profile context matters: standalone and single-node-replica-set runs may surface different compatibility deltas in handshake/read-preference/concern paths.
@@ -110,7 +111,8 @@ Notes:
 - `#265`: aggregate stage alias subset (`$set`/`$unset`) - completed.
 - `#266`: `$replaceWith` stage subset for root replacement - completed.
 - `#267`: aggregation stage subset regression + scorecard mapping update - completed.
-- `#104`: aggregate-stage unsupported reduction - remaining (advanced/non-alias stages).
+- `#269`: aggregation non-alias subset expansion (`$out` terminal subset) - completed.
+- `#104`: aggregate-stage unsupported reduction - remaining (`$merge`, `$listLocalSessions`, and advanced/non-alias stages).
 
 ## Reproduction
 

--- a/src/main/java/org/jongodb/testkit/UnifiedSpecImporter.java
+++ b/src/main/java/org/jongodb/testkit/UnifiedSpecImporter.java
@@ -396,7 +396,7 @@ public final class UnifiedSpecImporter {
     }
 
     private static boolean containsUnsupportedAggregateStage(final Map<String, Object> stage) {
-        if (stage.containsKey("$out") || stage.containsKey("$merge") || stage.containsKey("$listLocalSessions")) {
+        if (stage.containsKey("$merge") || stage.containsKey("$listLocalSessions")) {
             return true;
         }
         for (final Object value : stage.values()) {
@@ -411,7 +411,7 @@ public final class UnifiedSpecImporter {
         if (value instanceof Map<?, ?> mapValue) {
             for (final Map.Entry<?, ?> entry : mapValue.entrySet()) {
                 final String key = String.valueOf(entry.getKey());
-                if ("$out".equals(key) || "$merge".equals(key) || "$listLocalSessions".equals(key)) {
+                if ("$merge".equals(key) || "$listLocalSessions".equals(key)) {
                     return true;
                 }
                 if (containsUnsupportedAggregateStageValue(entry.getValue())) {

--- a/src/test/java/org/jongodb/testkit/UnifiedSpecImporterTest.java
+++ b/src/test/java/org/jongodb/testkit/UnifiedSpecImporterTest.java
@@ -407,7 +407,7 @@ class UnifiedSpecImporterTest {
     }
 
     @Test
-    void marksKnownUnsupportedAggregationFeaturesAsUnsupported() throws IOException {
+    void importsOutStageButKeepsMergeAndBypassValidationUnsupported() throws IOException {
         Files.writeString(
                 tempDir.resolve("unsupported-aggregation.json"),
                 """
@@ -456,8 +456,11 @@ class UnifiedSpecImporterTest {
         final UnifiedSpecImporter importer = new UnifiedSpecImporter();
         final UnifiedSpecImporter.ImportResult result = importer.importCorpus(tempDir);
 
-        assertEquals(0, result.importedCount());
-        assertEquals(3, result.unsupportedCount());
+        assertEquals(1, result.importedCount());
+        assertEquals(2, result.unsupportedCount());
+        final Scenario outScenario = result.importedScenarios().get(0).scenario();
+        assertEquals(1, outScenario.commands().size());
+        assertEquals("aggregate", outScenario.commands().get(0).commandName());
         assertTrue(result.skippedCases().stream().allMatch(skipped ->
                 skipped.kind() == UnifiedSpecImporter.SkipKind.UNSUPPORTED));
     }


### PR DESCRIPTION
## Summary
- add terminal  subset handling in aggregate execution path
- execute pipeline up to , replace target collection contents, and return empty firstBatch
- stop excluding  in unified-spec importer and update compatibility docs/scorecard

## Tests
- ./.tooling/gradle-8.10.2/bin/gradle --no-daemon test --tests org.jongodb.command.AggregateCommandE2ETest --tests org.jongodb.testkit.UnifiedSpecImporterTest --tests org.jongodb.command.CommandDispatcherE2ETest

Closes #269