### PR TITLE
[fixture] Manifest 스키마/프로파일 표준화

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Added declarative fixture manifest schema (`fixture-manifest.v1`) with standardized `dev`/`smoke`/`full` profile model.
+- Added fixture manifest loader/validator with path-aware aggregated validation errors.
+- Added deterministic fixture extraction planner + profile fingerprint generation.
+- Added sample fixture manifest templates under `testkit/fixture/manifests`.
+- Added fixture manifest onboarding documentation (`docs/FIXTURE_MANIFEST.md`).
+
 ## [0.1.3] - 2026-02-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Unsupported branches are standardized progressively as:
 
 - Usage: `docs/USAGE.md`
 - Spring integration: `docs/SPRING_TESTING.md`
+- Fixture manifest: `docs/FIXTURE_MANIFEST.md`
 - Compatibility boundary: `docs/COMPATIBILITY.md`
 - Complex-query certification: `docs/COMPLEX_QUERY_CERTIFICATION.md`
 - Support matrix: `docs/SUPPORT_MATRIX.md`

--- a/docs/FIXTURE_MANIFEST.md
+++ b/docs/FIXTURE_MANIFEST.md
@@ -1,0 +1,70 @@
+# Fixture Manifest
+
+`#249` introduces a declarative manifest contract for fixture extraction planning.
+
+Goal:
+- keep extraction criteria in one versioned file
+- standardize scenario profiles (`dev`, `smoke`, `full`)
+- guarantee deterministic profile-level plans with a reproducible fingerprint
+
+Current schema version:
+- `fixture-manifest.v1`
+
+## Schema (v1)
+
+Top-level fields:
+- `schemaVersion`: must be `fixture-manifest.v1`
+- `source.uriAlias`: source connection alias (for example `prod-main`)
+- `profiles.dev|smoke|full`: profile-specific extraction policy
+
+Profile fields:
+- `refreshMode`: `full` or `incremental`
+- `fieldRules.include|exclude`: optional default include/exclude rules
+- `collections[]`: per-collection extraction definitions
+
+Collection fields:
+- `database`, `collection`
+- `filter`, `projection`, `sort`, `limit`
+- `sample.size`, `sample.seed`
+- `fieldRules.include|exclude` (collection override/append)
+
+Validation highlights:
+- all three profiles (`dev`, `smoke`, `full`) are required
+- `limit` requires `sort`
+- `sample` requires positive `size`, non-empty `seed`, and `sort`
+- `incremental` profile requires `sort` for each collection
+- include/exclude overlap is rejected
+- all errors are aggregated with path-aware messages
+
+## Deterministic Profile Plan
+
+`FixtureExtractionPlanner.plan(...)` builds a profile plan only from a manifest.
+There is no planner API without a manifest input.
+
+The generated `FixtureExtractionPlan` includes:
+- source/profile/refresh metadata
+- canonical collection operations
+- deterministic `fingerprint` (FNV-1a 64-bit hex)
+
+This fingerprint can be stored in CI artifacts to verify that the same manifest/profile produced the same extraction intent.
+
+## Sample Manifests
+
+- `testkit/fixture/manifests/baseline-dev-smoke-full.json`
+- `testkit/fixture/manifests/incremental-events.json`
+- `testkit/fixture/manifests/sensitive-field-rules.json`
+
+These templates are intended for onboarding and can be copied as a starting point.
+
+## Java Usage
+
+```java
+Path manifestPath = Path.of("testkit/fixture/manifests/baseline-dev-smoke-full.json");
+FixtureManifest manifest = FixtureManifestLoader.load(manifestPath);
+
+FixtureExtractionPlan smokePlan = FixtureExtractionPlanner.plan(
+        manifest,
+        FixtureManifest.ScenarioProfile.SMOKE);
+
+System.out.println(smokePlan.fingerprint());
+```

--- a/src/main/java/org/jongodb/testkit/FixtureExtractionPlan.java
+++ b/src/main/java/org/jongodb/testkit/FixtureExtractionPlan.java
@@ -1,0 +1,110 @@
+package org.jongodb.testkit;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Deterministic extraction plan for one scenario profile.
+ */
+public record FixtureExtractionPlan(
+        String schemaVersion,
+        String sourceUriAlias,
+        FixtureManifest.ScenarioProfile profile,
+        FixtureManifest.RefreshMode refreshMode,
+        String fingerprint,
+        List<CollectionPlan> collections) {
+    public FixtureExtractionPlan {
+        schemaVersion = requireText(schemaVersion, "schemaVersion");
+        sourceUriAlias = requireText(sourceUriAlias, "sourceUriAlias");
+        profile = Objects.requireNonNull(profile, "profile");
+        refreshMode = Objects.requireNonNull(refreshMode, "refreshMode");
+        fingerprint = requireText(fingerprint, "fingerprint");
+        collections = List.copyOf(Objects.requireNonNull(collections, "collections"));
+    }
+
+    public String toJson() {
+        return DiffSummaryGenerator.JsonEncoder.encode(toMap());
+    }
+
+    Map<String, Object> toMap() {
+        final Map<String, Object> root = new LinkedHashMap<>();
+        root.put("schemaVersion", schemaVersion);
+        root.put("sourceUriAlias", sourceUriAlias);
+        root.put("profile", profile.value());
+        root.put("refreshMode", refreshMode.value());
+        root.put("fingerprint", fingerprint);
+
+        final List<Map<String, Object>> collectionItems = new ArrayList<>(collections.size());
+        for (final CollectionPlan collection : collections) {
+            collectionItems.add(collection.toMap());
+        }
+        root.put("collections", collectionItems);
+        return root;
+    }
+
+    public record CollectionPlan(
+            String database,
+            String collection,
+            Map<String, Object> filter,
+            Map<String, Object> projection,
+            Map<String, Object> sort,
+            Integer limit,
+            FixtureManifest.SampleSpec sample,
+            List<String> includeFields,
+            List<String> excludeFields) {
+        public CollectionPlan {
+            database = requireText(database, "database");
+            collection = requireText(collection, "collection");
+            filter = Map.copyOf(Objects.requireNonNull(filter, "filter"));
+            projection = Map.copyOf(Objects.requireNonNull(projection, "projection"));
+            sort = Map.copyOf(Objects.requireNonNull(sort, "sort"));
+            if (limit != null && limit <= 0) {
+                throw new IllegalArgumentException("limit must be > 0");
+            }
+            includeFields = List.copyOf(Objects.requireNonNull(includeFields, "includeFields"));
+            excludeFields = List.copyOf(Objects.requireNonNull(excludeFields, "excludeFields"));
+        }
+
+        Map<String, Object> toMap() {
+            final Map<String, Object> root = new LinkedHashMap<>();
+            root.put("database", database);
+            root.put("collection", collection);
+            if (!filter.isEmpty()) {
+                root.put("filter", filter);
+            }
+            if (!projection.isEmpty()) {
+                root.put("projection", projection);
+            }
+            if (!sort.isEmpty()) {
+                root.put("sort", sort);
+            }
+            if (limit != null) {
+                root.put("limit", limit);
+            }
+            if (sample != null) {
+                root.put("sample", sample.toMap());
+            }
+            if (!includeFields.isEmpty()) {
+                root.put("includeFields", includeFields);
+            }
+            if (!excludeFields.isEmpty()) {
+                root.put("excludeFields", excludeFields);
+            }
+            return root;
+        }
+    }
+
+    private static String requireText(final String value, final String fieldName) {
+        if (value == null) {
+            throw new IllegalArgumentException(fieldName + " must not be null");
+        }
+        final String trimmed = value.trim();
+        if (trimmed.isEmpty()) {
+            throw new IllegalArgumentException(fieldName + " must not be blank");
+        }
+        return trimmed;
+    }
+}

--- a/src/main/java/org/jongodb/testkit/FixtureExtractionPlanner.java
+++ b/src/main/java/org/jongodb/testkit/FixtureExtractionPlanner.java
@@ -1,0 +1,118 @@
+package org.jongodb.testkit;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Builds deterministic extraction plans from a manifest/profile pair.
+ *
+ * <p>By design, planning requires an explicit manifest. There is no planner API without one.
+ */
+public final class FixtureExtractionPlanner {
+    private FixtureExtractionPlanner() {}
+
+    public static FixtureExtractionPlan plan(
+            final Path manifestPath,
+            final FixtureManifest.ScenarioProfile profile) throws IOException {
+        final FixtureManifest manifest = FixtureManifestLoader.load(manifestPath);
+        return plan(manifest, profile);
+    }
+
+    public static FixtureExtractionPlan plan(
+            final FixtureManifest manifest,
+            final FixtureManifest.ScenarioProfile profile) {
+        final FixtureManifest sourceManifest = Objects.requireNonNull(manifest, "manifest");
+        final FixtureManifest.ScenarioProfile sourceProfile = Objects.requireNonNull(profile, "profile");
+
+        FixtureManifestValidator.validateOrThrow(sourceManifest);
+        final FixtureManifest.ProfileConfig profileConfig = sourceManifest.profile(sourceProfile);
+
+        final List<FixtureExtractionPlan.CollectionPlan> collectionPlans =
+                new ArrayList<>(profileConfig.collections().size());
+        for (final FixtureManifest.CollectionRule rule : profileConfig.collections()) {
+            final FixtureManifest.FieldRules effectiveRules =
+                    profileConfig.fieldRules().mergeWith(rule.fieldRules());
+            collectionPlans.add(new FixtureExtractionPlan.CollectionPlan(
+                    rule.database(),
+                    rule.collection(),
+                    rule.filter(),
+                    rule.projection(),
+                    rule.sort(),
+                    rule.limit(),
+                    rule.sample(),
+                    effectiveRules.include(),
+                    effectiveRules.exclude()));
+        }
+
+        collectionPlans.sort((left, right) -> {
+            final int dbCompare = left.database().compareTo(right.database());
+            if (dbCompare != 0) {
+                return dbCompare;
+            }
+            return left.collection().compareTo(right.collection());
+        });
+
+        final String fingerprint = computeFingerprint(
+                sourceManifest.schemaVersion(),
+                sourceManifest.source().uriAlias(),
+                sourceProfile,
+                profileConfig.refreshMode(),
+                collectionPlans);
+
+        return new FixtureExtractionPlan(
+                sourceManifest.schemaVersion(),
+                sourceManifest.source().uriAlias(),
+                sourceProfile,
+                profileConfig.refreshMode(),
+                fingerprint,
+                collectionPlans);
+    }
+
+    private static String computeFingerprint(
+            final String schemaVersion,
+            final String sourceUriAlias,
+            final FixtureManifest.ScenarioProfile profile,
+            final FixtureManifest.RefreshMode refreshMode,
+            final List<FixtureExtractionPlan.CollectionPlan> collectionPlans) {
+        final Map<String, Object> digestRoot = new LinkedHashMap<>();
+        digestRoot.put("schemaVersion", schemaVersion);
+        digestRoot.put("sourceUriAlias", sourceUriAlias);
+        digestRoot.put("profile", profile.value());
+        digestRoot.put("refreshMode", refreshMode.value());
+        final List<Map<String, Object>> collectionItems = new ArrayList<>(collectionPlans.size());
+        for (final FixtureExtractionPlan.CollectionPlan plan : collectionPlans) {
+            collectionItems.add(plan.toMap());
+        }
+        digestRoot.put("collections", collectionItems);
+        final String canonical = DiffSummaryGenerator.JsonEncoder.encode(digestRoot);
+        return toUnsignedHex(fnv1a64(canonical));
+    }
+
+    private static long fnv1a64(final String value) {
+        final String normalized = Objects.requireNonNull(value, "value");
+        long hash = 0xcbf29ce484222325L;
+        for (int i = 0; i < normalized.length(); i++) {
+            hash ^= normalized.charAt(i);
+            hash *= 0x100000001b3L;
+        }
+        return hash;
+    }
+
+    private static String toUnsignedHex(final long value) {
+        String hex = Long.toUnsignedString(value, 16);
+        if (hex.length() >= 16) {
+            return hex;
+        }
+        final StringBuilder sb = new StringBuilder(16);
+        for (int i = hex.length(); i < 16; i++) {
+            sb.append('0');
+        }
+        sb.append(hex);
+        return sb.toString();
+    }
+}

--- a/src/main/java/org/jongodb/testkit/FixtureManifest.java
+++ b/src/main/java/org/jongodb/testkit/FixtureManifest.java
@@ -1,0 +1,454 @@
+package org.jongodb.testkit;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeSet;
+import org.bson.Document;
+
+/**
+ * Declarative fixture extraction manifest model.
+ */
+public record FixtureManifest(
+        String schemaVersion,
+        Source source,
+        Map<ScenarioProfile, ProfileConfig> profiles) {
+    public static final String SCHEMA_VERSION = "fixture-manifest.v1";
+
+    public FixtureManifest {
+        schemaVersion = requireText(schemaVersion, "schemaVersion");
+        source = Objects.requireNonNull(source, "source");
+        profiles = unmodifiableMapCopy(Objects.requireNonNull(profiles, "profiles"));
+    }
+
+    public static FixtureManifest fromJson(final String json) {
+        final Document document = Document.parse(Objects.requireNonNull(json, "json"));
+        return fromMap(asStringMap(document, "manifest"));
+    }
+
+    public static FixtureManifest fromMap(final Map<String, Object> root) {
+        Objects.requireNonNull(root, "root");
+        final String schemaVersion = requireText((String) root.get("schemaVersion"), "schemaVersion");
+        final Source source = Source.fromMap(asStringMap(root.get("source"), "source"), "source");
+
+        final Map<String, Object> profileRoot = asStringMap(root.get("profiles"), "profiles");
+        final Map<ScenarioProfile, ProfileConfig> profiles = new LinkedHashMap<>();
+        for (final Map.Entry<String, Object> entry : profileRoot.entrySet()) {
+            final ScenarioProfile scenarioProfile = ScenarioProfile.fromText(entry.getKey());
+            final String path = "profiles." + scenarioProfile.value();
+            final ProfileConfig profileConfig = ProfileConfig.fromMap(
+                    scenarioProfile,
+                    asStringMap(entry.getValue(), path),
+                    path);
+            profiles.put(scenarioProfile, profileConfig);
+        }
+
+        return new FixtureManifest(schemaVersion, source, profiles);
+    }
+
+    public String toJson() {
+        return DiffSummaryGenerator.JsonEncoder.encode(toMap());
+    }
+
+    public ProfileConfig profile(final ScenarioProfile profile) {
+        final ScenarioProfile target = Objects.requireNonNull(profile, "profile");
+        final ProfileConfig config = profiles.get(target);
+        if (config == null) {
+            throw new IllegalArgumentException("profile '" + target.value() + "' is not defined in manifest");
+        }
+        return config;
+    }
+
+    Map<String, Object> toMap() {
+        final Map<String, Object> root = new LinkedHashMap<>();
+        root.put("schemaVersion", schemaVersion);
+        root.put("source", source.toMap());
+
+        final Map<String, Object> profileRoot = new LinkedHashMap<>();
+        for (final ScenarioProfile profile : ScenarioProfile.values()) {
+            final ProfileConfig config = profiles.get(profile);
+            if (config != null) {
+                profileRoot.put(profile.value(), config.toMap());
+            }
+        }
+        root.put("profiles", profileRoot);
+        return root;
+    }
+
+    public enum ScenarioProfile {
+        DEV("dev"),
+        SMOKE("smoke"),
+        FULL("full");
+
+        private final String value;
+
+        ScenarioProfile(final String value) {
+            this.value = value;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        static ScenarioProfile fromText(final String rawValue) {
+            final String value = requireText(rawValue, "profile").toLowerCase(Locale.ROOT);
+            for (final ScenarioProfile profile : values()) {
+                if (profile.value.equals(value)) {
+                    return profile;
+                }
+            }
+            throw new IllegalArgumentException("unsupported profile: " + rawValue + " (expected: dev|smoke|full)");
+        }
+    }
+
+    public enum RefreshMode {
+        FULL("full"),
+        INCREMENTAL("incremental");
+
+        private final String value;
+
+        RefreshMode(final String value) {
+            this.value = value;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        static RefreshMode fromText(final String rawValue, final String fieldName) {
+            final String value = requireText(rawValue, fieldName).toLowerCase(Locale.ROOT);
+            for (final RefreshMode mode : values()) {
+                if (mode.value.equals(value)) {
+                    return mode;
+                }
+            }
+            throw new IllegalArgumentException(
+                    fieldName + " must be one of: full|incremental (actual: " + rawValue + ")");
+        }
+    }
+
+    public record Source(String uriAlias) {
+        public Source {
+            uriAlias = requireText(uriAlias, "source.uriAlias");
+        }
+
+        static Source fromMap(final Map<String, Object> root, final String path) {
+            return new Source(requireText((String) root.get("uriAlias"), path + ".uriAlias"));
+        }
+
+        Map<String, Object> toMap() {
+            final Map<String, Object> root = new LinkedHashMap<>();
+            root.put("uriAlias", uriAlias);
+            return root;
+        }
+    }
+
+    public record ProfileConfig(
+            ScenarioProfile profile,
+            RefreshMode refreshMode,
+            FieldRules fieldRules,
+            List<CollectionRule> collections) {
+        public ProfileConfig {
+            profile = Objects.requireNonNull(profile, "profile");
+            refreshMode = Objects.requireNonNull(refreshMode, "refreshMode");
+            fieldRules = Objects.requireNonNull(fieldRules, "fieldRules");
+            collections = List.copyOf(Objects.requireNonNull(collections, "collections"));
+        }
+
+        static ProfileConfig fromMap(
+                final ScenarioProfile profile,
+                final Map<String, Object> root,
+                final String path) {
+            final String refreshRaw = (String) root.getOrDefault("refreshMode", RefreshMode.FULL.value());
+            final RefreshMode refreshMode = RefreshMode.fromText(refreshRaw, path + ".refreshMode");
+            final FieldRules fieldRules = FieldRules.fromObject(root.get("fieldRules"), path + ".fieldRules");
+            final List<Object> collectionRaw = asList(root.get("collections"), path + ".collections");
+            final List<CollectionRule> collections = new ArrayList<>(collectionRaw.size());
+            for (int i = 0; i < collectionRaw.size(); i++) {
+                collections.add(CollectionRule.fromMap(
+                        asStringMap(collectionRaw.get(i), path + ".collections[" + i + "]"),
+                        path + ".collections[" + i + "]"));
+            }
+            return new ProfileConfig(profile, refreshMode, fieldRules, collections);
+        }
+
+        Map<String, Object> toMap() {
+            final Map<String, Object> root = new LinkedHashMap<>();
+            root.put("refreshMode", refreshMode.value());
+            if (!fieldRules.isEmpty()) {
+                root.put("fieldRules", fieldRules.toMap());
+            }
+            final List<Map<String, Object>> collectionItems = new ArrayList<>(collections.size());
+            for (final CollectionRule collection : collections) {
+                collectionItems.add(collection.toMap());
+            }
+            root.put("collections", collectionItems);
+            return root;
+        }
+    }
+
+    public record CollectionRule(
+            String database,
+            String collection,
+            Map<String, Object> filter,
+            Map<String, Object> projection,
+            Map<String, Object> sort,
+            Integer limit,
+            SampleSpec sample,
+            FieldRules fieldRules) {
+        public CollectionRule {
+            database = requireText(database, "database");
+            collection = requireText(collection, "collection");
+            filter = canonicalizeMap(filter);
+            projection = canonicalizeMap(projection);
+            sort = canonicalizeMap(sort);
+            fieldRules = Objects.requireNonNull(fieldRules, "fieldRules");
+        }
+
+        static CollectionRule fromMap(final Map<String, Object> root, final String path) {
+            final String database = requireText((String) root.get("database"), path + ".database");
+            final String collection = requireText((String) root.get("collection"), path + ".collection");
+            final Map<String, Object> filter = asOptionalMap(root.get("filter"), path + ".filter");
+            final Map<String, Object> projection = asOptionalMap(root.get("projection"), path + ".projection");
+            final Map<String, Object> sort = asOptionalMap(root.get("sort"), path + ".sort");
+            final Integer limit = optionalInt(root.get("limit"), path + ".limit");
+            final SampleSpec sample = root.containsKey("sample")
+                    ? SampleSpec.fromMap(asStringMap(root.get("sample"), path + ".sample"), path + ".sample")
+                    : null;
+            final FieldRules fieldRules = FieldRules.fromObject(root.get("fieldRules"), path + ".fieldRules");
+            return new CollectionRule(database, collection, filter, projection, sort, limit, sample, fieldRules);
+        }
+
+        Map<String, Object> toMap() {
+            final Map<String, Object> root = new LinkedHashMap<>();
+            root.put("database", database);
+            root.put("collection", collection);
+            if (!filter.isEmpty()) {
+                root.put("filter", filter);
+            }
+            if (!projection.isEmpty()) {
+                root.put("projection", projection);
+            }
+            if (!sort.isEmpty()) {
+                root.put("sort", sort);
+            }
+            if (limit != null) {
+                root.put("limit", limit);
+            }
+            if (sample != null) {
+                root.put("sample", sample.toMap());
+            }
+            if (!fieldRules.isEmpty()) {
+                root.put("fieldRules", fieldRules.toMap());
+            }
+            return root;
+        }
+
+        String key() {
+            return database + "." + collection;
+        }
+    }
+
+    public record SampleSpec(int size, String seed) {
+        public SampleSpec {
+            seed = requireText(seed, "sample.seed");
+        }
+
+        static SampleSpec fromMap(final Map<String, Object> root, final String path) {
+            final int size = requireInt(root.get("size"), path + ".size");
+            final String seed = requireText((String) root.get("seed"), path + ".seed");
+            return new SampleSpec(size, seed);
+        }
+
+        Map<String, Object> toMap() {
+            final Map<String, Object> root = new LinkedHashMap<>();
+            root.put("size", size);
+            root.put("seed", seed);
+            return root;
+        }
+    }
+
+    public record FieldRules(List<String> include, List<String> exclude) {
+        public FieldRules {
+            include = normalizeFieldList(include, "include");
+            exclude = normalizeFieldList(exclude, "exclude");
+        }
+
+        static FieldRules empty() {
+            return new FieldRules(List.of(), List.of());
+        }
+
+        static FieldRules fromObject(final Object value, final String path) {
+            if (value == null) {
+                return empty();
+            }
+            final Map<String, Object> root = asStringMap(value, path);
+            final List<String> include = optionalFieldList(root.get("include"), path + ".include");
+            final List<String> exclude = optionalFieldList(root.get("exclude"), path + ".exclude");
+            return new FieldRules(include, exclude);
+        }
+
+        boolean isEmpty() {
+            return include.isEmpty() && exclude.isEmpty();
+        }
+
+        FieldRules mergeWith(final FieldRules overrideRules) {
+            final FieldRules override = Objects.requireNonNull(overrideRules, "overrideRules");
+            final List<String> mergedInclude = mergeOrdered(include, override.include());
+            final List<String> mergedExclude = mergeOrdered(exclude, override.exclude());
+            return new FieldRules(mergedInclude, mergedExclude);
+        }
+
+        Map<String, Object> toMap() {
+            final Map<String, Object> root = new LinkedHashMap<>();
+            if (!include.isEmpty()) {
+                root.put("include", include);
+            }
+            if (!exclude.isEmpty()) {
+                root.put("exclude", exclude);
+            }
+            return root;
+        }
+
+        private static List<String> mergeOrdered(final List<String> base, final List<String> override) {
+            final LinkedHashSet<String> merged = new LinkedHashSet<>();
+            merged.addAll(base);
+            merged.addAll(override);
+            return List.copyOf(merged);
+        }
+
+        private static List<String> normalizeFieldList(final List<String> values, final String fieldName) {
+            final List<String> source = values == null ? List.of() : values;
+            final LinkedHashSet<String> normalized = new LinkedHashSet<>();
+            for (int i = 0; i < source.size(); i++) {
+                final String value = requireText(source.get(i), fieldName + "[" + i + "]");
+                normalized.add(value);
+            }
+            return List.copyOf(normalized);
+        }
+    }
+
+    private static Map<String, Object> asOptionalMap(final Object value, final String fieldName) {
+        if (value == null) {
+            return Map.of();
+        }
+        return asStringMap(value, fieldName);
+    }
+
+    private static int requireInt(final Object value, final String fieldName) {
+        if (!(value instanceof Number number)) {
+            throw new IllegalArgumentException(fieldName + " must be numeric");
+        }
+        return number.intValue();
+    }
+
+    private static Integer optionalInt(final Object value, final String fieldName) {
+        if (value == null) {
+            return null;
+        }
+        return requireInt(value, fieldName);
+    }
+
+    private static List<String> optionalFieldList(final Object value, final String fieldName) {
+        if (value == null) {
+            return List.of();
+        }
+        final List<Object> raw = asList(value, fieldName);
+        final List<String> normalized = new ArrayList<>(raw.size());
+        for (int i = 0; i < raw.size(); i++) {
+            normalized.add(requireText(String.valueOf(raw.get(i)), fieldName + "[" + i + "]"));
+        }
+        return normalized;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> asStringMap(final Object value, final String fieldName) {
+        if (!(value instanceof Map<?, ?> map)) {
+            throw new IllegalArgumentException(fieldName + " must be an object");
+        }
+        final Map<String, Object> normalized = new LinkedHashMap<>();
+        for (final Map.Entry<?, ?> entry : map.entrySet()) {
+            normalized.put(String.valueOf(entry.getKey()), canonicalizeValue(entry.getValue()));
+        }
+        return Collections.unmodifiableMap(normalized);
+    }
+
+    private static List<Object> asList(final Object value, final String fieldName) {
+        if (!(value instanceof List<?> list)) {
+            throw new IllegalArgumentException(fieldName + " must be an array");
+        }
+        final List<Object> normalized = new ArrayList<>(list.size());
+        for (final Object item : list) {
+            normalized.add(canonicalizeValue(item));
+        }
+        return Collections.unmodifiableList(normalized);
+    }
+
+    private static Map<String, Object> canonicalizeMap(final Map<String, Object> source) {
+        final Map<String, Object> input = source == null ? Map.of() : source;
+        final Map<String, Object> canonical = new LinkedHashMap<>();
+        final TreeSet<String> keys = new TreeSet<>(input.keySet());
+        for (final String key : keys) {
+            canonical.put(key, canonicalizeValue(input.get(key)));
+        }
+        return Collections.unmodifiableMap(canonical);
+    }
+
+    private static Object canonicalizeValue(final Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Map<?, ?> mapValue) {
+            final Map<String, Object> canonical = new LinkedHashMap<>();
+            final TreeSet<String> keys = new TreeSet<>();
+            for (final Object key : mapValue.keySet()) {
+                keys.add(String.valueOf(key));
+            }
+            for (final String key : keys) {
+                canonical.put(key, canonicalizeValue(mapValue.get(key)));
+            }
+            return Collections.unmodifiableMap(canonical);
+        }
+        if (value instanceof Collection<?> collection) {
+            final List<Object> canonical = new ArrayList<>(collection.size());
+            for (final Object item : collection) {
+                canonical.add(canonicalizeValue(item));
+            }
+            return Collections.unmodifiableList(canonical);
+        }
+        return value;
+    }
+
+    private static Map<ScenarioProfile, ProfileConfig> unmodifiableMapCopy(
+            final Map<ScenarioProfile, ProfileConfig> source) {
+        final Map<ScenarioProfile, ProfileConfig> copy = new LinkedHashMap<>();
+        for (final ScenarioProfile profile : ScenarioProfile.values()) {
+            if (source.containsKey(profile)) {
+                copy.put(profile, source.get(profile));
+            }
+        }
+        for (final Map.Entry<ScenarioProfile, ProfileConfig> entry : source.entrySet()) {
+            if (!copy.containsKey(entry.getKey())) {
+                copy.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return Collections.unmodifiableMap(copy);
+    }
+
+    private static String requireText(final String value, final String fieldName) {
+        if (value == null) {
+            throw new IllegalArgumentException(fieldName + " must not be null");
+        }
+        final String trimmed = value.trim();
+        if (trimmed.isEmpty()) {
+            throw new IllegalArgumentException(fieldName + " must not be blank");
+        }
+        return trimmed;
+    }
+}

--- a/src/main/java/org/jongodb/testkit/FixtureManifestLoader.java
+++ b/src/main/java/org/jongodb/testkit/FixtureManifestLoader.java
@@ -1,0 +1,60 @@
+package org.jongodb.testkit;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * Loads fixture manifest files (JSON or YAML) and validates schema constraints.
+ */
+public final class FixtureManifestLoader {
+    private FixtureManifestLoader() {}
+
+    public static FixtureManifest load(final Path manifestPath) throws IOException {
+        Objects.requireNonNull(manifestPath, "manifestPath");
+        final Path normalized = manifestPath.toAbsolutePath().normalize();
+        if (!Files.exists(normalized)) {
+            throw new IllegalArgumentException("manifest path does not exist: " + normalized);
+        }
+        if (!Files.isRegularFile(normalized)) {
+            throw new IllegalArgumentException("manifest path must be a file: " + normalized);
+        }
+
+        final String content = Files.readString(normalized, StandardCharsets.UTF_8);
+        final FixtureManifest manifest = parse(content, normalized.getFileName().toString());
+        FixtureManifestValidator.validateOrThrow(manifest);
+        return manifest;
+    }
+
+    static FixtureManifest parse(final String content, final String sourceName) {
+        Objects.requireNonNull(content, "content");
+        final String normalizedName = Objects.requireNonNull(sourceName, "sourceName")
+                .trim()
+                .toLowerCase(Locale.ROOT);
+        if (normalizedName.endsWith(".yaml") || normalizedName.endsWith(".yml")) {
+            return parseYaml(content);
+        }
+        return FixtureManifest.fromJson(content);
+    }
+
+    private static FixtureManifest parseYaml(final String content) {
+        final Object root = new Yaml().load(content);
+        if (root == null) {
+            throw new IllegalArgumentException("manifest is empty");
+        }
+        if (!(root instanceof Map<?, ?> rawMap)) {
+            throw new IllegalArgumentException("manifest root must be an object");
+        }
+        final Map<String, Object> normalized = new LinkedHashMap<>();
+        for (final Map.Entry<?, ?> entry : rawMap.entrySet()) {
+            normalized.put(String.valueOf(entry.getKey()), entry.getValue());
+        }
+        return FixtureManifest.fromMap(normalized);
+    }
+}

--- a/src/main/java/org/jongodb/testkit/FixtureManifestValidationException.java
+++ b/src/main/java/org/jongodb/testkit/FixtureManifestValidationException.java
@@ -1,0 +1,35 @@
+package org.jongodb.testkit;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Aggregated fixture manifest validation errors.
+ */
+public final class FixtureManifestValidationException extends IllegalArgumentException {
+    private final List<String> errors;
+
+    public FixtureManifestValidationException(final List<String> errors) {
+        super(formatMessage(errors));
+        this.errors = List.copyOf(Objects.requireNonNull(errors, "errors"));
+    }
+
+    public List<String> errors() {
+        return errors;
+    }
+
+    private static String formatMessage(final List<String> errors) {
+        final List<String> normalized = List.copyOf(Objects.requireNonNull(errors, "errors"));
+        if (normalized.isEmpty()) {
+            return "fixture manifest validation failed";
+        }
+        final StringBuilder sb = new StringBuilder();
+        sb.append("fixture manifest validation failed (")
+                .append(normalized.size())
+                .append(" issue(s))");
+        for (final String error : normalized) {
+            sb.append('\n').append("- ").append(error);
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/org/jongodb/testkit/FixtureManifestValidator.java
+++ b/src/main/java/org/jongodb/testkit/FixtureManifestValidator.java
@@ -1,0 +1,178 @@
+package org.jongodb.testkit;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Static validator for {@link FixtureManifest}.
+ */
+public final class FixtureManifestValidator {
+    private static final Pattern URI_ALIAS_PATTERN = Pattern.compile("^[a-zA-Z0-9._-]+$");
+    private static final Pattern FIELD_PATH_PATTERN = Pattern.compile("^[a-zA-Z0-9_.$]+$");
+
+    private FixtureManifestValidator() {}
+
+    public static void validateOrThrow(final FixtureManifest manifest) {
+        final List<String> errors = validate(manifest);
+        if (!errors.isEmpty()) {
+            throw new FixtureManifestValidationException(errors);
+        }
+    }
+
+    public static List<String> validate(final FixtureManifest manifest) {
+        Objects.requireNonNull(manifest, "manifest");
+        final List<String> errors = new ArrayList<>();
+
+        if (!FixtureManifest.SCHEMA_VERSION.equals(manifest.schemaVersion())) {
+            errors.add("schemaVersion must be '" + FixtureManifest.SCHEMA_VERSION
+                    + "' (actual: " + manifest.schemaVersion() + ")");
+        }
+        validateSource(manifest.source(), errors);
+        validateProfiles(manifest, errors);
+        return List.copyOf(errors);
+    }
+
+    private static void validateSource(final FixtureManifest.Source source, final List<String> errors) {
+        if (source.uriAlias().length() < 2) {
+            errors.add("source.uriAlias must be at least 2 characters");
+        }
+        if (!URI_ALIAS_PATTERN.matcher(source.uriAlias()).matches()) {
+            errors.add("source.uriAlias may contain only letters, numbers, dot, underscore, and hyphen");
+        }
+    }
+
+    private static void validateProfiles(final FixtureManifest manifest, final List<String> errors) {
+        final EnumSet<FixtureManifest.ScenarioProfile> expected = EnumSet.allOf(FixtureManifest.ScenarioProfile.class);
+        final Set<FixtureManifest.ScenarioProfile> provided = manifest.profiles().keySet();
+        for (final FixtureManifest.ScenarioProfile profile : expected) {
+            if (!provided.contains(profile)) {
+                errors.add("profiles." + profile.value() + " is required");
+            }
+        }
+
+        for (final FixtureManifest.ScenarioProfile profile : provided) {
+            final FixtureManifest.ProfileConfig config = manifest.profiles().get(profile);
+            final String path = "profiles." + profile.value();
+            if (config == null) {
+                errors.add(path + " must not be null");
+                continue;
+            }
+            validateProfile(path, config, errors);
+        }
+    }
+
+    private static void validateProfile(
+            final String path,
+            final FixtureManifest.ProfileConfig profileConfig,
+            final List<String> errors) {
+        if (profileConfig.collections().isEmpty()) {
+            errors.add(path + ".collections must not be empty");
+        }
+        validateFieldRules(path + ".fieldRules", profileConfig.fieldRules(), errors);
+
+        final Set<String> seenCollections = new HashSet<>();
+        for (int i = 0; i < profileConfig.collections().size(); i++) {
+            final FixtureManifest.CollectionRule collection = profileConfig.collections().get(i);
+            final String collectionPath = path + ".collections[" + i + "]";
+            final String key = collection.key().toLowerCase(Locale.ROOT);
+            if (!seenCollections.add(key)) {
+                errors.add(collectionPath + " duplicates collection '" + collection.key() + "'");
+            }
+            validateCollection(collectionPath, profileConfig.refreshMode(), collection, errors);
+        }
+    }
+
+    private static void validateCollection(
+            final String path,
+            final FixtureManifest.RefreshMode refreshMode,
+            final FixtureManifest.CollectionRule collection,
+            final List<String> errors) {
+        if (collection.limit() != null && collection.limit() <= 0) {
+            errors.add(path + ".limit must be > 0 when provided");
+        }
+        if (collection.limit() != null && collection.sort().isEmpty()) {
+            errors.add(path + ".sort is required when limit is set (deterministic top-N extraction)");
+        }
+        if (collection.sample() != null) {
+            if (collection.sample().size() <= 0) {
+                errors.add(path + ".sample.size must be > 0");
+            }
+            if (collection.sample().seed().isBlank()) {
+                errors.add(path + ".sample.seed must not be blank");
+            }
+            if (collection.sort().isEmpty()) {
+                errors.add(path + ".sort is required when sample is set (deterministic sample ordering)");
+            }
+        }
+        if (refreshMode == FixtureManifest.RefreshMode.INCREMENTAL && collection.sort().isEmpty()) {
+            errors.add(path + ".sort is required for incremental refresh mode");
+        }
+        validateSort(path + ".sort", collection.sort(), errors);
+        validateFieldRules(path + ".fieldRules", collection.fieldRules(), errors);
+    }
+
+    private static void validateSort(
+            final String path,
+            final java.util.Map<String, Object> sort,
+            final List<String> errors) {
+        for (final java.util.Map.Entry<String, Object> entry : sort.entrySet()) {
+            final String fieldPath = entry.getKey();
+            if (!isValidFieldPath(fieldPath)) {
+                errors.add(path + "." + fieldPath + " is not a valid field path");
+            }
+            final Object value = entry.getValue();
+            if (!(value instanceof Number number)) {
+                errors.add(path + "." + fieldPath + " sort direction must be numeric 1 or -1");
+                continue;
+            }
+            final int direction = number.intValue();
+            if (direction != 1 && direction != -1) {
+                errors.add(path + "." + fieldPath + " sort direction must be 1 or -1");
+            }
+        }
+    }
+
+    private static void validateFieldRules(
+            final String path,
+            final FixtureManifest.FieldRules rules,
+            final List<String> errors) {
+        final Set<String> include = new HashSet<>();
+        for (final String field : rules.include()) {
+            if (!isValidFieldPath(field)) {
+                errors.add(path + ".include contains invalid field path '" + field + "'");
+            }
+            include.add(field);
+        }
+
+        final Set<String> overlap = new HashSet<>();
+        for (final String field : rules.exclude()) {
+            if (!isValidFieldPath(field)) {
+                errors.add(path + ".exclude contains invalid field path '" + field + "'");
+            }
+            if (include.contains(field)) {
+                overlap.add(field);
+            }
+        }
+        if (!overlap.isEmpty()) {
+            errors.add(path + " include/exclude overlap is not allowed: " + overlap);
+        }
+    }
+
+    private static boolean isValidFieldPath(final String fieldPath) {
+        if (fieldPath == null || fieldPath.isBlank()) {
+            return false;
+        }
+        if (!FIELD_PATH_PATTERN.matcher(fieldPath).matches()) {
+            return false;
+        }
+        return !fieldPath.startsWith(".")
+                && !fieldPath.endsWith(".")
+                && !fieldPath.contains("..");
+    }
+}

--- a/src/test/java/org/jongodb/testkit/FixtureExtractionPlannerTest.java
+++ b/src/test/java/org/jongodb/testkit/FixtureExtractionPlannerTest.java
@@ -1,0 +1,58 @@
+package org.jongodb.testkit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class FixtureExtractionPlannerTest {
+    @Test
+    void producesDeterministicFingerprintPerProfile() throws Exception {
+        final FixtureManifest manifest =
+                FixtureManifestLoader.load(java.nio.file.Path.of("testkit/fixture/manifests/baseline-dev-smoke-full.json"));
+
+        final FixtureExtractionPlan first = FixtureExtractionPlanner.plan(
+                manifest,
+                FixtureManifest.ScenarioProfile.DEV);
+        final FixtureExtractionPlan second = FixtureExtractionPlanner.plan(
+                manifest,
+                FixtureManifest.ScenarioProfile.DEV);
+        final FixtureExtractionPlan smoke = FixtureExtractionPlanner.plan(
+                manifest,
+                FixtureManifest.ScenarioProfile.SMOKE);
+
+        assertEquals(first.fingerprint(), second.fingerprint());
+        assertNotEquals(first.fingerprint(), smoke.fingerprint());
+        assertEquals(FixtureManifest.SCHEMA_VERSION, first.schemaVersion());
+        assertEquals("dev", first.profile().value());
+        assertTrue(first.collections().size() >= 1);
+    }
+
+    @Test
+    void failsWhenManifestDoesNotMeetSchemaContract() {
+        final String invalidManifestJson =
+                """
+                {
+                  "schemaVersion": "fixture-manifest.v1",
+                  "source": { "uriAlias": "prod-core" },
+                  "profiles": {
+                    "dev": {
+                      "refreshMode": "full",
+                      "collections": [
+                        { "database": "app", "collection": "users", "limit": 10 }
+                      ]
+                    }
+                  }
+                }
+                """;
+        final FixtureManifest manifest = FixtureManifest.fromJson(invalidManifestJson);
+
+        final FixtureManifestValidationException error = assertThrows(
+                FixtureManifestValidationException.class,
+                () -> FixtureExtractionPlanner.plan(manifest, FixtureManifest.ScenarioProfile.DEV));
+        assertTrue(error.getMessage().contains("profiles.smoke is required"));
+        assertTrue(error.getMessage().contains("profiles.full is required"));
+    }
+}

--- a/src/test/java/org/jongodb/testkit/FixtureManifestLoaderTest.java
+++ b/src/test/java/org/jongodb/testkit/FixtureManifestLoaderTest.java
@@ -1,0 +1,37 @@
+package org.jongodb.testkit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class FixtureManifestLoaderTest {
+    @Test
+    void loadsJsonTemplateManifests() throws Exception {
+        final List<Path> templates = List.of(
+                Path.of("testkit/fixture/manifests/baseline-dev-smoke-full.json"),
+                Path.of("testkit/fixture/manifests/incremental-events.json"),
+                Path.of("testkit/fixture/manifests/sensitive-field-rules.json"));
+
+        for (final Path template : templates) {
+            final FixtureManifest manifest = FixtureManifestLoader.load(template);
+            assertEquals(FixtureManifest.SCHEMA_VERSION, manifest.schemaVersion());
+            assertEquals(3, manifest.profiles().size());
+            assertNotNull(manifest.profile(FixtureManifest.ScenarioProfile.DEV));
+            assertNotNull(manifest.profile(FixtureManifest.ScenarioProfile.SMOKE));
+            assertNotNull(manifest.profile(FixtureManifest.ScenarioProfile.FULL));
+        }
+    }
+
+    @Test
+    void returnsClearErrorForMissingManifestPath() {
+        final IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class,
+                () -> FixtureManifestLoader.load(Path.of("testkit/fixture/manifests/missing.json")));
+        assertTrue(error.getMessage().contains("manifest path does not exist"));
+    }
+}

--- a/src/test/java/org/jongodb/testkit/FixtureManifestValidatorTest.java
+++ b/src/test/java/org/jongodb/testkit/FixtureManifestValidatorTest.java
@@ -1,0 +1,65 @@
+package org.jongodb.testkit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class FixtureManifestValidatorTest {
+    @Test
+    void reportsFriendlyValidationErrors() {
+        final String invalidJson =
+                """
+                {
+                  "schemaVersion": "fixture-manifest.v2",
+                  "source": { "uriAlias": "x" },
+                  "profiles": {
+                    "dev": {
+                      "refreshMode": "full",
+                      "collections": [
+                        {
+                          "database": "app",
+                          "collection": "users",
+                          "limit": 10
+                        }
+                      ]
+                    },
+                    "smoke": {
+                      "refreshMode": "full",
+                      "collections": [
+                        {
+                          "database": "app",
+                          "collection": "orders",
+                          "sort": { "_id": 1 },
+                          "sample": { "size": 0, "seed": "smoke-seed" }
+                        }
+                      ]
+                    },
+                    "full": {
+                      "refreshMode": "incremental",
+                      "collections": [
+                        {
+                          "database": "app",
+                          "collection": "orders"
+                        }
+                      ]
+                    }
+                  }
+                }
+                """;
+
+        try {
+            final FixtureManifest manifest = FixtureManifest.fromJson(invalidJson);
+            final List<String> errors = FixtureManifestValidator.validate(manifest);
+
+            assertTrue(errors.stream().anyMatch(message -> message.contains("schemaVersion must be")));
+            assertTrue(errors.stream().anyMatch(message -> message.contains("source.uriAlias must be at least 2 characters")));
+            assertTrue(errors.stream().anyMatch(message -> message.contains("profiles.dev.collections[0].sort is required")));
+            assertTrue(errors.stream().anyMatch(message -> message.contains("profiles.smoke.collections[0].sample.size must be > 0")));
+            assertTrue(errors.stream().anyMatch(message -> message.contains("profiles.full.collections[0].sort is required for incremental refresh mode")));
+        } catch (final Exception e) {
+            fail("expected validation error list, but parsing threw: " + e.getMessage());
+        }
+    }
+}

--- a/testkit/fixture/manifests/baseline-dev-smoke-full.json
+++ b/testkit/fixture/manifests/baseline-dev-smoke-full.json
@@ -1,0 +1,140 @@
+{
+  "schemaVersion": "fixture-manifest.v1",
+  "source": {
+    "uriAlias": "prod-main"
+  },
+  "profiles": {
+    "dev": {
+      "refreshMode": "full",
+      "fieldRules": {
+        "exclude": [
+          "auditTrail",
+          "debugMetadata"
+        ]
+      },
+      "collections": [
+        {
+          "database": "app",
+          "collection": "users",
+          "filter": {
+            "status": "ACTIVE"
+          },
+          "projection": {
+            "_id": 1,
+            "email": 1,
+            "profile": 1,
+            "updatedAt": 1
+          },
+          "sort": {
+            "_id": 1
+          },
+          "limit": 1000,
+          "fieldRules": {
+            "exclude": [
+              "passwordHash",
+              "tokenHistory"
+            ]
+          }
+        },
+        {
+          "database": "app",
+          "collection": "orders",
+          "filter": {
+            "state": {
+              "$in": [
+                "PAID",
+                "SHIPPED"
+              ]
+            }
+          },
+          "sort": {
+            "_id": 1
+          },
+          "limit": 1500
+        }
+      ]
+    },
+    "smoke": {
+      "refreshMode": "full",
+      "fieldRules": {
+        "exclude": [
+          "auditTrail",
+          "debugMetadata"
+        ]
+      },
+      "collections": [
+        {
+          "database": "app",
+          "collection": "users",
+          "projection": {
+            "_id": 1,
+            "email": 1,
+            "updatedAt": 1
+          },
+          "sort": {
+            "updatedAt": -1,
+            "_id": 1
+          },
+          "sample": {
+            "size": 50,
+            "seed": "users-smoke-v1"
+          },
+          "fieldRules": {
+            "exclude": [
+              "email"
+            ]
+          }
+        },
+        {
+          "database": "app",
+          "collection": "orders",
+          "sort": {
+            "updatedAt": -1,
+            "_id": 1
+          },
+          "sample": {
+            "size": 50,
+            "seed": "orders-smoke-v1"
+          }
+        }
+      ]
+    },
+    "full": {
+      "refreshMode": "incremental",
+      "collections": [
+        {
+          "database": "app",
+          "collection": "users",
+          "filter": {
+            "updatedAt": {
+              "$gte": "2025-01-01T00:00:00Z"
+            }
+          },
+          "projection": {
+            "_id": 1,
+            "email": 1,
+            "profile": 1,
+            "updatedAt": 1
+          },
+          "sort": {
+            "updatedAt": 1,
+            "_id": 1
+          }
+        },
+        {
+          "database": "app",
+          "collection": "orders",
+          "filter": {
+            "updatedAt": {
+              "$gte": "2025-01-01T00:00:00Z"
+            }
+          },
+          "sort": {
+            "updatedAt": 1,
+            "_id": 1
+          }
+        }
+      ]
+    }
+  }
+}

--- a/testkit/fixture/manifests/incremental-events.json
+++ b/testkit/fixture/manifests/incremental-events.json
@@ -1,0 +1,76 @@
+{
+  "schemaVersion": "fixture-manifest.v1",
+  "source": {
+    "uriAlias": "prod-events"
+  },
+  "profiles": {
+    "dev": {
+      "refreshMode": "incremental",
+      "collections": [
+        {
+          "database": "events",
+          "collection": "event_log",
+          "filter": {
+            "eventType": {
+              "$in": [
+                "ORDER_CREATED",
+                "ORDER_CANCELLED",
+                "PAYMENT_CAPTURED"
+              ]
+            }
+          },
+          "projection": {
+            "_id": 1,
+            "eventType": 1,
+            "aggregateId": 1,
+            "occurredAt": 1,
+            "payload": 1
+          },
+          "sort": {
+            "occurredAt": 1,
+            "_id": 1
+          },
+          "limit": 5000
+        }
+      ]
+    },
+    "smoke": {
+      "refreshMode": "incremental",
+      "collections": [
+        {
+          "database": "events",
+          "collection": "event_log",
+          "sort": {
+            "occurredAt": -1,
+            "_id": 1
+          },
+          "sample": {
+            "size": 100,
+            "seed": "event-log-smoke-v1"
+          }
+        }
+      ]
+    },
+    "full": {
+      "refreshMode": "incremental",
+      "collections": [
+        {
+          "database": "events",
+          "collection": "event_log",
+          "sort": {
+            "occurredAt": 1,
+            "_id": 1
+          }
+        },
+        {
+          "database": "events",
+          "collection": "dead_letter_queue",
+          "sort": {
+            "occurredAt": 1,
+            "_id": 1
+          }
+        }
+      ]
+    }
+  }
+}

--- a/testkit/fixture/manifests/sensitive-field-rules.json
+++ b/testkit/fixture/manifests/sensitive-field-rules.json
@@ -1,0 +1,108 @@
+{
+  "schemaVersion": "fixture-manifest.v1",
+  "source": {
+    "uriAlias": "prod-identity"
+  },
+  "profiles": {
+    "dev": {
+      "refreshMode": "full",
+      "fieldRules": {
+        "exclude": [
+          "pii.ssn",
+          "pii.passport",
+          "credentials.passwordHash",
+          "credentials.twoFactorSecret"
+        ]
+      },
+      "collections": [
+        {
+          "database": "identity",
+          "collection": "customer_profile",
+          "sort": {
+            "_id": 1
+          },
+          "limit": 3000,
+          "fieldRules": {
+            "include": [
+              "_id",
+              "tenantId",
+              "status",
+              "profile",
+              "pii.email",
+              "pii.phone"
+            ]
+          }
+        }
+      ]
+    },
+    "smoke": {
+      "refreshMode": "full",
+      "fieldRules": {
+        "exclude": [
+          "pii.ssn",
+          "pii.passport",
+          "credentials.passwordHash",
+          "credentials.twoFactorSecret"
+        ]
+      },
+      "collections": [
+        {
+          "database": "identity",
+          "collection": "customer_profile",
+          "sort": {
+            "_id": 1
+          },
+          "sample": {
+            "size": 100,
+            "seed": "identity-smoke-v1"
+          },
+          "fieldRules": {
+            "include": [
+              "_id",
+              "tenantId",
+              "status",
+              "profile",
+              "pii.email"
+            ]
+          }
+        }
+      ]
+    },
+    "full": {
+      "refreshMode": "incremental",
+      "fieldRules": {
+        "exclude": [
+          "pii.ssn",
+          "pii.passport",
+          "credentials.passwordHash",
+          "credentials.twoFactorSecret"
+        ]
+      },
+      "collections": [
+        {
+          "database": "identity",
+          "collection": "customer_profile",
+          "filter": {
+            "updatedAt": {
+              "$gte": "2025-01-01T00:00:00Z"
+            }
+          },
+          "sort": {
+            "updatedAt": 1,
+            "_id": 1
+          },
+          "fieldRules": {
+            "include": [
+              "_id",
+              "tenantId",
+              "status",
+              "profile",
+              "pii.email",
+              "pii.phone"
+            ]
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `fixture-manifest.v1` schema model for source alias, profile configs, collection extraction clauses, field include/exclude rules, and refresh modes
- add manifest loader + static validator with aggregated path-aware errors
- add deterministic profile extraction planner with fingerprint output to ensure reproducible profile planning
- add three sample manifests for onboarding and a dedicated fixture manifest document

## Tests
- `./.tooling/gradle-8.10.2/bin/gradle test --tests org.jongodb.testkit.FixtureManifestLoaderTest --tests org.jongodb.testkit.FixtureManifestValidatorTest --tests org.jongodb.testkit.FixtureExtractionPlannerTest`
- `./.tooling/gradle-8.10.2/bin/gradle test`

Closes #249
