### PR TITLE
perf(command): reduce BSON<->Document conversion overhead

### DIFF
--- a/src/test/java/org/jongodb/command/CommandDispatcherE2ETest.java
+++ b/src/test/java/org/jongodb/command/CommandDispatcherE2ETest.java
@@ -907,6 +907,12 @@ class CommandDispatcherE2ETest {
                         .asDocument()
                         .getInt32("index")
                         .getValue());
+        assertTrue(upsertResponse
+                .getArray("upserted")
+                .get(0)
+                .asDocument()
+                .get("_id")
+                .isObjectId());
         assertEquals(
                 1,
                 upsertResponse


### PR DESCRIPTION
## Summary
- reduce conversion overhead in EngineBackedCommandStore by reusing a static BSON decoder context and fast-pathing empty BSON/Document conversions
- add scalar fast paths in upserted-id conversion to avoid wrapping values into temporary Document/BSON round-trips for common types
- pre-size find result conversion buffers and keep behavior locked with an upsert ObjectId type assertion in command E2E tests

## Tests
- ./.tooling/gradle-8.10.2/bin/gradle --no-daemon test --tests org.jongodb.command.CommandDispatcherE2ETest --tests org.jongodb.command.BulkWriteCommandE2ETest --tests org.jongodb.command.FindAndModifyCommandE2ETest --tests org.jongodb.command.AggregateCommandE2ETest

Closes #95
