### PR TITLE
[node][runtime] Binary checksum verification for launcher integrity (#285)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to this project are documented in this file.
 - Added startup latency telemetry hook for launch attempts (including auto fallback success/failure events).
 - Added `node:doctor` launcher preflight diagnostics command with structured report output.
 - Added Java classpath auto-discovery fallback hardening for `auto`/`java` launch modes with configurable probe command/cwd.
+- Added runtime SHA-256 binary integrity verification for bundled binaries and explicit `binaryChecksum`/`JONGODB_BINARY_CHECKSUM` paths.
 
 ## [0.1.3] - 2026-02-24
 

--- a/docs/NODE_DOCTOR.md
+++ b/docs/NODE_DOCTOR.md
@@ -17,6 +17,7 @@ Outputs:
 - Node version baseline (`>=20`)
 - memory-server build artifact presence
 - `JONGODB_BINARY_PATH` validity (if configured)
+- `JONGODB_BINARY_CHECKSUM` format/match against explicit binary path (if configured)
 - bundled binary package resolution for current platform/arch
 - classpath availability:
   - direct `JONGODB_CLASSPATH`

--- a/docs/NODE_TROUBLESHOOTING_PLAYBOOK.md
+++ b/docs/NODE_TROUBLESHOOTING_PLAYBOOK.md
@@ -15,6 +15,7 @@ Use this playbook when `@jongodb/memory-server` startup or test-runtime integrat
 | --- | --- | --- |
 | `No launcher runtime configured` | neither binary nor Java classpath resolved | set `binaryPath` / `JONGODB_BINARY_PATH`, or set `classpath` / `JONGODB_CLASSPATH` |
 | `Binary launch mode requested but no binary was found` | `launchMode: "binary"` but executable is not resolvable | provide explicit `binaryPath` or set `JONGODB_BINARY_PATH` |
+| `Binary checksum verification failed` | configured checksum does not match local binary bytes | verify binary provenance and align `binaryChecksum`/`JONGODB_BINARY_CHECKSUM` |
 | `Java launch mode requested but Java classpath is not configured` | `launchMode: "java"` without classpath | pass `classpath` option or export `JONGODB_CLASSPATH` |
 | `Classpath auto-discovery probe failed` | Gradle classpath probe command/cwd is invalid or unavailable | set explicit `classpath`/`JONGODB_CLASSPATH`, or fix `classpathDiscoveryCommand`/`classpathDiscoveryWorkingDirectory` |
 | `Failed to start jongodb with available launch configurations` | all launch candidates failed (binary/java) | inspect aggregated `[binary:...]` / `[java:...]` messages and fix per candidate |

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -51,10 +51,11 @@ Use this when publishing `@jongodb/memory-server`:
 7. Confirm core package publishes after binaries with synced optional dependency versions.
 8. For manual workflow runs, never set `publish=true` with empty `version` (workflow blocks this).
 9. Confirm workflow packs tarball artifacts first (binary/core) and publishes from those packed files.
-10. Confirm GitHub Artifact Attestations are generated for packed tarballs (`actions/attest-build-provenance`).
-11. Run `npm publish --dry-run` and review package contents.
-12. Publish only when `NPM_TOKEN` is configured and verify npm registry visibility.
-13. Update README usage examples with the released package version.
+10. Confirm staged binary package metadata contains refreshed `jongodb.sha256` checksum before publish.
+11. Confirm GitHub Artifact Attestations are generated for packed tarballs (`actions/attest-build-provenance`).
+12. Run `npm publish --dry-run` and review package contents.
+13. Publish only when `NPM_TOKEN` is configured and verify npm registry visibility.
+14. Update README usage examples with the released package version.
 
 ## Node Canary Channel Gate (Draft)
 

--- a/packages/memory-server-bin-darwin-arm64/package.json
+++ b/packages/memory-server-bin-darwin-arm64/package.json
@@ -24,6 +24,7 @@
   "scripts": {},
   "jongodb": {
     "binary": "bin/jongodb",
+    "sha256": "627df6248da49ffabd461becb946009c89439d161f2342a8ec42330942a508e7",
     "platform": "darwin",
     "arch": "arm64"
   },

--- a/packages/memory-server-bin-linux-x64-gnu/package.json
+++ b/packages/memory-server-bin-linux-x64-gnu/package.json
@@ -27,6 +27,7 @@
   "scripts": {},
   "jongodb": {
     "binary": "bin/jongodb",
+    "sha256": "627df6248da49ffabd461becb946009c89439d161f2342a8ec42330942a508e7",
     "platform": "linux",
     "arch": "x64",
     "libc": "gnu"

--- a/packages/memory-server-bin-win32-x64/package.json
+++ b/packages/memory-server-bin-win32-x64/package.json
@@ -24,6 +24,8 @@
   "scripts": {},
   "jongodb": {
     "binary": "bin/jongodb.cmd",
+    "sha256": "5d0b7dd673e16b5b6612963a19b4d8b7dfc5a049fa9a74ba978cbb893a408a09",
+    "sha256Target": "bin/jongodb.cmd",
     "platform": "win32",
     "arch": "x64"
   },

--- a/packages/memory-server/README.md
+++ b/packages/memory-server/README.md
@@ -247,6 +247,10 @@ Binary resolution order:
 2. `JONGODB_BINARY_PATH`
 3. bundled platform binary package
 
+Binary integrity verification:
+- bundled platform binary packages are verified against embedded `jongodb.sha256` metadata before launch
+- explicit binary paths can opt into verification with `binaryChecksum` or `JONGODB_BINARY_CHECKSUM`
+
 Bundled targets:
 - `@jongodb/memory-server-bin-darwin-arm64`
 - `@jongodb/memory-server-bin-linux-x64-gnu`
@@ -298,6 +302,7 @@ Vitest export (`@jongodb/memory-server/vitest`):
 Core:
 - `launchMode`: `auto` | `binary` | `java` (default: `auto`)
 - `binaryPath`: binary executable override path
+- `binaryChecksum`: expected SHA-256 checksum for explicit binary verification
 - `classpath`: Java classpath string or string array
 - `classpathDiscovery`: `auto` | `off` (default: `auto`)
 - `classpathDiscoveryCommand`: override command used for classpath auto-discovery probe
@@ -365,6 +370,7 @@ const runtime = createJongodbEnvRuntime({
 - runtime startup logs and failure tails apply secret redaction (`<redacted>`) for password/token-style values
 - `No launcher runtime configured`: set `binaryPath` / `JONGODB_BINARY_PATH` / `classpath` / `JONGODB_CLASSPATH`
 - `Binary launch mode requested but no binary was found`: provide `binaryPath` or `JONGODB_BINARY_PATH`
+- `Binary checksum verification failed`: validate `binaryChecksum` / `JONGODB_BINARY_CHECKSUM` and binary file provenance
 - `Java launch mode requested but Java classpath is not configured`: provide `classpath` or `JONGODB_CLASSPATH`
 - `Classpath auto-discovery probe failed`: set explicit `classpath` / `JONGODB_CLASSPATH`, or fix Gradle probe command/cwd
 - `spawn ... ENOENT`: missing runtime executable path


### PR DESCRIPTION
## Summary
- add SHA-256 verification before binary launch with support for `binaryChecksum`, `JONGODB_BINARY_CHECKSUM`, and bundled package checksum metadata
- include bundled binary package `jongodb.sha256` metadata and update bin staging script to refresh checksums during release packaging
- extend diagnostics/docs (`node:doctor`, troubleshooting, release checklist) and add checksum regression tests

## Testing
- npm run node:build
- node --test packages/memory-server/dist/esm/test/binary-launcher.test.js
- npm run node:doctor -- --outputDir build/reports/node-doctor --no-fail true
- node ./scripts/node/stage-bin-package.mjs --workspace packages/memory-server-bin-linux-x64-gnu --binary packages/memory-server-bin-linux-x64-gnu/bin/jongodb

Closes #285
