### PR TITLE
[node][nest] NestJS testing module adapter hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project are documented in this file.
 - Added Node adapter topology-profile/URI option sync validation with mismatch regression tests.
 - Added Jest global setup/teardown stabilization for idempotent state reuse and stale state auto-recovery.
 - Added Vitest workspace helper for project-level DB/env isolation policy.
+- Added Nest Jest adapter hardened defaults (`MONGODB_URI`+`DATABASE_URL`, worker DB isolation) with override coverage.
 
 ## [0.1.3] - 2026-02-24
 

--- a/packages/memory-server/README.md
+++ b/packages/memory-server/README.md
@@ -196,6 +196,10 @@ import { registerJongodbForNestJest } from "@jongodb/memory-server/nestjs";
 registerJongodbForNestJest({ beforeAll, afterAll });
 ```
 
+Nest adapter defaults:
+- binds both `MONGODB_URI` and `DATABASE_URL` unless env keys are explicitly overridden
+- defaults to `databaseNameStrategy: "worker"` for Jest parallel isolation
+
 Common patterns:
 - NestJS + Mongoose: use `process.env.MONGODB_URI` in `forRootAsync`
 - Prisma (Mongo): set runtime `envVarNames` to include `DATABASE_URL`

--- a/packages/memory-server/src/nestjs.ts
+++ b/packages/memory-server/src/nestjs.ts
@@ -16,5 +16,16 @@ export function registerJongodbForNestJest(
   hooks: NestJestHookRegistrar,
   options: NestJongodbOptions = {}
 ): RegisteredNestJongodbServer {
-  return registerJongodbForJest(hooks, options);
+  const hasExplicitEnvBinding =
+    options.envVarName !== undefined || options.envVarNames !== undefined;
+
+  return registerJongodbForJest(hooks, {
+    ...options,
+    // Nest projects commonly consume either spring-style MONGODB_URI or DATABASE_URL in test modules.
+    ...(hasExplicitEnvBinding
+      ? {}
+      : { envVarNames: ["MONGODB_URI", "DATABASE_URL"] }),
+    // Parallel Nest Jest workers should isolate DBs by default to reduce cross-suite data bleed.
+    databaseNameStrategy: options.databaseNameStrategy ?? "worker",
+  });
 }


### PR DESCRIPTION
## Summary
- harden Nest Jest adapter defaults to reduce per-project boilerplate:
  - default env bindings now include both `MONGODB_URI` and `DATABASE_URL`
  - default `databaseNameStrategy` now uses `worker` for parallel Jest isolation
- keep full override flexibility: explicit `envVarName`/`envVarNames` and `databaseNameStrategy` still win
- add regression tests for hardened defaults and explicit override behavior
- update README with Nest adapter default contract

## Tests
- `npm run --workspace @jongodb/memory-server build`
- `JONGODB_TEST_CLASSPATH="$(./.tooling/gradle-8.10.2/bin/gradle --no-daemon -q printLauncherClasspath | tail -n 1)" node --test --test-name-pattern='Nest|Vitest|workspace|override|hardened defaults' packages/memory-server/dist/esm/test/runner-helpers.test.js`

Closes #295
