### PR TITLE
feat(node): add launcher doctor preflight diagnostics command (#283)

### DIFF
--- a/.github/ISSUE_TEMPLATE/node-memory-server-debug.yml
+++ b/.github/ISSUE_TEMPLATE/node-memory-server-debug.yml
@@ -11,10 +11,12 @@ body:
         Please run the debug bundle collector before filing:
 
         ```bash
+        npm run node:doctor -- --outputDir build/reports/node-doctor
         npm run node:debug:bundle -- --outputDir build/reports/node-debug-bundle
         ```
 
         Attach:
+        - `build/reports/node-doctor/doctor.json` (or `doctor.md`)
         - `build/reports/node-debug-bundle/bundle.json`
         - `build/reports/node-debug-bundle/SUMMARY.md`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project are documented in this file.
 - Added runtime launcher log secret redaction policy and regression coverage.
 - Added Node debug bundle collector CLI and issue template for reproducible support reports.
 - Added startup latency telemetry hook for launch attempts (including auto fallback success/failure events).
+- Added `node:doctor` launcher preflight diagnostics command with structured report output.
 
 ## [0.1.3] - 2026-02-24
 

--- a/docs/NODE_DOCTOR.md
+++ b/docs/NODE_DOCTOR.md
@@ -1,0 +1,37 @@
+# Node Launcher Doctor (Preflight Diagnostics)
+
+`node:doctor` checks launcher preflight health for `@jongodb/memory-server`.
+
+## Command
+
+```bash
+npm run node:doctor -- --outputDir build/reports/node-doctor
+```
+
+Outputs:
+- `build/reports/node-doctor/doctor.json`
+- `build/reports/node-doctor/doctor.md`
+
+## What It Checks
+
+- Node version baseline (`>=20`)
+- memory-server build artifact presence
+- `JONGODB_BINARY_PATH` validity (if configured)
+- bundled binary package resolution for current platform/arch
+- classpath availability:
+  - direct `JONGODB_CLASSPATH`
+  - Gradle auto-probe (`gradle -q printLauncherClasspath`)
+- aggregate runtime preflight readiness (binary or classpath available)
+
+## Exit Behavior
+
+- exits with non-zero code on failing checks by default
+- use `--no-fail true` to always exit zero while still producing reports
+
+## Recommended Usage
+
+Run before filing runtime issues and attach report files.
+
+Related:
+- `docs/NODE_DEBUG_BUNDLE.md`
+- `docs/NODE_TROUBLESHOOTING_PLAYBOOK.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Runtime and compatibility:
 - `docs/NODE_COMPAT_SMOKE.md`
 - `docs/NODE_COLD_START_BENCHMARK.md`
 - `docs/NODE_DEBUG_BUNDLE.md`
+- `docs/NODE_DOCTOR.md`
 - `docs/NODE_LOG_REDACTION_POLICY.md`
 - `docs/NODE_MIGRATION_FROM_MONGODB_MEMORY_SERVER.md`
 - `docs/NODE_SEMVER_POLICY.md`

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "node:release:check": "npm run --workspace @jongodb/memory-server release:check",
     "node:benchmark:cold-start": "node ./scripts/node/benchmark-memory-server-cold-start.mjs",
     "node:debug:bundle": "node ./scripts/node/collect-memory-server-debug-bundle.mjs",
+    "node:doctor": "node ./scripts/node/memory-server-doctor.mjs",
     "node:sync-bin-optional-deps": "node ./scripts/node/sync-memory-server-optional-bins.mjs",
     "node:benchmark:native-profiles": "node ./scripts/node/benchmark-native-image-profiles.mjs"
   }

--- a/packages/memory-server/README.md
+++ b/packages/memory-server/README.md
@@ -372,3 +372,5 @@ Security policy reference:
 Support/debug bundle:
 - generate issue bundle: `npm run node:debug:bundle -- --outputDir build/reports/node-debug-bundle`
 - collector guide: [`docs/NODE_DEBUG_BUNDLE.md`](../../docs/NODE_DEBUG_BUNDLE.md)
+- preflight doctor: `npm run node:doctor -- --outputDir build/reports/node-doctor`
+- doctor guide: [`docs/NODE_DOCTOR.md`](../../docs/NODE_DOCTOR.md)

--- a/scripts/node/memory-server-doctor.mjs
+++ b/scripts/node/memory-server-doctor.mjs
@@ -1,0 +1,333 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const requireFromRoot = createRequire(path.resolve(process.cwd(), "__doctor_resolver__.cjs"));
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`[node-doctor] ${message}`);
+  process.exit(1);
+});
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const repoRoot = resolveRepoRoot();
+  const outputDir = path.resolve(repoRoot, args.outputDir ?? "build/reports/node-doctor");
+  const shouldFailOnIssues = args["no-fail"] !== "true";
+
+  const checks = [];
+  checks.push(checkNodeVersion());
+  checks.push(checkBuildArtifacts(repoRoot));
+  checks.push(checkBinaryEnvPath());
+
+  const bundledBinary = resolveBundledBinary(repoRoot);
+  checks.push(bundledBinary.check);
+
+  const classpathEnv = process.env.JONGODB_CLASSPATH?.trim() ?? "";
+  if (classpathEnv.length > 0) {
+    checks.push({
+      id: "classpath-env",
+      status: "pass",
+      summary: "JONGODB_CLASSPATH is set.",
+      details: truncate(classpathEnv, 400),
+    });
+  } else {
+    const classpathProbe = resolveClasspathViaGradle(repoRoot);
+    checks.push(classpathProbe.check);
+  }
+
+  const hasAnyRuntimePath =
+    checkPassed(checks, "binary-env-path") ||
+    checkPassed(checks, "bundled-binary") ||
+    checkPassed(checks, "classpath-env") ||
+    checkPassed(checks, "classpath-gradle");
+
+  checks.push({
+    id: "runtime-preflight",
+    status: hasAnyRuntimePath ? "pass" : "fail",
+    summary: hasAnyRuntimePath
+      ? "At least one launcher runtime path is available."
+      : "No launcher runtime path detected (binary/classpath missing).",
+    details: hasAnyRuntimePath
+      ? "binary or classpath is resolvable."
+      : "Configure JONGODB_BINARY_PATH, bundled binaries, or JONGODB_CLASSPATH.",
+  });
+
+  const report = {
+    generatedAt: new Date().toISOString(),
+    host: {
+      platform: process.platform,
+      arch: process.arch,
+      node: process.version,
+    },
+    checks,
+  };
+
+  mkdirSync(outputDir, { recursive: true });
+  const jsonPath = path.join(outputDir, "doctor.json");
+  const markdownPath = path.join(outputDir, "doctor.md");
+  writeFileSync(jsonPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  writeFileSync(markdownPath, toMarkdown(report), "utf8");
+
+  console.log(`[node-doctor] report=${jsonPath}`);
+  console.log(`[node-doctor] report=${markdownPath}`);
+
+  const hasFail = checks.some((entry) => entry.status === "fail");
+  if (hasFail && shouldFailOnIssues) {
+    throw new Error("Doctor detected failing preflight checks.");
+  }
+}
+
+function checkNodeVersion() {
+  const major = Number.parseInt(process.versions.node.split(".")[0] ?? "0", 10);
+  if (major >= 20) {
+    return {
+      id: "node-version",
+      status: "pass",
+      summary: `Node version is supported (${process.version}).`,
+      details: "Required: >=20",
+    };
+  }
+  return {
+    id: "node-version",
+    status: "fail",
+    summary: `Node version is unsupported (${process.version}).`,
+    details: "Required: >=20",
+  };
+}
+
+function checkBuildArtifacts(repoRoot) {
+  const esmEntry = path.join(repoRoot, "packages/memory-server/dist/esm/index.js");
+  if (!existsSync(esmEntry)) {
+    return {
+      id: "build-artifacts",
+      status: "warn",
+      summary: "memory-server dist artifacts not found.",
+      details: "Run: npm run node:build",
+    };
+  }
+  return {
+    id: "build-artifacts",
+    status: "pass",
+    summary: "memory-server build artifacts exist.",
+    details: esmEntry,
+  };
+}
+
+function checkBinaryEnvPath() {
+  const candidate = process.env.JONGODB_BINARY_PATH?.trim() ?? "";
+  if (candidate.length === 0) {
+    return {
+      id: "binary-env-path",
+      status: "warn",
+      summary: "JONGODB_BINARY_PATH is not set.",
+      details: "Optional; bundled binary or classpath may still be used.",
+    };
+  }
+  if (!existsSync(candidate)) {
+    return {
+      id: "binary-env-path",
+      status: "fail",
+      summary: "JONGODB_BINARY_PATH is set but file does not exist.",
+      details: candidate,
+    };
+  }
+  return {
+    id: "binary-env-path",
+    status: "pass",
+    summary: "JONGODB_BINARY_PATH points to an existing file.",
+    details: candidate,
+  };
+}
+
+function resolveBundledBinary(repoRoot) {
+  const packageName = detectBundledPackageName();
+  if (packageName === null) {
+    return {
+      check: {
+        id: "bundled-binary",
+        status: "warn",
+        summary: "No bundled binary mapping for current platform/arch.",
+        details: `${process.platform}/${process.arch}`,
+      },
+    };
+  }
+
+  try {
+    const packageJsonPath = requireFromRoot.resolve(`${packageName}/package.json`);
+    const parsed = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+    const binaryRelativePath = parsed?.jongodb?.binary;
+    if (typeof binaryRelativePath !== "string" || binaryRelativePath.trim().length === 0) {
+      return {
+        check: {
+          id: "bundled-binary",
+          status: "warn",
+          summary: `Bundled package '${packageName}' found but binary metadata is missing.`,
+          details: packageJsonPath,
+        },
+      };
+    }
+    const packageDir = path.dirname(packageJsonPath);
+    const binaryPath = path.resolve(packageDir, binaryRelativePath);
+    if (!existsSync(binaryPath)) {
+      return {
+        check: {
+          id: "bundled-binary",
+          status: "fail",
+          summary: `Bundled package '${packageName}' found but binary file is missing.`,
+          details: binaryPath,
+        },
+      };
+    }
+    const sizeBytes = statSync(binaryPath).size;
+    return {
+      check: {
+        id: "bundled-binary",
+        status: "pass",
+        summary: `Bundled binary package '${packageName}' is available.`,
+        details: `${path.relative(repoRoot, binaryPath)} (${sizeBytes} bytes)`,
+      },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      check: {
+        id: "bundled-binary",
+        status: "warn",
+        summary: `Bundled binary package '${packageName}' is not resolvable in current install.`,
+        details: message,
+      },
+    };
+  }
+}
+
+function resolveClasspathViaGradle(repoRoot) {
+  const gradleCmd = resolveGradleCmd(repoRoot);
+  try {
+    const output = execFileSync(gradleCmd, ["--no-daemon", "-q", "printLauncherClasspath"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const classpath = output
+      .split(/\r?\n/u)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+      .at(-1);
+    if (classpath === undefined || classpath.length === 0) {
+      return {
+        check: {
+          id: "classpath-gradle",
+          status: "fail",
+          summary: "Gradle classpath probe returned empty output.",
+          details: `${gradleCmd} --no-daemon -q printLauncherClasspath`,
+        },
+      };
+    }
+    return {
+      check: {
+        id: "classpath-gradle",
+        status: "pass",
+        summary: "Gradle classpath auto-probe succeeded.",
+        details: truncate(classpath, 400),
+      },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      check: {
+        id: "classpath-gradle",
+        status: "warn",
+        summary: "Gradle classpath auto-probe failed.",
+        details: `${gradleCmd} --no-daemon -q printLauncherClasspath | ${message}`,
+      },
+    };
+  }
+}
+
+function resolveGradleCmd(repoRoot) {
+  const repoLocalGradle = path.resolve(repoRoot, ".tooling/gradle-8.10.2/bin/gradle");
+  if (existsSync(repoLocalGradle)) {
+    return repoLocalGradle;
+  }
+  return "gradle";
+}
+
+function detectBundledPackageName() {
+  if (process.platform === "darwin" && process.arch === "arm64") {
+    return "@jongodb/memory-server-bin-darwin-arm64";
+  }
+  if (process.platform === "linux" && process.arch === "x64") {
+    return "@jongodb/memory-server-bin-linux-x64-gnu";
+  }
+  if (process.platform === "win32" && process.arch === "x64") {
+    return "@jongodb/memory-server-bin-win32-x64";
+  }
+  return null;
+}
+
+function checkPassed(checks, id) {
+  return checks.some((entry) => entry.id === id && entry.status === "pass");
+}
+
+function parseArgs(argv) {
+  const parsed = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const current = argv[index];
+    if (!current.startsWith("--")) {
+      continue;
+    }
+    const normalized = current.slice(2);
+    const equalIndex = normalized.indexOf("=");
+    if (equalIndex >= 0) {
+      parsed[normalized.slice(0, equalIndex)] = normalized.slice(equalIndex + 1);
+      continue;
+    }
+    const next = argv[index + 1];
+    if (next !== undefined && !next.startsWith("--")) {
+      parsed[normalized] = next;
+      index += 1;
+      continue;
+    }
+    parsed[normalized] = "true";
+  }
+  return parsed;
+}
+
+function resolveRepoRoot() {
+  const scriptFile = fileURLToPath(import.meta.url);
+  const scriptDir = path.dirname(scriptFile);
+  return path.resolve(scriptDir, "..", "..");
+}
+
+function truncate(value, maxLength) {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return `${value.slice(0, maxLength)}...`;
+}
+
+function toMarkdown(report) {
+  const rows = report.checks
+    .map(
+      (entry) =>
+        `| ${entry.id} | ${entry.status.toUpperCase()} | ${entry.summary} | ${entry.details ?? ""} |`
+    )
+    .join("\n");
+  return [
+    "# Node Launcher Doctor",
+    "",
+    `Generated at: ${report.generatedAt}`,
+    "",
+    "| Check | Status | Summary | Details |",
+    "| --- | --- | --- | --- |",
+    rows,
+    "",
+  ].join("\n");
+}


### PR DESCRIPTION
## Summary
- add `node:doctor` launcher preflight diagnostics CLI
- produce structured doctor reports (`doctor.json`, `doctor.md`) with runtime-path checks
- add doctor guide docs and wire doctor flow into node issue template
- document doctor command in memory-server README support section

## Testing
- npm run node:doctor -- --outputDir build/reports/node-doctor

Closes #283
