### PR TITLE
feat(spring): add shared-server mode for test initializer

### DIFF
--- a/docs/SPRING_TESTING.md
+++ b/docs/SPRING_TESTING.md
@@ -62,6 +62,17 @@ Optional test database name:
 - `jongodb.test.database=<dbName>` (initializer style)
 - `JongodbMongoDynamicPropertySupport.register(registry, "<dbName>")` (dynamic style)
 
+Optional shared-server mode for initializer/single-hook style:
+- `@TestPropertySource(properties = "jongodb.test.sharedServer=true")`
+- `jongodb.test.sharedServer=true`
+
+When enabled, multiple Spring contexts in the same JVM reuse one in-process TCP server.
+The shared server closes automatically after the last shared context closes.
+
+Isolation caveat:
+- shared mode reuses process/port for speed, so prefer unique `jongodb.test.database` values per test class.
+- keep shared mode disabled (default) if your suite requires strict per-context process isolation.
+
 ## Migration from MongoDB Testcontainers
 
 ### Before (typical pattern)

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -68,6 +68,11 @@ class AccountIntegrationTest {
 Optional database override:
 - set `jongodb.test.database=<dbName>` as a test property.
 
+Optional shared-server mode for multi-context suites:
+- set `jongodb.test.sharedServer=true` as a test property.
+- when enabled, Spring contexts in the same JVM reuse one in-process TCP server.
+- use unique `jongodb.test.database` values per test class when sharing to avoid data bleed.
+
 ### Option C: `@DynamicPropertySource`
 
 Use `JongodbMongoDynamicPropertySupport` as a drop-in replacement pattern for many Testcontainers setups:

--- a/src/main/java/org/jongodb/spring/test/JongodbMongoInitializer.java
+++ b/src/main/java/org/jongodb/spring/test/JongodbMongoInitializer.java
@@ -3,6 +3,7 @@ package org.jongodb.spring.test;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.jongodb.server.TcpMongoServer;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -12,19 +13,27 @@ import org.springframework.core.env.MapPropertySource;
 /**
  * Spring test initializer that starts an in-memory {@link TcpMongoServer} and wires MongoDB
  * properties for the test context.
+ *
+ * <p>By default each context gets a dedicated server. Set {@link #SHARED_SERVER_PROPERTY} to
+ * {@code true} to reuse one shared in-process server across multiple Spring contexts in the same JVM.
  */
 public final class JongodbMongoInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
     public static final String DEFAULT_DATABASE = "test";
     public static final String DATABASE_PROPERTY = "jongodb.test.database";
+    public static final String SHARED_SERVER_PROPERTY = "jongodb.test.sharedServer";
     public static final String SERVER_BEAN_NAME = "jongodbTcpMongoServer";
+    private static final Object SHARED_SERVER_LOCK = new Object();
+    private static final AtomicBoolean SHARED_SHUTDOWN_HOOK_REGISTERED = new AtomicBoolean(false);
+    private static TcpMongoServer sharedServer;
+    private static int sharedServerRefCount;
 
     @Override
     public void initialize(final ConfigurableApplicationContext context) {
         Objects.requireNonNull(context, "context");
 
         final String database = normalizeDatabase(context.getEnvironment().getProperty(DATABASE_PROPERTY));
-        final TcpMongoServer server = TcpMongoServer.inMemory();
-        server.start();
+        final boolean sharedServerEnabled = parseSharedServerEnabled(context.getEnvironment().getProperty(SHARED_SERVER_PROPERTY));
+        final TcpMongoServer server = sharedServerEnabled ? acquireSharedServer() : startDedicatedServer();
 
         final Map<String, Object> properties = new LinkedHashMap<>();
         properties.put("spring.data.mongodb.uri", server.connectionString(database));
@@ -35,9 +44,75 @@ public final class JongodbMongoInitializer implements ApplicationContextInitiali
         context.getBeanFactory().registerSingleton(SERVER_BEAN_NAME, server);
         context.addApplicationListener(event -> {
             if (event instanceof ContextClosedEvent) {
-                server.close();
+                if (sharedServerEnabled) {
+                    releaseSharedServer();
+                } else {
+                    server.close();
+                }
             }
         });
+    }
+
+    /**
+     * Explicit cleanup hook for suites that opt into shared-server mode.
+     *
+     * <p>Shared servers are normally closed when the last shared Spring context closes.
+     * This method is useful in test teardown blocks to aggressively release the shared endpoint.
+     */
+    public static void stopSharedServer() {
+        synchronized (SHARED_SERVER_LOCK) {
+            closeSharedServerLocked();
+        }
+    }
+
+    private static TcpMongoServer startDedicatedServer() {
+        final TcpMongoServer server = TcpMongoServer.inMemory();
+        server.start();
+        return server;
+    }
+
+    private static TcpMongoServer acquireSharedServer() {
+        synchronized (SHARED_SERVER_LOCK) {
+            if (sharedServer != null && sharedServer.isRunning()) {
+                sharedServerRefCount++;
+                return sharedServer;
+            }
+            closeSharedServerLocked();
+            sharedServer = TcpMongoServer.inMemory();
+            sharedServer.start();
+            sharedServerRefCount = 1;
+            registerSharedShutdownHookOnce();
+            return sharedServer;
+        }
+    }
+
+    private static void releaseSharedServer() {
+        synchronized (SHARED_SERVER_LOCK) {
+            if (sharedServerRefCount <= 0) {
+                closeSharedServerLocked();
+                return;
+            }
+            sharedServerRefCount--;
+            if (sharedServerRefCount == 0) {
+                closeSharedServerLocked();
+            }
+        }
+    }
+
+    private static void registerSharedShutdownHookOnce() {
+        if (!SHARED_SHUTDOWN_HOOK_REGISTERED.compareAndSet(false, true)) {
+            return;
+        }
+        Runtime.getRuntime().addShutdownHook(new Thread(JongodbMongoInitializer::stopSharedServer, "jongodb-shared-tcp-shutdown"));
+    }
+
+    private static void closeSharedServerLocked() {
+        final TcpMongoServer previous = sharedServer;
+        sharedServer = null;
+        sharedServerRefCount = 0;
+        if (previous != null) {
+            previous.close();
+        }
     }
 
     private static String normalizeDatabase(final String candidate) {
@@ -45,5 +120,12 @@ public final class JongodbMongoInitializer implements ApplicationContextInitiali
             return DEFAULT_DATABASE;
         }
         return candidate.trim();
+    }
+
+    private static boolean parseSharedServerEnabled(final String rawValue) {
+        if (rawValue == null || rawValue.isBlank()) {
+            return false;
+        }
+        return Boolean.parseBoolean(rawValue.trim());
     }
 }


### PR DESCRIPTION
## Summary
- add opt-in shared-server mode to `JongodbMongoInitializer` via `jongodb.test.sharedServer=true`
- implement shared server lifecycle with reference counting, context-close release, and JVM shutdown-hook fallback
- keep default behavior unchanged (dedicated server per context) and expose `stopSharedServer()` for explicit suite teardown
- document shared mode usage and isolation caveats in Spring docs

## Tests
- ./.tooling/gradle-8.10.2/bin/gradle --no-daemon test --tests org.jongodb.spring.test.JongodbMongoInitializerTest --tests org.jongodb.spring.test.JongodbMongoTestDefaultWiringTest --tests org.jongodb.spring.test.JongodbMongoTestDatabaseOverrideWiringTest --tests org.jongodb.spring.test.JongodbMongoDynamicPropertySupportTest
- ./.tooling/gradle-8.10.2/bin/gradle --no-daemon test --tests 'org.jongodb.spring.test.*'

Closes #94
