### PR TITLE
[node][vitest] workspace helper and project-level isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project are documented in this file.
 - Added Node adapter replica-set profile contract tests for URI/env propagation and `hello` handshake invariants.
 - Added Node adapter topology-profile/URI option sync validation with mismatch regression tests.
 - Added Jest global setup/teardown stabilization for idempotent state reuse and stale state auto-recovery.
+- Added Vitest workspace helper for project-level DB/env isolation policy.
 
 ## [0.1.3] - 2026-02-24
 

--- a/packages/memory-server/README.md
+++ b/packages/memory-server/README.md
@@ -170,6 +170,23 @@ import { registerJongodbForVitest } from "@jongodb/memory-server/vitest";
 registerJongodbForVitest({ beforeAll, afterAll });
 ```
 
+Vitest workspace (project isolation):
+
+```ts
+import { beforeAll, afterAll } from "vitest";
+import { registerJongodbForVitestWorkspace } from "@jongodb/memory-server/vitest";
+
+registerJongodbForVitestWorkspace({ beforeAll, afterAll }, {
+  projectName: "catalog-api",
+  isolationMode: "project",
+  databaseName: "test",
+});
+```
+
+Workspace helper behavior:
+- `isolationMode: "project"` (default): appends project token to database name and writes project-scoped URI env key
+- `isolationMode: "shared"`: keeps provided database name without project suffix
+
 NestJS (Jest E2E):
 
 ```ts
@@ -230,6 +247,7 @@ Nest export (`@jongodb/memory-server/nestjs`):
 
 Vitest export (`@jongodb/memory-server/vitest`):
 - `registerJongodbForVitest(hooks, options?)`
+- `registerJongodbForVitestWorkspace(hooks, workspaceOptions)`
 
 ## Options Reference
 

--- a/packages/memory-server/src/vitest.ts
+++ b/packages/memory-server/src/vitest.ts
@@ -1,6 +1,9 @@
 import { type JongodbMemoryServerOptions } from "./index.js";
 import { createJongodbEnvRuntime } from "./runtime.js";
 
+const DEFAULT_DATABASE = "test";
+const DEFAULT_ENV_VAR_NAME = "MONGODB_URI";
+
 export interface VitestHookRegistrar {
   beforeAll(callback: () => unknown | Promise<unknown>): void;
   afterAll(callback: () => unknown | Promise<unknown>): void;
@@ -13,6 +16,21 @@ export interface VitestHookOptions extends JongodbMemoryServerOptions {
 
 export interface RegisteredVitestJongodbServer {
   readonly uri: string;
+}
+
+export type VitestWorkspaceIsolationMode = "project" | "shared";
+
+export interface VitestWorkspaceHookOptions extends VitestHookOptions {
+  projectName: string;
+  isolationMode?: VitestWorkspaceIsolationMode;
+  projectEnvVarName?: string;
+}
+
+export interface RegisteredVitestWorkspaceJongodbServer
+  extends RegisteredVitestJongodbServer {
+  readonly isolationMode: VitestWorkspaceIsolationMode;
+  readonly databaseName: string;
+  readonly envVarNames: readonly string[];
 }
 
 export function registerJongodbForVitest(
@@ -34,4 +52,127 @@ export function registerJongodbForVitest(
       return runtime.uri;
     },
   };
+}
+
+export function registerJongodbForVitestWorkspace(
+  hooks: VitestHookRegistrar,
+  options: VitestWorkspaceHookOptions
+): RegisteredVitestWorkspaceJongodbServer {
+  const isolationMode = options.isolationMode ?? "project";
+  const projectName = normalizeProjectName(options.projectName);
+  const {
+    projectName: _projectName,
+    isolationMode: _isolationMode,
+    projectEnvVarName,
+    ...runtimeOptionsBase
+  } = options;
+
+  const runtimeOptions: VitestHookOptions = { ...runtimeOptionsBase };
+  if (isolationMode === "project") {
+    runtimeOptions.databaseName = withProjectDatabaseSuffix(
+      runtimeOptions.databaseName,
+      projectName
+    );
+  }
+
+  const envVarNames = resolveWorkspaceEnvVarNames(
+    runtimeOptions,
+    projectName,
+    isolationMode,
+    projectEnvVarName
+  );
+  if (envVarNames !== null) {
+    runtimeOptions.envVarNames = envVarNames;
+    delete runtimeOptions.envVarName;
+  }
+
+  const runtime = createJongodbEnvRuntime(runtimeOptions);
+
+  hooks.beforeAll(async () => {
+    await runtime.setup();
+  });
+
+  hooks.afterAll(async () => {
+    await runtime.teardown();
+  });
+
+  return {
+    isolationMode,
+    databaseName: runtimeOptions.databaseName ?? DEFAULT_DATABASE,
+    get envVarNames(): readonly string[] {
+      return runtime.envVarNames;
+    },
+    get uri(): string {
+      return runtime.uri;
+    },
+  };
+}
+
+function normalizeProjectName(name: string): string {
+  const normalized = name.trim();
+  if (normalized.length === 0) {
+    throw new Error("projectName must not be empty.");
+  }
+  return normalized;
+}
+
+function withProjectDatabaseSuffix(
+  databaseName: string | undefined,
+  projectName: string
+): string {
+  const base = databaseName?.trim() || DEFAULT_DATABASE;
+  return `${base}_p${sanitizeProjectToken(projectName)}`;
+}
+
+function sanitizeProjectToken(token: string): string {
+  const normalized = token
+    .trim()
+    .replace(/[^A-Za-z0-9_]+/g, "_")
+    .replace(/^_+/g, "")
+    .replace(/_+$/g, "");
+  return normalized.length > 0 ? normalized : "project";
+}
+
+function resolveWorkspaceEnvVarNames(
+  runtimeOptions: VitestHookOptions,
+  projectName: string,
+  isolationMode: VitestWorkspaceIsolationMode,
+  projectEnvVarName: string | undefined
+): string[] | null {
+  const candidates: string[] = [];
+  if (runtimeOptions.envVarName !== undefined) {
+    candidates.push(runtimeOptions.envVarName);
+  }
+  if (runtimeOptions.envVarNames !== undefined) {
+    candidates.push(...runtimeOptions.envVarNames);
+  }
+  if (projectEnvVarName !== undefined) {
+    candidates.push(projectEnvVarName);
+  }
+
+  if (isolationMode === "project") {
+    if (candidates.length === 0) {
+      candidates.push(DEFAULT_ENV_VAR_NAME);
+    }
+    candidates.push(`MONGODB_URI_${sanitizeProjectToken(projectName).toUpperCase()}`);
+  }
+
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  const resolved: string[] = [];
+  const seen = new Set<string>();
+  for (const candidate of candidates) {
+    const normalized = candidate.trim();
+    if (normalized.length === 0) {
+      throw new Error("envVarName/envVarNames entries must not be empty.");
+    }
+    if (seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    resolved.push(normalized);
+  }
+  return resolved;
 }


### PR DESCRIPTION
## Summary
- add `registerJongodbForVitestWorkspace` helper to formalize workspace policy for project-level isolation vs shared mode
- default workspace policy (`isolationMode=project`) now:
  - appends project token suffix to database name
  - emits project-scoped URI env key (`MONGODB_URI_<PROJECT>`)
- add shared-mode path that keeps database name unsuffixed
- add regression tests for workspace default isolation and shared-mode behavior
- document workspace helper usage in memory-server README

## Tests
- `npm run --workspace @jongodb/memory-server build`
- `JONGODB_TEST_CLASSPATH="$(./.tooling/gradle-8.10.2/bin/gradle --no-daemon -q printLauncherClasspath | tail -n 1)" node --test --test-name-pattern='Vitest|workspace|registerJongodbForVitestWorkspace' packages/memory-server/dist/esm/test/runner-helpers.test.js`

Closes #294
