### PR TITLE
[node][runtime] topology profile negotiation and URI option sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project are documented in this file.
 - Added fixture manifest onboarding documentation (`docs/FIXTURE_MANIFEST.md`).
 - Added fixture usage/operations playbook (`docs/FIXTURE_PLAYBOOK.md`) for developer/reviewer/operator workflows.
 - Added Node adapter replica-set profile contract tests for URI/env propagation and `hello` handshake invariants.
+- Added Node adapter topology-profile/URI option sync validation with mismatch regression tests.
 
 ## [0.1.3] - 2026-02-24
 

--- a/packages/memory-server/README.md
+++ b/packages/memory-server/README.md
@@ -204,6 +204,7 @@ Launcher contract:
 - stdout ready line: `JONGODB_URI=mongodb://...`
 - optional stderr failure line: `JONGODB_START_FAILURE=...`
 - process stays alive until termination signal
+- runtime validates URI topology sync (requested `topologyProfile` vs emitted `replicaSet` query)
 
 ## API Surface
 
@@ -287,6 +288,7 @@ const runtime = createJongodbEnvRuntime({
 - `Java launch mode requested but Java classpath is not configured`: provide `classpath` or `JONGODB_CLASSPATH`
 - `spawn ... ENOENT`: missing runtime executable path
 - startup timeout: launcher did not emit `JONGODB_URI=...`
+- `Launcher URI topology options are out of sync`: emitted URI query does not match requested `topologyProfile`/`replicaSetName`
 
 Parallel test tip:
 - use `databaseNameStrategy: "worker"` or per-worker suffixes to prevent data collisions


### PR DESCRIPTION
## Summary
- enforce topology negotiation contract at runtime startup by validating launcher-emitted URI query options against requested topology profile
- fail startup when:
  - `topologyProfile=singleNodeReplicaSet` but URI lacks `replicaSet`
  - `topologyProfile=standalone` but URI includes `replicaSet`
  - requested `replicaSetName` differs from URI `replicaSet`
- add mismatch regression tests in binary launcher suite and update runtime README troubleshooting

## Tests
- `npm run --workspace @jongodb/memory-server build`
- `JONGODB_TEST_CLASSPATH="$(./.tooling/gradle-8.10.2/bin/gradle --no-daemon -q printLauncherClasspath | tail -n 1)" node --test --test-name-pattern='topology|replica-set|singleNodeReplicaSet' packages/memory-server/dist/esm/test/binary-launcher.test.js packages/memory-server/dist/esm/test/runtime-manager.test.js packages/memory-server/dist/esm/test/runtime.test.js`
- `node --test --test-name-pattern='standalone profile URI includes replicaSet query' packages/memory-server/dist/esm/test/binary-launcher.test.js`

Closes #292
