### PR TITLE
[node][runtime] Harden graceful shutdown and orphan cleanup (#287)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project are documented in this file.
 - Added Java classpath auto-discovery fallback hardening for `auto`/`java` launch modes with configurable probe command/cwd.
 - Added runtime SHA-256 binary integrity verification for bundled binaries and explicit `binaryChecksum`/`JONGODB_BINARY_CHECKSUM` paths.
 - Added local classpath-discovery artifact cache with TTL/quota pruning policy and configurable cache limits.
+- Added process-exit launcher cleanup hook (`cleanupOnProcessExit`) to reduce orphan runtime processes after abrupt test termination.
 
 ## [0.1.3] - 2026-02-24
 

--- a/docs/NODE_TROUBLESHOOTING_PLAYBOOK.md
+++ b/docs/NODE_TROUBLESHOOTING_PLAYBOOK.md
@@ -25,6 +25,7 @@ Use this playbook when `@jongodb/memory-server` startup or test-runtime integrat
 | `Requested replicaSetName does not match URI replicaSet query` | configured replica set name differs from emitted URI | align `replicaSetName` with launcher output |
 | `Jest global state file has invalid schema` | stale/corrupted `.jongodb/jest-memory-server.json` | delete state file and rerun setup |
 | `Unable to stop detached Jest process pid=` | detached launcher process did not terminate cleanly | verify PID ownership/process health and rerun teardown; if needed kill process manually |
+| port remains occupied after abrupt test abort | non-detached launcher was left running after forced interruption | keep `cleanupOnProcessExit=true` (default) and rerun teardown/cleanup |
 | `envVarName/envVarNames entries must not be empty` | invalid runtime/jest/vitest env key config | ensure all env var names are non-empty trimmed strings |
 | `projectName must not be empty` | invalid Vitest workspace integration input | provide non-empty `projectName` for `registerJongodbForVitestWorkspace` |
 
@@ -67,6 +68,7 @@ rm -f .jongodb/jest-memory-server.json
 - `launchMode` is one of `auto`, `binary`, `java`.
 - `classpathDiscovery` is `auto` or `off` (`auto` default).
 - `artifactCacheMaxEntries` / `artifactCacheMaxBytes` / `artifactCacheTtlMs` are positive values.
+- `cleanupOnProcessExit` is enabled unless you intentionally want detached/orphaned lifecycle behavior.
 - `host`, `port`, `databaseName` values are valid/non-empty.
 - `topologyProfile` and `replicaSetName` match expected URI contract.
 - `envVarName` / `envVarNames` are valid and unique for your test runtime.

--- a/packages/memory-server/README.md
+++ b/packages/memory-server/README.md
@@ -323,6 +323,7 @@ Core:
 - `port`: bind port (`0` means ephemeral)
 - `startupTimeoutMs`: startup timeout (default: `15000`)
 - `stopTimeoutMs`: stop timeout before forced kill (default: `5000`)
+- `cleanupOnProcessExit`: send `SIGTERM` to non-detached launcher on parent process exit (default: `true`)
 - `env`: extra child process environment variables
 - `logLevel`: `silent` | `info` | `debug` (default: `silent`)
 - `onStartupTelemetry`: optional hook for startup attempt telemetry (`attempt`, `mode`, `source`, `startupDurationMs`, `success`, `errorMessage`)


### PR DESCRIPTION
## Summary
- add managed launcher registry with process-exit cleanup hook so non-detached runtimes receive `SIGTERM` on parent exit
- expose `cleanupOnProcessExit` option (default `true`) for explicit control
- add integration regression test that verifies launcher process is terminated when parent exits without calling `stop()`

## Testing
- npm run node:build
- node --test packages/memory-server/dist/esm/test/binary-launcher.test.js

Closes #287
