### PR TITLE
[node][runtime] single-node replica-set profile contract tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project are documented in this file.
 - Added sample fixture manifest templates under `testkit/fixture/manifests`.
 - Added fixture manifest onboarding documentation (`docs/FIXTURE_MANIFEST.md`).
 - Added fixture usage/operations playbook (`docs/FIXTURE_PLAYBOOK.md`) for developer/reviewer/operator workflows.
+- Added Node adapter replica-set profile contract tests for URI/env propagation and `hello` handshake invariants.
 
 ## [0.1.3] - 2026-02-24
 

--- a/packages/memory-server/README.md
+++ b/packages/memory-server/README.md
@@ -260,6 +260,16 @@ const runtime = createJongodbEnvRuntime({
 });
 ```
 
+Replica-set contract test coverage:
+- URI must include `?replicaSet=<name>` when `topologyProfile=singleNodeReplicaSet`
+- `hello` response must expose `setName`, `hosts`, `primary`, `isWritablePrimary`, `topologyVersion`
+
+Run Node adapter contract tests:
+
+```bash
+npm run --workspace @jongodb/memory-server test
+```
+
 Scoped env example:
 
 ```ts


### PR DESCRIPTION
## Summary
- add Node runtime contract test for `singleNodeReplicaSet` startup profile to verify:
  - URI includes `?replicaSet=<name>`
  - `hello` response includes `setName`, `hosts`, `primary`, `isWritablePrimary`, `topologyVersion`
- add env-runtime contract test to ensure `createJongodbEnvRuntime` propagates replica-set URI correctly
- document replica-set contract coverage and test command in memory-server README

## Tests
- `npm run --workspace @jongodb/memory-server build`
- `JONGODB_TEST_CLASSPATH="$(./.tooling/gradle-8.10.2/bin/gradle --no-daemon -q printLauncherClasspath | tail -n 1)" node --test --test-name-pattern='replica-set' packages/memory-server/dist/esm/test/runtime-manager.test.js packages/memory-server/dist/esm/test/runtime.test.js`
- `JONGODB_TEST_CLASSPATH="$(./.tooling/gradle-8.10.2/bin/gradle --no-daemon -q printLauncherClasspath | tail -n 1)" node --test --test-name-pattern='singleNodeReplicaSet' packages/memory-server/dist/esm/test/binary-launcher.test.js`

Closes #291
