### PR TITLE
feat(node): add strict api type coverage report workflow (#307)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project are documented in this file.
 - Added Node adapter semver/compatibility policy documentation (`docs/NODE_SEMVER_POLICY.md`).
 - Added dedicated migration guide from `mongodb-memory-server` to `@jongodb/memory-server`.
 - Added Node adapter troubleshooting playbook mapped by error signatures.
+- Added strict Node API type coverage report workflow and export coverage report artifact.
 
 ## [0.1.3] - 2026-02-24
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "node:build": "npm run --workspace @jongodb/memory-server build",
     "node:test": "npm run --workspace @jongodb/memory-server test",
     "node:typecheck": "npm run --workspace @jongodb/memory-server typecheck",
+    "node:type:report": "npm run --workspace @jongodb/memory-server type:report",
     "node:release:check": "npm run --workspace @jongodb/memory-server release:check",
     "node:sync-bin-optional-deps": "node ./scripts/node/sync-memory-server-optional-bins.mjs",
     "node:benchmark:native-profiles": "node ./scripts/node/benchmark-native-image-profiles.mjs"

--- a/packages/memory-server/README.md
+++ b/packages/memory-server/README.md
@@ -325,6 +325,15 @@ Run Node adapter contract tests:
 npm run --workspace @jongodb/memory-server test
 ```
 
+Run strict API type coverage report:
+
+```bash
+npm run node:type:report
+```
+
+Report output:
+- `packages/memory-server/reports/type-api-coverage.md`
+
 Scoped env example:
 
 ```ts

--- a/packages/memory-server/package.json
+++ b/packages/memory-server/package.json
@@ -114,10 +114,11 @@
     "build:cjs": "tsc -p tsconfig.build.cjs.json",
     "build:post": "node ./scripts/write-cjs-package.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "type:report": "npm run typecheck && npm run build:esm && node ./scripts/type-api-coverage-report.mjs",
     "pretest": "npm run build",
     "test": "node --test dist/esm/test/*.test.js && node ./scripts/cjs-smoke.cjs",
     "prepack": "npm run clean && npm run build",
-    "release:check": "npm run build && npm run typecheck && npm run test && npm pack --dry-run"
+    "release:check": "npm run build && npm run type:report && npm run test && npm pack --dry-run"
   },
   "devDependencies": {
     "@types/node": "^20.17.57",

--- a/packages/memory-server/reports/type-api-coverage.md
+++ b/packages/memory-server/reports/type-api-coverage.md
@@ -1,0 +1,15 @@
+# Type API Coverage Report
+
+Strict type gate:
+- `npm run typecheck`
+- `npm run build:esm`
+
+| Export subpath | Source exports | Declaration exports | Missing | Coverage |
+| --- | ---: | ---: | ---: | ---: |
+| `.` | 3 | 3 | 0 | 100.00% |
+| `./runtime` | 3 | 3 | 0 | 100.00% |
+| `./jest` | 10 | 10 | 0 | 100.00% |
+| `./nestjs` | 4 | 4 | 0 | 100.00% |
+| `./vitest` | 8 | 8 | 0 | 100.00% |
+
+Overall: 28/28 (100.00%)

--- a/packages/memory-server/scripts/type-api-coverage-report.mjs
+++ b/packages/memory-server/scripts/type-api-coverage-report.mjs
@@ -1,0 +1,185 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import ts from "typescript";
+
+const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
+const packageDir = path.resolve(scriptsDir, "..");
+const reportPath = path.join(packageDir, "reports", "type-api-coverage.md");
+
+const modules = [
+  {
+    subpath: ".",
+    source: path.join(packageDir, "src", "index.ts"),
+    declaration: path.join(packageDir, "dist", "esm", "index.d.ts"),
+  },
+  {
+    subpath: "./runtime",
+    source: path.join(packageDir, "src", "runtime.ts"),
+    declaration: path.join(packageDir, "dist", "esm", "runtime.d.ts"),
+  },
+  {
+    subpath: "./jest",
+    source: path.join(packageDir, "src", "jest.ts"),
+    declaration: path.join(packageDir, "dist", "esm", "jest.d.ts"),
+  },
+  {
+    subpath: "./nestjs",
+    source: path.join(packageDir, "src", "nestjs.ts"),
+    declaration: path.join(packageDir, "dist", "esm", "nestjs.d.ts"),
+  },
+  {
+    subpath: "./vitest",
+    source: path.join(packageDir, "src", "vitest.ts"),
+    declaration: path.join(packageDir, "dist", "esm", "vitest.d.ts"),
+  },
+];
+
+const rows = [];
+let totalExports = 0;
+let totalMissing = 0;
+
+for (const entry of modules) {
+  const sourceText = await readFile(entry.source, "utf8");
+  const declarationText = await readFile(entry.declaration, "utf8");
+
+  const sourceExports = collectExportedNames(sourceText, entry.source);
+  const declarationExports = collectExportedNames(
+    declarationText,
+    entry.declaration
+  );
+
+  const missing = [...sourceExports].filter(
+    (name) => !declarationExports.has(name)
+  );
+  const coverage =
+    sourceExports.size === 0
+      ? 100
+      : Math.round(
+          ((sourceExports.size - missing.length) / sourceExports.size) * 10_000
+        ) / 100;
+
+  totalExports += sourceExports.size;
+  totalMissing += missing.length;
+
+  rows.push({
+    subpath: entry.subpath,
+    sourceExportCount: sourceExports.size,
+    declarationExportCount: declarationExports.size,
+    missing,
+    coverage,
+  });
+}
+
+const overallCoverage =
+  totalExports === 0
+    ? 100
+    : Math.round(((totalExports - totalMissing) / totalExports) * 10_000) / 100;
+
+const reportLines = [
+  "# Type API Coverage Report",
+  "",
+  "Strict type gate:",
+  "- `npm run typecheck`",
+  "- `npm run build:esm`",
+  "",
+  "| Export subpath | Source exports | Declaration exports | Missing | Coverage |",
+  "| --- | ---: | ---: | ---: | ---: |",
+  ...rows.map(
+    (row) =>
+      `| \`${row.subpath}\` | ${row.sourceExportCount} | ${row.declarationExportCount} | ${row.missing.length} | ${row.coverage.toFixed(
+        2
+      )}% |`
+  ),
+  "",
+  `Overall: ${totalExports - totalMissing}/${totalExports} (${overallCoverage.toFixed(
+    2
+  )}%)`,
+];
+
+for (const row of rows) {
+  if (row.missing.length === 0) {
+    continue;
+  }
+  reportLines.push("");
+  reportLines.push(`## Missing exports in \`${row.subpath}\``);
+  for (const name of row.missing) {
+    reportLines.push(`- \`${name}\``);
+  }
+}
+
+await mkdir(path.dirname(reportPath), { recursive: true });
+await writeFile(reportPath, `${reportLines.join("\n")}\n`, "utf8");
+
+console.log(`Type API coverage report written: ${reportPath}`);
+console.log(
+  `Type API coverage summary: exports=${totalExports} missing=${totalMissing} coverage=${overallCoverage.toFixed(
+    2
+  )}%`
+);
+
+if (totalMissing > 0) {
+  throw new Error(
+    `Type API declaration coverage check failed (missing ${totalMissing} exports).`
+  );
+}
+
+function collectExportedNames(sourceText, filePath) {
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true
+  );
+  const names = new Set();
+
+  for (const node of sourceFile.statements) {
+    if (ts.isExportDeclaration(node)) {
+      if (
+        node.exportClause !== undefined &&
+        ts.isNamedExports(node.exportClause)
+      ) {
+        for (const element of node.exportClause.elements) {
+          names.add(element.name.text);
+        }
+      }
+      continue;
+    }
+
+    if (!hasExportModifier(node)) {
+      continue;
+    }
+
+    if (
+      ts.isInterfaceDeclaration(node) ||
+      ts.isTypeAliasDeclaration(node) ||
+      ts.isFunctionDeclaration(node) ||
+      ts.isClassDeclaration(node) ||
+      ts.isEnumDeclaration(node)
+    ) {
+      if (node.name !== undefined) {
+        names.add(node.name.text);
+      }
+      continue;
+    }
+
+    if (ts.isVariableStatement(node)) {
+      for (const declaration of node.declarationList.declarations) {
+        if (ts.isIdentifier(declaration.name)) {
+          names.add(declaration.name.text);
+        }
+      }
+    }
+  }
+
+  return names;
+}
+
+function hasExportModifier(node) {
+  return (
+    node.modifiers?.some(
+      (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword
+    ) ?? false
+  );
+}


### PR DESCRIPTION
## Summary
- add strict API type coverage report script for `@jongodb/memory-server` public export subpaths
- add workspace command `node:type:report` and package script `type:report` for strict check + declaration coverage verification
- generate and track `packages/memory-server/reports/type-api-coverage.md` as the coverage report artifact

## Testing
- npm run node:type:report

Closes #307
