### PR TITLE
perf(engine): optimize read-path copy strategy for find/aggregate

### DIFF
--- a/src/main/java/org/jongodb/engine/AggregationPipeline.java
+++ b/src/main/java/org/jongodb/engine/AggregationPipeline.java
@@ -64,7 +64,7 @@ public final class AggregationPipeline {
         Objects.requireNonNull(collectionResolver, "collectionResolver");
         Objects.requireNonNull(collation, "collation");
 
-        List<Document> working = copyDocuments(source, "source documents must not contain null");
+        List<Document> working = materializeDocuments(source, "source documents must not contain null");
 
         for (final Document stage : pipeline) {
             if (stage == null) {
@@ -830,7 +830,7 @@ public final class AggregationPipeline {
 
         final List<Document> output = new ArrayList<>(input.size());
         for (final Document source : input) {
-            final List<Document> foreignSource = copyDocuments(
+            final List<Document> foreignSource = materializeDocuments(
                     collectionResolver.resolve(from),
                     "$lookup resolver returned null documents");
             List<Document> joined = foreignSource;
@@ -881,8 +881,8 @@ public final class AggregationPipeline {
             }
         }
 
-        final List<Document> combined = copyDocuments(input, "input must not contain null");
-        List<Document> unionSource = copyDocuments(
+        final List<Document> combined = materializeDocuments(input, "input must not contain null");
+        List<Document> unionSource = materializeDocuments(
                 collectionResolver.resolve(collectionName),
                 "$unionWith resolver returned null documents");
         if (!unionPipeline.isEmpty()) {
@@ -1005,18 +1005,18 @@ public final class AggregationPipeline {
         return List.copyOf(pipeline);
     }
 
-    private static List<Document> copyDocuments(final Iterable<Document> source, final String nullMessage) {
+    private static List<Document> materializeDocuments(final Iterable<Document> source, final String nullMessage) {
         Objects.requireNonNull(source, "source");
-        final List<Document> copied = source instanceof List<?> listSource
+        final List<Document> materialized = source instanceof List<?> listSource
                 ? new ArrayList<>(listSource.size())
                 : new ArrayList<>();
         for (final Document document : source) {
             if (document == null) {
                 throw new IllegalArgumentException(nullMessage);
             }
-            copied.add(DocumentCopies.copy(document));
+            materialized.add(document);
         }
-        return copied;
+        return materialized;
     }
 
     private static boolean lookupValueMatches(final Object localValue, final Object foreignValue) {

--- a/src/main/java/org/jongodb/engine/InMemoryCollectionStore.java
+++ b/src/main/java/org/jongodb/engine/InMemoryCollectionStore.java
@@ -227,7 +227,7 @@ public final class InMemoryCollectionStore implements CollectionStore {
 
     @Override
     public synchronized List<Document> find(final Document filter, final CollationSupport.Config collation) {
-        Document effectiveFilter = filter == null ? new Document() : DocumentCopies.copy(filter);
+        final Document effectiveFilter = filter == null ? new Document() : filter;
         final CollationSupport.Config effectiveCollation =
                 collation == null ? CollationSupport.Config.simple() : collation;
         return copyMatchingDocuments(effectiveFilter, effectiveCollation);

--- a/src/test/java/org/jongodb/engine/AggregationPipelineTest.java
+++ b/src/test/java/org/jongodb/engine/AggregationPipelineTest.java
@@ -1,0 +1,52 @@
+package org.jongodb.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+
+class AggregationPipelineTest {
+    @Test
+    void executeDoesNotMutateSourceDocumentsForSetAndUnset() {
+        final Document sourceDocument = new Document("_id", 1)
+                .append("name", "alpha")
+                .append("legacy", true)
+                .append("profile", new Document("city", "Seoul"));
+        final List<Document> source = List.of(sourceDocument);
+
+        final List<Document> result = AggregationPipeline.execute(
+                source,
+                List.of(
+                        new Document("$set", new Document("profile.city", "Busan")),
+                        new Document("$unset", "legacy")));
+
+        assertEquals("Seoul", sourceDocument.get("profile", Document.class).getString("city"));
+        assertTrue(sourceDocument.getBoolean("legacy"));
+        assertEquals(1, result.size());
+        assertNotSame(sourceDocument, result.get(0));
+        assertEquals("Busan", result.get(0).get("profile", Document.class).getString("city"));
+        assertFalse(result.get(0).containsKey("legacy"));
+    }
+
+    @Test
+    void executeDoesNotMutateSourceDocumentsForUnwind() {
+        final Document sourceDocument = new Document("_id", 1).append("tags", List.of("a", "b"));
+        final List<Document> source = List.of(sourceDocument);
+
+        final List<Document> result =
+                AggregationPipeline.execute(source, List.of(new Document("$unwind", "$tags")));
+
+        assertEquals(List.of("a", "b"), sourceDocument.getList("tags", String.class));
+        assertEquals(2, result.size());
+        final List<Object> unwindValues = new ArrayList<>();
+        for (final Document document : result) {
+            unwindValues.add(document.get("tags"));
+        }
+        assertEquals(List.of("a", "b"), unwindValues);
+    }
+}

--- a/src/test/java/org/jongodb/engine/InMemoryCollectionStoreTest.java
+++ b/src/test/java/org/jongodb/engine/InMemoryCollectionStoreTest.java
@@ -120,6 +120,25 @@ class InMemoryCollectionStoreTest {
     }
 
     @Test
+    void findDoesNotMutateCallerFilterDocument() {
+        CollectionStore store = new InMemoryCollectionStore();
+        store.insertMany(Arrays.asList(
+                new Document("_id", 1).append("name", "Ada").append("role", "user"),
+                new Document("_id", 2).append("name", "Linus").append("role", "admin")));
+
+        Document filter = new Document("$or", List.of(
+                new Document("role", "user"),
+                new Document("name", "Missing")));
+        Document before = Document.parse(filter.toJson());
+
+        List<Document> filtered = store.find(filter);
+
+        assertEquals(1, filtered.size());
+        assertEquals(1, filtered.get(0).getInteger("_id"));
+        assertEquals(before, filter);
+    }
+
+    @Test
     void insertManyAppendsToExistingCollectionState() {
         CollectionStore store = new InMemoryCollectionStore();
 


### PR DESCRIPTION
## Summary
- reduce aggregate read-path deep copies by materializing pipeline inputs without cloning each source document
- preserve mutation safety by keeping stage-level copy semantics and final output defensive copies
- remove unnecessary filter deep-copy in InMemoryCollectionStore.find and add regression coverage

## Tests
- ./.tooling/gradle-8.10.2/bin/gradle --no-daemon test --tests org.jongodb.engine.AggregationPipelineTest --tests org.jongodb.engine.InMemoryCollectionStoreTest --tests org.jongodb.engine.InMemoryCollectionStoreAggregateTest --tests org.jongodb.command.EngineBackedCommandStoreAggregateStreamingTest
- ./.tooling/gradle-8.10.2/bin/gradle --no-daemon test --tests org.jongodb.command.AggregateCommandE2ETest --tests org.jongodb.command.CommandDispatcherE2ETest

Closes #96
