### PR TITLE
[node][runtime] Add local artifact cache pruning/quota policy (#286)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this project are documented in this file.
 - Added `node:doctor` launcher preflight diagnostics command with structured report output.
 - Added Java classpath auto-discovery fallback hardening for `auto`/`java` launch modes with configurable probe command/cwd.
 - Added runtime SHA-256 binary integrity verification for bundled binaries and explicit `binaryChecksum`/`JONGODB_BINARY_CHECKSUM` paths.
+- Added local classpath-discovery artifact cache with TTL/quota pruning policy and configurable cache limits.
 
 ## [0.1.3] - 2026-02-24
 

--- a/docs/NODE_ARTIFACT_CACHE_POLICY.md
+++ b/docs/NODE_ARTIFACT_CACHE_POLICY.md
@@ -1,0 +1,35 @@
+# Node Artifact Cache Policy
+
+`@jongodb/memory-server` stores classpath auto-discovery artifacts in a local cache to reduce repeated Gradle probes.
+
+## Default Policy
+
+- directory: `.jongodb/cache`
+- max entries: `32`
+- max size: `5 MiB` (`5_242_880` bytes)
+- TTL: `7 days` (`604_800_000 ms`)
+
+Pruning runs before each classpath auto-discovery read/write:
+- remove expired entries (`mtime > TTL`)
+- enforce entry-count limit (oldest-first removal)
+- enforce total-size limit (oldest-first removal)
+
+## Configuration
+
+Runtime options:
+- `artifactCacheDir`
+- `artifactCacheMaxEntries`
+- `artifactCacheMaxBytes`
+- `artifactCacheTtlMs`
+
+Environment variables:
+- `JONGODB_ARTIFACT_CACHE_DIR`
+- `JONGODB_ARTIFACT_CACHE_MAX_ENTRIES`
+- `JONGODB_ARTIFACT_CACHE_MAX_BYTES`
+- `JONGODB_ARTIFACT_CACHE_TTL_MS`
+
+## Operational Notes
+
+- Cache is best-effort; malformed cache files are discarded automatically.
+- Delete `.jongodb/cache` to force a clean probe path.
+- Keep the cache under project workspace storage (avoid shared global temp paths in CI).

--- a/docs/NODE_TROUBLESHOOTING_PLAYBOOK.md
+++ b/docs/NODE_TROUBLESHOOTING_PLAYBOOK.md
@@ -50,6 +50,12 @@ npm run node:build
 npm --prefix testkit/node-compat test
 ```
 
+Clear classpath artifact cache:
+
+```bash
+rm -rf .jongodb/cache
+```
+
 Clear Jest global runtime state:
 
 ```bash
@@ -60,6 +66,7 @@ rm -f .jongodb/jest-memory-server.json
 
 - `launchMode` is one of `auto`, `binary`, `java`.
 - `classpathDiscovery` is `auto` or `off` (`auto` default).
+- `artifactCacheMaxEntries` / `artifactCacheMaxBytes` / `artifactCacheTtlMs` are positive values.
 - `host`, `port`, `databaseName` values are valid/non-empty.
 - `topologyProfile` and `replicaSetName` match expected URI contract.
 - `envVarName` / `envVarNames` are valid and unique for your test runtime.

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Runtime and compatibility:
 - `docs/COMPATIBILITY_SCORECARD.md`
 - `docs/NODE_COMPAT_SMOKE.md`
 - `docs/NODE_COLD_START_BENCHMARK.md`
+- `docs/NODE_ARTIFACT_CACHE_POLICY.md`
 - `docs/NODE_DEBUG_BUNDLE.md`
 - `docs/NODE_DOCTOR.md`
 - `docs/NODE_LOG_REDACTION_POLICY.md`

--- a/packages/memory-server/README.md
+++ b/packages/memory-server/README.md
@@ -263,6 +263,7 @@ Java fallback:
   - args: `--no-daemon -q printLauncherClasspath`
   - working directory: `options.classpathDiscoveryWorkingDirectory` -> `JONGODB_CLASSPATH_DISCOVERY_CWD` -> `process.cwd()`
   - disable probe: `classpathDiscovery: "off"` or `JONGODB_CLASSPATH_DISCOVERY=off`
+  - probe results are cached under `.jongodb/cache` with default pruning (`maxEntries=32`, `maxBytes=5MiB`, `ttl=7d`)
 
 Launcher contract:
 - stdout ready line: `JONGODB_URI=mongodb://...`
@@ -307,6 +308,10 @@ Core:
 - `classpathDiscovery`: `auto` | `off` (default: `auto`)
 - `classpathDiscoveryCommand`: override command used for classpath auto-discovery probe
 - `classpathDiscoveryWorkingDirectory`: cwd for classpath auto-discovery probe
+- `artifactCacheDir`: artifact cache directory for classpath auto-discovery metadata (default: `.jongodb/cache`)
+- `artifactCacheMaxEntries`: max cache entries retained after prune (default: `32`)
+- `artifactCacheMaxBytes`: max cache size retained after prune (default: `5_242_880` bytes)
+- `artifactCacheTtlMs`: cache TTL for entries before expiration prune (default: `604_800_000`)
 - `javaPath`: Java executable path (default: `java`)
 - `launcherClass`: Java launcher class (default: `org.jongodb.server.TcpMongoServerLauncher`)
 - `topologyProfile`: `standalone` | `singleNodeReplicaSet` (default: `standalone`)
@@ -373,6 +378,7 @@ const runtime = createJongodbEnvRuntime({
 - `Binary checksum verification failed`: validate `binaryChecksum` / `JONGODB_BINARY_CHECKSUM` and binary file provenance
 - `Java launch mode requested but Java classpath is not configured`: provide `classpath` or `JONGODB_CLASSPATH`
 - `Classpath auto-discovery probe failed`: set explicit `classpath` / `JONGODB_CLASSPATH`, or fix Gradle probe command/cwd
+- stale cache concerns: tune `artifactCache*` options or remove `.jongodb/cache` to force fresh probe
 - `spawn ... ENOENT`: missing runtime executable path
 - startup timeout: launcher did not emit `JONGODB_URI=...`
 - `Launcher URI topology options are out of sync`: emitted URI query does not match requested `topologyProfile`/`replicaSetName`


### PR DESCRIPTION
## Summary
- add classpath auto-discovery artifact cache with configurable directory, TTL, max entries, and max bytes limits
- enforce prune policy (expire + oldest-first quota trimming) before and after cache writes
- add regression coverage for cache reuse, max-entry pruning, and TTL expiration, and document cache policy/troubleshooting

## Testing
- npm run node:build
- node --test packages/memory-server/dist/esm/test/binary-launcher.test.js

Closes #286
