### PR TITLE
feat(node): add startup latency telemetry hook with fallback events (#290)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to this project are documented in this file.
 - Added Node cold-start benchmark suite with CI budget gate and report artifacts.
 - Added runtime launcher log secret redaction policy and regression coverage.
 - Added Node debug bundle collector CLI and issue template for reproducible support reports.
+- Added startup latency telemetry hook for launch attempts (including auto fallback success/failure events).
 
 ## [0.1.3] - 2026-02-24
 

--- a/packages/memory-server/README.md
+++ b/packages/memory-server/README.md
@@ -307,6 +307,7 @@ Core:
 - `stopTimeoutMs`: stop timeout before forced kill (default: `5000`)
 - `env`: extra child process environment variables
 - `logLevel`: `silent` | `info` | `debug` (default: `silent`)
+- `onStartupTelemetry`: optional hook for startup attempt telemetry (`attempt`, `mode`, `source`, `startupDurationMs`, `success`, `errorMessage`)
 
 Runtime helper options:
 - `envVarName`: single target env key (default: `MONGODB_URI`)


### PR DESCRIPTION
## Summary
- add `onStartupTelemetry` hook to `startJongodbMemoryServer` options
- emit startup telemetry events per launch attempt with duration/success/error context
- cover success and auto-fallback failure->recovery event flow in regression tests
- document startup telemetry hook in README options reference

## Testing
- npm run node:build
- node --test packages/memory-server/dist/esm/test/binary-launcher.test.js

Closes #290
