### PR TITLE
ci(node): add canary prerelease automation workflow (#303)

### DIFF
--- a/.github/workflows/npm-node-canary-release.yml
+++ b/.github/workflows/npm-node-canary-release.yml
@@ -1,0 +1,138 @@
+name: Node Adapter Canary Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Publish canary to npm (false runs dry-run only)"
+        required: false
+        default: true
+        type: boolean
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/memory-server/**"
+      - "scripts/node/**"
+      - "package-lock.json"
+      - ".github/workflows/npm-node-canary-release.yml"
+
+permissions:
+  attestations: write
+  contents: read
+  id-token: write
+
+concurrency:
+  group: node-canary-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  canary:
+    name: Publish @jongodb/memory-server canary
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Set up Temurin 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "8.10.2"
+
+      - name: Resolve publish mode
+        id: mode
+        shell: bash
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            SHOULD_PUBLISH=true
+          elif [[ "${{ inputs.publish }}" == "true" ]]; then
+            SHOULD_PUBLISH=true
+          else
+            SHOULD_PUBLISH=false
+          fi
+          echo "should_publish=$SHOULD_PUBLISH" >> "$GITHUB_OUTPUT"
+
+      - name: Install workspace dependencies
+        run: npm ci
+
+      - name: Build and typecheck node adapter
+        run: |
+          npm run node:build
+          npm run node:typecheck
+
+      - name: Resolve canary version
+        id: version
+        shell: bash
+        run: |
+          BASE_VERSION=$(node -p "require('./packages/memory-server/package.json').version")
+          BASE_VERSION="${BASE_VERSION%-SNAPSHOT}"
+          TIMESTAMP=$(date -u +%Y%m%d%H%M%S)
+          COMMIT_SHA=$(git rev-parse --short HEAD)
+          CANARY_VERSION="${BASE_VERSION}-canary.${TIMESTAMP}.${COMMIT_SHA}"
+          echo "value=$CANARY_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Set canary version for core package
+        run: npm version "${{ steps.version.outputs.value }}" --workspace @jongodb/memory-server --no-git-tag-version
+
+      - name: Pack core canary artifact
+        id: pack
+        shell: bash
+        run: |
+          mkdir -p "${RUNNER_TEMP}/npm-pack"
+          PACK_FILE=$(npm pack "./packages/memory-server" --pack-destination "${RUNNER_TEMP}/npm-pack" | tail -n 1)
+          PACK_PATH="${RUNNER_TEMP}/npm-pack/${PACK_FILE}"
+          if [[ ! -f "$PACK_PATH" ]]; then
+            echo "Packed tarball not found: $PACK_PATH"
+            exit 1
+          fi
+          echo "file=$PACK_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Attest canary package provenance (SLSA)
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: ${{ steps.pack.outputs.file }}
+
+      - name: npm publish dry-run (canary)
+        run: npm publish "${{ steps.pack.outputs.file }}" --tag canary --access public --provenance --dry-run
+
+      - name: Validate npm credentials for publish
+        if: steps.mode.outputs.should_publish == 'true'
+        shell: bash
+        run: |
+          if [[ -z "${NPM_TOKEN}" ]]; then
+            echo "NPM_TOKEN secret is required for canary publish runs."
+            exit 1
+          fi
+
+      - name: npm publish canary
+        if: steps.mode.outputs.should_publish == 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish "${{ steps.pack.outputs.file }}" --tag canary --access public --provenance
+
+      - name: Publish summary
+        shell: bash
+        run: |
+          {
+            echo "### Node Canary Release"
+            echo "- version: \`${{ steps.version.outputs.value }}\`"
+            echo "- should_publish: \`${{ steps.mode.outputs.should_publish }}\`"
+            echo "- package: \`@jongodb/memory-server\`"
+            echo "- dist-tag: \`canary\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project are documented in this file.
 - Added Prisma MongoDB provider CRUD smoke harness with generated client workflow in node-compat suite.
 - Added node adapter compatibility CI matrix across Ubuntu/macOS and Node 20/22.
 - Added npm release pipeline tarball attestation flow (`actions/attest-build-provenance`) for binary/core Node packages.
+- Added Node adapter canary pre-release workflow with canary dist-tag publish automation and attested tarball flow.
 
 ## [0.1.3] - 2026-02-24
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -55,6 +55,16 @@ Use this when publishing `@jongodb/memory-server`:
 11. Publish only when `NPM_TOKEN` is configured and verify npm registry visibility.
 12. Update README usage examples with the released package version.
 
+## Node Canary Channel Gate (Draft)
+
+Use this when validating `@jongodb/memory-server` canary automation:
+
+1. Confirm `Node Adapter Canary Release` workflow is configured on `main` push and `workflow_dispatch`.
+2. Confirm generated version format includes canary suffix (`<base>-canary.<UTC timestamp>.<short sha>`).
+3. Confirm workflow packs the npm tarball, attests it (`actions/attest-build-provenance`), then publishes from that tarball.
+4. Confirm publish uses npm dist-tag `canary` (never `latest`).
+5. Confirm dry-run path works without publish credentials (`publish=false` in manual run).
+
 ## Release History
 
 | Version | Date (UTC) | Commit | Maven | GitHub Actions |

--- a/packages/memory-server/README.md
+++ b/packages/memory-server/README.md
@@ -46,6 +46,12 @@ Node adapter compatibility smoke runs in CI across:
 npm i -D @jongodb/memory-server
 ```
 
+Canary channel:
+
+```bash
+npm i -D @jongodb/memory-server@canary
+```
+
 ## Module Format
 
 This package supports both:


### PR DESCRIPTION
## Summary
- add `Node Adapter Canary Release` workflow for automated canary channel publication
- generate canary version suffix from base version + UTC timestamp + commit SHA
- publish canary from packed tarball with npm provenance and GitHub attestation
- document canary install/gate steps in README and release checklist

## Validation
- npm run node:build

Closes #303
