### PR TITLE
ci(node): add npm attestation flow for release artifacts (#302)

### DIFF
--- a/.github/workflows/npm-node-release.yml
+++ b/.github/workflows/npm-node-release.yml
@@ -17,6 +17,7 @@ on:
       - "node-v*.*.*"
 
 permissions:
+  attestations: write
   contents: read
   id-token: write
 
@@ -173,6 +174,24 @@ jobs:
         shell: bash
         run: node ./scripts/node/stage-bin-package.mjs --workspace "${{ matrix.workspace_dir }}" --binary "${RUNNER_TEMP}/${{ matrix.output_name }}"
 
+      - name: Pack binary npm artifact
+        id: pack_binary
+        shell: bash
+        run: |
+          mkdir -p "${RUNNER_TEMP}/npm-pack"
+          PACK_FILE=$(npm pack "./${{ matrix.workspace_dir }}" --pack-destination "${RUNNER_TEMP}/npm-pack" | tail -n 1)
+          PACK_PATH="${RUNNER_TEMP}/npm-pack/${PACK_FILE}"
+          if [[ ! -f "$PACK_PATH" ]]; then
+            echo "Packed tarball not found: $PACK_PATH"
+            exit 1
+          fi
+          echo "file=$PACK_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Attest binary package provenance (SLSA)
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: ${{ steps.pack_binary.outputs.file }}
+
       - name: Validate npm credentials for publish
         if: needs.meta.outputs.should_publish == 'true'
         shell: bash
@@ -183,13 +202,13 @@ jobs:
           fi
 
       - name: npm publish dry-run
-        run: npm publish "./${{ matrix.workspace_dir }}" --access public --provenance --dry-run
+        run: npm publish "${{ steps.pack_binary.outputs.file }}" --access public --provenance --dry-run
 
       - name: npm publish
         if: needs.meta.outputs.should_publish == 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish "./${{ matrix.workspace_dir }}" --access public --provenance
+        run: npm publish "${{ steps.pack_binary.outputs.file }}" --access public --provenance
 
   publish-core:
     name: Publish @jongodb/memory-server
@@ -219,6 +238,24 @@ jobs:
           npm version "${{ needs.meta.outputs.version }}" --workspace @jongodb/memory-server --no-git-tag-version
           node ./scripts/node/sync-memory-server-optional-bins.mjs --version "${{ needs.meta.outputs.version }}"
 
+      - name: Pack core npm artifact
+        id: pack_core
+        shell: bash
+        run: |
+          mkdir -p "${RUNNER_TEMP}/npm-pack"
+          PACK_FILE=$(npm pack "./packages/memory-server" --pack-destination "${RUNNER_TEMP}/npm-pack" | tail -n 1)
+          PACK_PATH="${RUNNER_TEMP}/npm-pack/${PACK_FILE}"
+          if [[ ! -f "$PACK_PATH" ]]; then
+            echo "Packed tarball not found: $PACK_PATH"
+            exit 1
+          fi
+          echo "file=$PACK_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Attest core package provenance (SLSA)
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: ${{ steps.pack_core.outputs.file }}
+
       - name: Validate npm credentials for publish
         if: needs.meta.outputs.should_publish == 'true'
         shell: bash
@@ -229,10 +266,10 @@ jobs:
           fi
 
       - name: npm publish dry-run
-        run: npm publish --workspace @jongodb/memory-server --access public --provenance --dry-run
+        run: npm publish "${{ steps.pack_core.outputs.file }}" --access public --provenance --dry-run
 
       - name: npm publish
         if: needs.meta.outputs.should_publish == 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --workspace @jongodb/memory-server --access public --provenance
+        run: npm publish "${{ steps.pack_core.outputs.file }}" --access public --provenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project are documented in this file.
 - Added TypeORM MongoDB repository CRUD smoke harness scenario in node-compat suite.
 - Added Prisma MongoDB provider CRUD smoke harness with generated client workflow in node-compat suite.
 - Added node adapter compatibility CI matrix across Ubuntu/macOS and Node 20/22.
+- Added npm release pipeline tarball attestation flow (`actions/attest-build-provenance`) for binary/core Node packages.
 
 ## [0.1.3] - 2026-02-24
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -49,9 +49,11 @@ Use this when publishing `@jongodb/memory-server`:
    - `@jongodb/memory-server-bin-win32-x64`
 6. Confirm core package publishes after binaries with synced optional dependency versions.
 7. For manual workflow runs, never set `publish=true` with empty `version` (workflow blocks this).
-8. Run `npm publish --dry-run` and review package contents.
-9. Publish only when `NPM_TOKEN` is configured and verify npm registry visibility.
-10. Update README usage examples with the released package version.
+8. Confirm workflow packs tarball artifacts first (binary/core) and publishes from those packed files.
+9. Confirm GitHub Artifact Attestations are generated for packed tarballs (`actions/attest-build-provenance`).
+10. Run `npm publish --dry-run` and review package contents.
+11. Publish only when `NPM_TOKEN` is configured and verify npm registry visibility.
+12. Update README usage examples with the released package version.
 
 ## Release History
 


### PR DESCRIPTION
## Summary
- add GitHub Artifact Attestations (`actions/attest-build-provenance`) to node npm release workflow
- switch binary/core publish steps to pack tarballs first, attest those tarballs, then publish from the packed files
- update release checklist and changelog to document provenance + SLSA attestation gates

## Validation
- workflow changes inspected for shell/output wiring across binary/core jobs

Closes #302
