### PR TITLE
ci(node): add os and node version matrix for node adapter smoke (#301)

### DIFF
--- a/.github/workflows/node-compat-smoke.yml
+++ b/.github/workflows/node-compat-smoke.yml
@@ -14,9 +14,18 @@ permissions:
 
 jobs:
   smoke:
-    name: mongodb + mongoose smoke
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
+    name: node-compat smoke (${{ matrix.os }}, node-${{ matrix.node }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+        node:
+          - "20"
+          - "22"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -27,11 +36,14 @@ jobs:
           distribution: temurin
           java-version: "17"
 
-      - name: Set up Node 20
+      - name: Set up Node ${{ matrix.node }}
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: ${{ matrix.node }}
           cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            testkit/node-compat/package-lock.json
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -67,7 +79,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: node-compat-smoke-report
+          name: node-compat-smoke-report-${{ matrix.os }}-node${{ matrix.node }}
           path: testkit/node-compat/reports/node-compat-smoke.json
           if-no-files-found: warn
           retention-days: 14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project are documented in this file.
 - Added Mongoose transaction/session smoke harness scenario with session visibility/commit coverage.
 - Added TypeORM MongoDB repository CRUD smoke harness scenario in node-compat suite.
 - Added Prisma MongoDB provider CRUD smoke harness with generated client workflow in node-compat suite.
+- Added node adapter compatibility CI matrix across Ubuntu/macOS and Node 20/22.
 
 ## [0.1.3] - 2026-02-24
 

--- a/packages/memory-server/README.md
+++ b/packages/memory-server/README.md
@@ -34,6 +34,12 @@ Actual deltas vary by test shape, dataset size, and CI machine characteristics.
 
 - Node.js 20+
 
+## CI Coverage
+
+Node adapter compatibility smoke runs in CI across:
+- OS: `ubuntu-latest`, `macos-latest`
+- Node: `20`, `22`
+
 ## Install
 
 ```bash


### PR DESCRIPTION
## Summary
- expand node compatibility smoke workflow to an OS/Node matrix
- run smoke job on `ubuntu-latest` and `macos-latest` across Node `20` and `22`
- make artifact names matrix-specific and document matrix coverage in README

## Testing
- npm run node:build
- JONGODB_CLASSPATH="$(./.tooling/gradle-8.10.2/bin/gradle --no-daemon -q printLauncherClasspath | tail -n 1)" npm --prefix testkit/node-compat test

Closes #301
