### PR TITLE
docs(node): add troubleshooting playbook by error signature (#306)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project are documented in this file.
 - Added Node adapter canary pre-release workflow with canary dist-tag publish automation and attested tarball flow.
 - Added Node adapter semver/compatibility policy documentation (`docs/NODE_SEMVER_POLICY.md`).
 - Added dedicated migration guide from `mongodb-memory-server` to `@jongodb/memory-server`.
+- Added Node adapter troubleshooting playbook mapped by error signatures.
 
 ## [0.1.3] - 2026-02-24
 

--- a/docs/NODE_TROUBLESHOOTING_PLAYBOOK.md
+++ b/docs/NODE_TROUBLESHOOTING_PLAYBOOK.md
@@ -1,0 +1,65 @@
+# Node Adapter Troubleshooting Playbook (Error Signature Based)
+
+Use this playbook when `@jongodb/memory-server` startup or test-runtime integration fails.
+
+## Quick Triage Flow
+
+1. Capture the exact error message (first line + stack origin).
+2. Match message text in the signature table below.
+3. Apply the corresponding fix.
+4. Re-run with debug logging (`logLevel: "debug"`) if still unresolved.
+
+## Signature Table
+
+| Error signature (contains) | Likely cause | Primary fix |
+| --- | --- | --- |
+| `No launcher runtime configured` | neither binary nor Java classpath resolved | set `binaryPath` / `JONGODB_BINARY_PATH`, or set `classpath` / `JONGODB_CLASSPATH` |
+| `Binary launch mode requested but no binary was found` | `launchMode: "binary"` but executable is not resolvable | provide explicit `binaryPath` or set `JONGODB_BINARY_PATH` |
+| `Java launch mode requested but Java classpath is not configured` | `launchMode: "java"` without classpath | pass `classpath` option or export `JONGODB_CLASSPATH` |
+| `Failed to start jongodb with available launch configurations` | all launch candidates failed (binary/java) | inspect aggregated `[binary:...]` / `[java:...]` messages and fix per candidate |
+| `Launcher emitted empty JONGODB_URI line` | launcher started but did not emit valid URI contract | verify launcher command args/env; update runtime/binary to a compatible build |
+| `Requested topologyProfile=singleNodeReplicaSet but URI is missing replicaSet query` | topology profile and emitted URI are mismatched | ensure launcher emits `?replicaSet=<name>` or switch to `topologyProfile: "standalone"` |
+| `Requested topologyProfile=standalone but URI includes replicaSet query` | standalone profile requested, replica-set URI emitted | remove replica-set URI query or request replica-set profile explicitly |
+| `Requested replicaSetName does not match URI replicaSet query` | configured replica set name differs from emitted URI | align `replicaSetName` with launcher output |
+| `Jest global state file has invalid schema` | stale/corrupted `.jongodb/jest-memory-server.json` | delete state file and rerun setup |
+| `Unable to stop detached Jest process pid=` | detached launcher process did not terminate cleanly | verify PID ownership/process health and rerun teardown; if needed kill process manually |
+| `envVarName/envVarNames entries must not be empty` | invalid runtime/jest/vitest env key config | ensure all env var names are non-empty trimmed strings |
+| `projectName must not be empty` | invalid Vitest workspace integration input | provide non-empty `projectName` for `registerJongodbForVitestWorkspace` |
+
+## Fast Fix Commands
+
+Resolve Java classpath in repo:
+
+```bash
+export JONGODB_CLASSPATH="$(./.tooling/gradle-8.10.2/bin/gradle --no-daemon -q printLauncherClasspath | tail -n 1)"
+```
+
+Run node compatibility smoke after fix:
+
+```bash
+npm run node:build
+npm --prefix testkit/node-compat test
+```
+
+Clear Jest global runtime state:
+
+```bash
+rm -f .jongodb/jest-memory-server.json
+```
+
+## Configuration Sanity Checklist
+
+- `launchMode` is one of `auto`, `binary`, `java`.
+- `host`, `port`, `databaseName` values are valid/non-empty.
+- `topologyProfile` and `replicaSetName` match expected URI contract.
+- `envVarName` / `envVarNames` are valid and unique for your test runtime.
+- CI runner has either bundled binary availability or Java classpath setup.
+
+## Escalation Data to Attach
+
+When opening an issue, include:
+- exact error message
+- runtime options (without secrets)
+- launch mode (`auto` / `binary` / `java`)
+- Node version + OS
+- whether failure is local-only or CI-only

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Runtime and compatibility:
 - `docs/NODE_COMPAT_SMOKE.md`
 - `docs/NODE_MIGRATION_FROM_MONGODB_MEMORY_SERVER.md`
 - `docs/NODE_SEMVER_POLICY.md`
+- `docs/NODE_TROUBLESHOOTING_PLAYBOOK.md`
 - `docs/SUPPORT_MATRIX.md`
 - `docs/RELEASE_CHECKLIST.md`
 - `docs/ROADMAP.md`

--- a/packages/memory-server/README.md
+++ b/packages/memory-server/README.md
@@ -254,6 +254,11 @@ Launcher contract:
 - process stays alive until termination signal
 - runtime validates URI topology sync (requested `topologyProfile` vs emitted `replicaSet` query)
 
+## Troubleshooting
+
+Signature-based troubleshooting playbook:
+- [`docs/NODE_TROUBLESHOOTING_PLAYBOOK.md`](../../docs/NODE_TROUBLESHOOTING_PLAYBOOK.md)
+
 ## API Surface
 
 Main export (`@jongodb/memory-server`):


### PR DESCRIPTION
## Summary
- add `docs/NODE_TROUBLESHOOTING_PLAYBOOK.md` with signature-based diagnosis and fix actions
- document common launcher/topology/jest-runtime error signatures with direct remediation
- link playbook from docs index and memory-server README troubleshooting section

## Validation
- documentation-only update

Closes #306
