### PR TITLE
docs(node): add semver and compatibility policy guide (#304)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project are documented in this file.
 - Added node adapter compatibility CI matrix across Ubuntu/macOS and Node 20/22.
 - Added npm release pipeline tarball attestation flow (`actions/attest-build-provenance`) for binary/core Node packages.
 - Added Node adapter canary pre-release workflow with canary dist-tag publish automation and attested tarball flow.
+- Added Node adapter semver/compatibility policy documentation (`docs/NODE_SEMVER_POLICY.md`).
 
 ## [0.1.3] - 2026-02-24
 

--- a/docs/NODE_SEMVER_POLICY.md
+++ b/docs/NODE_SEMVER_POLICY.md
@@ -1,0 +1,64 @@
+# Node Adapter Semver and Compatibility Policy
+
+Applies to:
+- `@jongodb/memory-server`
+- `@jongodb/memory-server-bin-*` optional binary packages
+
+## Semver Rules
+
+1. Stable releases follow SemVer (`MAJOR.MINOR.PATCH`).
+2. `PATCH` releases:
+   - bug fixes and internal hardening
+   - no intended public API/behavior break
+3. `MINOR` releases:
+   - backward-compatible API additions
+   - new integrations, options, diagnostics, and non-breaking defaults
+4. `MAJOR` releases:
+   - breaking public API changes
+   - behavior changes that require user migration
+
+## Pre-Release Channels
+
+- Canary channel publishes with npm dist-tag `canary`.
+- Canary version format:
+  - `<base>-canary.<UTC timestamp>.<short sha>`
+- Canary builds are for early feedback and may change without deprecation windows.
+
+## Compatibility Contract
+
+- Runtime baseline:
+  - Node.js `20+`
+- Launch modes:
+  - binary launch when bundled platform binary exists
+  - Java fallback (`JONGODB_CLASSPATH`) remains supported
+- Module contract:
+  - ESM and CommonJS both supported for the public runtime API
+- Framework integration scope:
+  - Jest / Vitest / Nest Jest helpers
+  - compatibility smoke coverage for mongodb driver, express, koa, mongoose, prisma, typeorm
+
+## Core vs Binary Package Versioning
+
+- Stable release line:
+  - core package and platform binary packages are version-aligned for the same release tag.
+- Canary line:
+  - canary publish currently targets `@jongodb/memory-server` with `canary` dist-tag.
+  - optional binary dependencies may stay pinned to the latest stable release unless a dedicated canary binary publish is introduced.
+
+## Deprecation and Removal Policy
+
+1. Deprecations are announced in `CHANGELOG.md` and release notes before removal.
+2. Deprecated public options should remain available for at least one minor release cycle, unless a security or correctness issue requires immediate removal.
+3. Breaking removals must include migration notes in docs and release notes.
+
+## Release Safety Gates
+
+Before publishing stable Node adapter releases:
+- pass Node adapter verify checks (`node:build`, `node:typecheck`, smoke workflow)
+- publish/verify attested tarball artifacts in release workflow
+- confirm compatibility and release checklist documents are current
+
+Related docs:
+- `docs/RELEASE_CHECKLIST.md`
+- `docs/NODE_COMPAT_SMOKE.md`
+- `packages/memory-server/README.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Runtime and compatibility:
 - `docs/COMPLEX_QUERY_CERTIFICATION.md`
 - `docs/COMPATIBILITY_SCORECARD.md`
 - `docs/NODE_COMPAT_SMOKE.md`
+- `docs/NODE_SEMVER_POLICY.md`
 - `docs/SUPPORT_MATRIX.md`
 - `docs/RELEASE_CHECKLIST.md`
 - `docs/ROADMAP.md`

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -41,19 +41,20 @@ Use this when publishing `@jongodb/memory-server`:
 
 1. Confirm `Node Adapter Release` workflow verify job is green.
 2. Confirm package version is set explicitly (tag `node-vX.Y.Z` or manual input).
-3. Confirm npm scope ownership for `@jongodb` and valid `NPM_TOKEN` in GitHub repository secrets.
-4. Confirm GraalVM native-image is available in workflow runners (linux, macOS, windows) for binary jobs.
-5. Confirm platform binary packages publish first:
+3. Confirm version bump rationale aligns with `docs/NODE_SEMVER_POLICY.md` (patch/minor/major classification).
+4. Confirm npm scope ownership for `@jongodb` and valid `NPM_TOKEN` in GitHub repository secrets.
+5. Confirm GraalVM native-image is available in workflow runners (linux, macOS, windows) for binary jobs.
+6. Confirm platform binary packages publish first:
    - `@jongodb/memory-server-bin-linux-x64-gnu`
    - `@jongodb/memory-server-bin-darwin-arm64`
    - `@jongodb/memory-server-bin-win32-x64`
-6. Confirm core package publishes after binaries with synced optional dependency versions.
-7. For manual workflow runs, never set `publish=true` with empty `version` (workflow blocks this).
-8. Confirm workflow packs tarball artifacts first (binary/core) and publishes from those packed files.
-9. Confirm GitHub Artifact Attestations are generated for packed tarballs (`actions/attest-build-provenance`).
-10. Run `npm publish --dry-run` and review package contents.
-11. Publish only when `NPM_TOKEN` is configured and verify npm registry visibility.
-12. Update README usage examples with the released package version.
+7. Confirm core package publishes after binaries with synced optional dependency versions.
+8. For manual workflow runs, never set `publish=true` with empty `version` (workflow blocks this).
+9. Confirm workflow packs tarball artifacts first (binary/core) and publishes from those packed files.
+10. Confirm GitHub Artifact Attestations are generated for packed tarballs (`actions/attest-build-provenance`).
+11. Run `npm publish --dry-run` and review package contents.
+12. Publish only when `NPM_TOKEN` is configured and verify npm registry visibility.
+13. Update README usage examples with the released package version.
 
 ## Node Canary Channel Gate (Draft)
 

--- a/packages/memory-server/README.md
+++ b/packages/memory-server/README.md
@@ -40,6 +40,11 @@ Node adapter compatibility smoke runs in CI across:
 - OS: `ubuntu-latest`, `macos-latest`
 - Node: `20`, `22`
 
+## Versioning Policy
+
+SemVer/compatibility policy for Node adapter releases:
+- [`docs/NODE_SEMVER_POLICY.md`](../../docs/NODE_SEMVER_POLICY.md)
+
 ## Install
 
 ```bash


### PR DESCRIPTION
## Summary
- add `docs/NODE_SEMVER_POLICY.md` for Node adapter semver, compatibility, and deprecation rules
- document stable/canary versioning expectations and release safety gates
- link policy from docs index, memory-server README, and release checklist

## Validation
- documentation-only update; no runtime code changes

Closes #304
