### PR TITLE
feat(node): add mongoose session smoke harness scenario (#298)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project are documented in this file.
 - Added Nest Jest adapter hardened defaults (`MONGODB_URI`+`DATABASE_URL`, worker DB isolation) with override coverage.
 - Added Express integration smoke scenario and recipe coverage in node-compat suite.
 - Added Koa integration smoke scenario and recipe coverage in node-compat suite.
+- Added Mongoose transaction/session smoke harness scenario with session visibility/commit coverage.
 
 ## [0.1.3] - 2026-02-24
 

--- a/packages/memory-server/README.md
+++ b/packages/memory-server/README.md
@@ -202,6 +202,7 @@ Nest adapter defaults:
 
 Common patterns:
 - NestJS + Mongoose: use `process.env.MONGODB_URI` in `forRootAsync`
+- Mongoose transaction/session tests: run `startSession`/`withTransaction` against runtime URI in integration suites
 - Prisma (Mongo): set runtime `envVarNames` to include `DATABASE_URL`
 - TypeORM (Mongo): pass runtime URI into `url`
 - Express: inject `process.env.MONGODB_URI` into a shared MongoClient bootstrap and keep app routes DB-agnostic

--- a/testkit/node-compat/README.md
+++ b/testkit/node-compat/README.md
@@ -5,7 +5,7 @@ Practical compatibility smoke suite for:
 - official Node `mongodb` driver
 - `express` route integration with MongoDB driver
 - `koa` route integration with MongoDB driver
-- `mongoose`
+- `mongoose` (CRUD + transaction/session)
 
 The suite runs against `jongodb` started through the Node adapter runtime and writes a JSON report.
 


### PR DESCRIPTION
## Summary
- add a Mongoose session smoke scenario using `withTransaction` in the node compatibility suite
- verify session-scoped visibility for uncommitted writes and commit persistence
- update node-compat and memory-server docs for Mongoose transaction/session coverage

## Testing
- npm run node:build
- JONGODB_CLASSPATH="$(./.tooling/gradle-8.10.2/bin/gradle --no-daemon -q printLauncherClasspath | tail -n 1)" npm --prefix testkit/node-compat test

Closes #298
