### PR TITLE
[node][jest] globalSetup/globalTeardown helper package stabilization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project are documented in this file.
 - Added fixture usage/operations playbook (`docs/FIXTURE_PLAYBOOK.md`) for developer/reviewer/operator workflows.
 - Added Node adapter replica-set profile contract tests for URI/env propagation and `hello` handshake invariants.
 - Added Node adapter topology-profile/URI option sync validation with mismatch regression tests.
+- Added Jest global setup/teardown stabilization for idempotent state reuse and stale state auto-recovery.
 
 ## [0.1.3] - 2026-02-24
 

--- a/packages/memory-server/README.md
+++ b/packages/memory-server/README.md
@@ -157,6 +157,10 @@ import { createJestGlobalTeardown } from "@jongodb/memory-server/jest";
 export default createJestGlobalTeardown();
 ```
 
+Global setup/teardown stabilization notes:
+- repeated global setup calls with the same state file now reuse the existing detached launcher (idempotent)
+- stale state files (PID no longer alive) are auto-healed by starting a fresh launcher
+
 Vitest:
 
 ```ts


### PR DESCRIPTION
## Summary
- stabilize Jest global lifecycle helpers by making `createJestGlobalSetup` idempotent with state-file reuse
- when state file exists:
  - reuse existing detached launcher if PID is alive
  - auto-heal stale state (dead PID) by removing state and starting a fresh launcher
- teardown now clears `state.envVarName` from process env before removing state file
- add regression tests for setup idempotency and stale-state replacement

## Tests
- `npm run --workspace @jongodb/memory-server build`
- `JONGODB_TEST_CLASSPATH="$(./.tooling/gradle-8.10.2/bin/gradle --no-daemon -q printLauncherClasspath | tail -n 1)" node --test --test-name-pattern='jest global setup|registerJongodbForJest|stale state|idempotent' packages/memory-server/dist/esm/test/runner-helpers.test.js`

Closes #293
