### PR TITLE
[fixture] 사용/운영 플레이북 문서화

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ All notable changes to this project are documented in this file.
 - Added declarative fixture manifest schema (`fixture-manifest.v1`) with standardized `dev`/`smoke`/`full` profile model.
 - Added fixture manifest loader/validator with path-aware aggregated validation errors.
 - Added deterministic fixture extraction planner + profile fingerprint generation.
+- Added fixture manifest CLI utility (`FixtureManifestTool`) and Gradle task (`fixtureManifestPlan`) for profile plan validation/output.
 - Added sample fixture manifest templates under `testkit/fixture/manifests`.
 - Added fixture manifest onboarding documentation (`docs/FIXTURE_MANIFEST.md`).
+- Added fixture usage/operations playbook (`docs/FIXTURE_PLAYBOOK.md`) for developer/reviewer/operator workflows.
 
 ## [0.1.3] - 2026-02-24
 

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Unsupported branches are standardized progressively as:
 - Usage: `docs/USAGE.md`
 - Spring integration: `docs/SPRING_TESTING.md`
 - Fixture manifest: `docs/FIXTURE_MANIFEST.md`
+- Fixture playbook: `docs/FIXTURE_PLAYBOOK.md`
 - Compatibility boundary: `docs/COMPATIBILITY.md`
 - Complex-query certification: `docs/COMPLEX_QUERY_CERTIFICATION.md`
 - Support matrix: `docs/SUPPORT_MATRIX.md`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -255,6 +255,28 @@ tasks.register<JavaExec>("utfCorpusEvidence") {
     }
 }
 
+tasks.register<JavaExec>("fixtureManifestPlan") {
+    group = "verification"
+    description = "Validates fixture manifest and renders deterministic profile extraction plan."
+    classpath = sourceSets["main"].runtimeClasspath
+    mainClass.set("org.jongodb.testkit.FixtureManifestTool")
+
+    val manifestPath = (findProperty("fixtureManifestPath") as String?)?.trim().orEmpty()
+    val profile = (findProperty("fixtureProfile") as String?)?.trim().orEmpty().ifBlank { "dev" }
+    val renderJson = (findProperty("fixturePlanJson") as String?)?.toBoolean() ?: false
+
+    doFirst {
+        if (manifestPath.isBlank()) {
+            throw GradleException("fixtureManifestPath property is required")
+        }
+    }
+
+    args("--manifest=$manifestPath", "--profile=$profile")
+    if (renderJson) {
+        args("--json")
+    }
+}
+
 tasks.register<JavaExec>("complexQueryCertificationEvidence") {
     group = "verification"
     description = "Runs canonical complex-query certification pack and enforces gate policy."

--- a/docs/FIXTURE_PLAYBOOK.md
+++ b/docs/FIXTURE_PLAYBOOK.md
@@ -1,0 +1,154 @@
+# Fixture Playbook
+
+Audience:
+- Developer: generate/update fixture intent for feature work.
+- Reviewer: verify safety, determinism, and approval gates.
+- Operator: enforce security/branch policy and release hygiene.
+
+Scope:
+- `jongodb` fixture workflow based on manifest-driven planning (`fixture-manifest.v1`).
+- extraction transport/restore artifact pipeline will expand with `#250`/`#253`, but this playbook is executable now for manifest governance and Spring test reset workflow.
+
+## 1) Developer Guide
+
+### 1.1 First-Time Setup (Create)
+
+1. Start from a template:
+   - `testkit/fixture/manifests/baseline-dev-smoke-full.json`
+   - `testkit/fixture/manifests/incremental-events.json`
+   - `testkit/fixture/manifests/sensitive-field-rules.json`
+2. Adjust `source.uriAlias`, collection clauses, and field rules.
+3. Validate and render deterministic plan:
+
+```bash
+gradle fixtureManifestPlan \
+  -PfixtureManifestPath=testkit/fixture/manifests/baseline-dev-smoke-full.json \
+  -PfixtureProfile=dev
+```
+
+Optional canonical JSON output:
+
+```bash
+gradle fixtureManifestPlan \
+  -PfixtureManifestPath=testkit/fixture/manifests/baseline-dev-smoke-full.json \
+  -PfixtureProfile=dev \
+  -PfixturePlanJson=true
+```
+
+4. Save the emitted `fingerprint` in your PR description for reviewer comparison.
+
+### 1.2 Local Restore/Test Loop
+
+For Spring integration tests, use reset-first workflow to avoid data bleed:
+
+1. Use `@JongodbMongoTest` or `JongodbMongoInitializer`.
+2. Reset state before each test slice:
+
+```java
+@Autowired
+ApplicationContext context;
+
+@BeforeEach
+void reset() {
+    JongodbMongoResetSupport.reset(context);
+}
+```
+
+3. Seed fixture data through repository/template setup code in test fixtures.
+
+This gives deterministic local replay even before dedicated restore CLI (`#253`) lands.
+
+### 1.3 Refresh Request and Approval
+
+When requesting fixture updates:
+
+1. Include manifest diff + old/new `fingerprint`.
+2. Explain why refresh mode is `full` or `incremental`.
+3. Declare field-rule changes (especially PII-related include/exclude edits).
+4. Request explicit reviewer approval before merging.
+
+## 2) Reviewer Guide
+
+Reviewer checklist:
+
+1. `schemaVersion` is `fixture-manifest.v1`.
+2. All three profiles exist: `dev`, `smoke`, `full`.
+3. Determinism guardrails hold:
+   - `limit` has `sort`.
+   - `sample` has `size`, `seed`, and `sort`.
+   - incremental profile collections have `sort`.
+4. Field rules are safe:
+   - no include/exclude overlap.
+   - no newly exposed sensitive fields without justification.
+5. PR contains `fixtureManifestPlan` fingerprint evidence.
+
+## 3) Troubleshooting
+
+### 3.1 Restore Failure / Data Bleed
+
+Symptoms:
+- tests pass individually but fail in suite order.
+
+Actions:
+1. Ensure reset hook (`JongodbMongoResetSupport.reset`) runs before each test.
+2. If shared server mode is enabled, verify per-test database naming policy.
+3. Disable `jongodb.test.sharedServer` temporarily for isolation triage.
+
+### 3.2 Version Mismatch
+
+Symptoms:
+- manifest tool fails with schema validation errors.
+
+Actions:
+1. Confirm `schemaVersion` is `fixture-manifest.v1`.
+2. Re-run:
+
+```bash
+gradle fixtureManifestPlan -PfixtureManifestPath=<path> -PfixtureProfile=dev
+```
+
+3. If still failing, fix path-specific errors from validator output.
+
+### 3.3 Drift Threshold Exceeded (Policy)
+
+Suggested policy:
+- if profile fingerprint changes unexpectedly between adjacent PRs, mark as drift candidate and require additional approval.
+
+Actions:
+1. Compare previous PR fingerprint vs current fingerprint for same profile.
+2. If drift is unplanned, block merge and request manifest clause-level explanation.
+
+## 4) Operator Guide
+
+### 4.1 Security Principles
+
+MUST:
+- use read-only credentials for extraction-oriented workflows.
+- keep secrets in CI secret store or local secure vault, never in manifest.
+- mask/exclude sensitive fields in `fieldRules`.
+
+MUST NOT:
+- commit raw secrets, connection strings, or production credentials.
+- broaden include rules for sensitive namespaces without security review.
+
+### 4.2 Branch and Release Strategy
+
+Recommended branch flow:
+1. `issue/<id>-...` branch per fixture change.
+2. PR includes manifest diff + fingerprint evidence.
+3. Merge only after CI + reviewer checklist completion.
+4. Keep fixture policy docs (`docs/FIXTURE_MANIFEST.md`, this playbook) aligned with release notes.
+
+### 4.3 Incident Handling
+
+If a fixture-related incident is reported:
+1. Freeze new fixture refresh merges.
+2. Identify first bad fingerprint change.
+3. Revert manifest change or re-approve with corrected field/sort constraints.
+4. Document root cause in PR and update this playbook.
+
+## Related Docs
+
+- `docs/FIXTURE_MANIFEST.md`
+- `docs/SPRING_TESTING.md`
+- `docs/USAGE.md`

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -313,3 +313,9 @@ The certification gate requires:
 - at least 3 projects
 - all canaries pass
 - rollback rehearsal success for all projects
+
+## Related Docs
+
+- `docs/FIXTURE_MANIFEST.md`
+- `docs/FIXTURE_PLAYBOOK.md`
+- `docs/SPRING_TESTING.md`

--- a/src/main/java/org/jongodb/testkit/FixtureManifestTool.java
+++ b/src/main/java/org/jongodb/testkit/FixtureManifestTool.java
@@ -1,0 +1,127 @@
+package org.jongodb.testkit;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * CLI utility for fixture manifest validation and deterministic plan rendering.
+ */
+public final class FixtureManifestTool {
+    private FixtureManifestTool() {}
+
+    public static void main(final String[] args) {
+        final int exitCode = run(args, System.out, System.err);
+        if (exitCode != 0) {
+            System.exit(exitCode);
+        }
+    }
+
+    static int run(final String[] args, final PrintStream out, final PrintStream err) {
+        Objects.requireNonNull(args, "args");
+        Objects.requireNonNull(out, "out");
+        Objects.requireNonNull(err, "err");
+
+        final Config config;
+        try {
+            config = parseArgs(args);
+        } catch (final IllegalArgumentException e) {
+            err.println(e.getMessage());
+            printUsage(err);
+            return 2;
+        }
+
+        if (config.help()) {
+            printUsage(out);
+            return 0;
+        }
+
+        try {
+            final FixtureManifest manifest = FixtureManifestLoader.load(config.manifestPath());
+            final FixtureExtractionPlan plan = FixtureExtractionPlanner.plan(manifest, config.profile());
+            renderSummary(config.manifestPath(), plan, out);
+            if (config.jsonOutput()) {
+                out.println();
+                out.println(plan.toJson());
+            }
+            return 0;
+        } catch (final IOException | RuntimeException e) {
+            err.println("fixture manifest tool failed: " + e.getMessage());
+            return 1;
+        }
+    }
+
+    private static Config parseArgs(final String[] args) {
+        Path manifestPath = null;
+        FixtureManifest.ScenarioProfile profile = FixtureManifest.ScenarioProfile.DEV;
+        boolean jsonOutput = false;
+        boolean help = false;
+
+        for (final String arg : args) {
+            if ("--help".equals(arg) || "-h".equals(arg)) {
+                help = true;
+                continue;
+            }
+            if ("--json".equals(arg)) {
+                jsonOutput = true;
+                continue;
+            }
+            if (arg.startsWith("--manifest=")) {
+                manifestPath = Path.of(valueAfterPrefix(arg, "--manifest="));
+                continue;
+            }
+            if (arg.startsWith("--profile=")) {
+                profile = FixtureManifest.ScenarioProfile.fromText(valueAfterPrefix(arg, "--profile="));
+                continue;
+            }
+            throw new IllegalArgumentException("unknown argument: " + arg);
+        }
+
+        if (!help && manifestPath == null) {
+            throw new IllegalArgumentException("--manifest=<path> is required");
+        }
+        return new Config(manifestPath, profile, jsonOutput, help);
+    }
+
+    private static void renderSummary(
+            final Path manifestPath,
+            final FixtureExtractionPlan plan,
+            final PrintStream out) {
+        out.println("Fixture manifest validated");
+        out.println("- manifest: " + manifestPath.toAbsolutePath().normalize());
+        out.println("- schemaVersion: " + plan.schemaVersion());
+        out.println("- sourceUriAlias: " + plan.sourceUriAlias());
+        out.println("- profile: " + plan.profile().value());
+        out.println("- refreshMode: " + plan.refreshMode().value());
+        out.println("- fingerprint: " + plan.fingerprint());
+        out.println("- collectionCount: " + plan.collections().size());
+        for (final FixtureExtractionPlan.CollectionPlan collection : plan.collections()) {
+            out.println("  - " + collection.database() + "." + collection.collection()
+                    + " limit=" + (collection.limit() == null ? "-" : collection.limit())
+                    + " sample=" + (collection.sample() == null ? "-" : collection.sample().size()));
+        }
+    }
+
+    private static String valueAfterPrefix(final String arg, final String prefix) {
+        final String value = arg.substring(prefix.length()).trim();
+        if (value.isEmpty()) {
+            throw new IllegalArgumentException(prefix + " must have a value");
+        }
+        return value;
+    }
+
+    private static void printUsage(final PrintStream stream) {
+        stream.println("Usage: FixtureManifestTool --manifest=<path> [--profile=dev|smoke|full] [--json]");
+        stream.println("  --manifest=<path>     Manifest JSON/YAML path (required)");
+        stream.println("  --profile=<name>      Profile to render (default: dev)");
+        stream.println("  --json                Print canonical plan JSON");
+        stream.println("  --help                Show usage");
+    }
+
+    private record Config(
+            Path manifestPath,
+            FixtureManifest.ScenarioProfile profile,
+            boolean jsonOutput,
+            boolean help) {}
+}

--- a/src/test/java/org/jongodb/testkit/FixtureManifestToolTest.java
+++ b/src/test/java/org/jongodb/testkit/FixtureManifestToolTest.java
@@ -1,0 +1,45 @@
+package org.jongodb.testkit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import org.junit.jupiter.api.Test;
+
+class FixtureManifestToolTest {
+    @Test
+    void rendersProfilePlanSummary() {
+        final ByteArrayOutputStream outBytes = new ByteArrayOutputStream();
+        final ByteArrayOutputStream errBytes = new ByteArrayOutputStream();
+        final int exitCode = FixtureManifestTool.run(
+                new String[] {
+                    "--manifest=testkit/fixture/manifests/baseline-dev-smoke-full.json",
+                    "--profile=smoke"
+                },
+                new PrintStream(outBytes),
+                new PrintStream(errBytes));
+
+        assertEquals(0, exitCode);
+        final String output = outBytes.toString();
+        assertTrue(output.contains("Fixture manifest validated"));
+        assertTrue(output.contains("- profile: smoke"));
+        assertTrue(output.contains("- fingerprint: "));
+        assertEquals("", errBytes.toString());
+    }
+
+    @Test
+    void failsWithUsageWhenManifestArgIsMissing() {
+        final ByteArrayOutputStream outBytes = new ByteArrayOutputStream();
+        final ByteArrayOutputStream errBytes = new ByteArrayOutputStream();
+        final int exitCode = FixtureManifestTool.run(
+                new String[] {"--profile=dev"},
+                new PrintStream(outBytes),
+                new PrintStream(errBytes));
+
+        assertEquals(2, exitCode);
+        final String errorOutput = errBytes.toString();
+        assertTrue(errorOutput.contains("--manifest=<path> is required"));
+        assertTrue(errorOutput.contains("Usage: FixtureManifestTool"));
+    }
+}


### PR DESCRIPTION
## Summary
- add fixture operations playbook for developer/reviewer/operator workflows
- add `FixtureManifestTool` CLI for manifest validation + deterministic profile plan rendering
- add `fixtureManifestPlan` Gradle task (`-PfixtureManifestPath`, `-PfixtureProfile`, `-PfixturePlanJson`) for operational usage in docs/PR reviews
- update docs index links (`README.md`, `docs/USAGE.md`) and changelog

## Tests
- `./.tooling/gradle-8.10.2/bin/gradle test --tests org.jongodb.testkit.FixtureManifestLoaderTest --tests org.jongodb.testkit.FixtureManifestValidatorTest --tests org.jongodb.testkit.FixtureExtractionPlannerTest --tests org.jongodb.testkit.FixtureManifestToolTest`
- `./.tooling/gradle-8.10.2/bin/gradle fixtureManifestPlan -PfixtureManifestPath=testkit/fixture/manifests/baseline-dev-smoke-full.json -PfixtureProfile=smoke`
- `./.tooling/gradle-8.10.2/bin/gradle test`

Closes #258
