### PR TITLE
[node][runtime] Add startup port collision retry/backoff strategy (#288)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to this project are documented in this file.
 - Added runtime SHA-256 binary integrity verification for bundled binaries and explicit `binaryChecksum`/`JONGODB_BINARY_CHECKSUM` paths.
 - Added local classpath-discovery artifact cache with TTL/quota pruning policy and configurable cache limits.
 - Added process-exit launcher cleanup hook (`cleanupOnProcessExit`) to reduce orphan runtime processes after abrupt test termination.
+- Added fixed-port collision retry/backoff strategy (`portRetryAttempts`, `portRetryBackoffMs`) with next-port fallback behavior.
 
 ## [0.1.3] - 2026-02-24
 

--- a/docs/NODE_TROUBLESHOOTING_PLAYBOOK.md
+++ b/docs/NODE_TROUBLESHOOTING_PLAYBOOK.md
@@ -16,6 +16,7 @@ Use this playbook when `@jongodb/memory-server` startup or test-runtime integrat
 | `No launcher runtime configured` | neither binary nor Java classpath resolved | set `binaryPath` / `JONGODB_BINARY_PATH`, or set `classpath` / `JONGODB_CLASSPATH` |
 | `Binary launch mode requested but no binary was found` | `launchMode: "binary"` but executable is not resolvable | provide explicit `binaryPath` or set `JONGODB_BINARY_PATH` |
 | `Binary checksum verification failed` | configured checksum does not match local binary bytes | verify binary provenance and align `binaryChecksum`/`JONGODB_BINARY_CHECKSUM` |
+| `EADDRINUSE` / `address already in use` | requested port is occupied by another process/test | use `port: 0` or tune `portRetryAttempts`/`portRetryBackoffMs` for fixed-port mode |
 | `Java launch mode requested but Java classpath is not configured` | `launchMode: "java"` without classpath | pass `classpath` option or export `JONGODB_CLASSPATH` |
 | `Classpath auto-discovery probe failed` | Gradle classpath probe command/cwd is invalid or unavailable | set explicit `classpath`/`JONGODB_CLASSPATH`, or fix `classpathDiscoveryCommand`/`classpathDiscoveryWorkingDirectory` |
 | `Failed to start jongodb with available launch configurations` | all launch candidates failed (binary/java) | inspect aggregated `[binary:...]` / `[java:...]` messages and fix per candidate |
@@ -69,6 +70,7 @@ rm -f .jongodb/jest-memory-server.json
 - `classpathDiscovery` is `auto` or `off` (`auto` default).
 - `artifactCacheMaxEntries` / `artifactCacheMaxBytes` / `artifactCacheTtlMs` are positive values.
 - `cleanupOnProcessExit` is enabled unless you intentionally want detached/orphaned lifecycle behavior.
+- `portRetryAttempts` / `portRetryBackoffMs` are non-negative values for fixed-port collision handling.
 - `host`, `port`, `databaseName` values are valid/non-empty.
 - `topologyProfile` and `replicaSetName` match expected URI contract.
 - `envVarName` / `envVarNames` are valid and unique for your test runtime.

--- a/packages/memory-server/README.md
+++ b/packages/memory-server/README.md
@@ -242,6 +242,10 @@ Common patterns:
 - `binary`: binary only
 - `java`: Java only
 
+Port collision retry (fixed `port > 0`):
+- when launcher failures include port-in-use signatures, runtime retries on the next port number
+- defaults: `portRetryAttempts=3`, `portRetryBackoffMs=100` (linear backoff by retry index)
+
 Binary resolution order:
 1. `options.binaryPath`
 2. `JONGODB_BINARY_PATH`
@@ -321,6 +325,8 @@ Core:
 - `databaseNameStrategy`: `static` | `worker` (default: `static`)
 - `host`: bind host (default: `127.0.0.1`)
 - `port`: bind port (`0` means ephemeral)
+- `portRetryAttempts`: retry count for port-collision failures when `port > 0` (default: `3`)
+- `portRetryBackoffMs`: base backoff per retry for port collisions (default: `100`)
 - `startupTimeoutMs`: startup timeout (default: `15000`)
 - `stopTimeoutMs`: stop timeout before forced kill (default: `5000`)
 - `cleanupOnProcessExit`: send `SIGTERM` to non-detached launcher on parent process exit (default: `true`)
@@ -377,6 +383,7 @@ const runtime = createJongodbEnvRuntime({
 - `No launcher runtime configured`: set `binaryPath` / `JONGODB_BINARY_PATH` / `classpath` / `JONGODB_CLASSPATH`
 - `Binary launch mode requested but no binary was found`: provide `binaryPath` or `JONGODB_BINARY_PATH`
 - `Binary checksum verification failed`: validate `binaryChecksum` / `JONGODB_BINARY_CHECKSUM` and binary file provenance
+- `EADDRINUSE` / `address already in use`: increase base `port`, tune `portRetryAttempts`, or use `port: 0`
 - `Java launch mode requested but Java classpath is not configured`: provide `classpath` or `JONGODB_CLASSPATH`
 - `Classpath auto-discovery probe failed`: set explicit `classpath` / `JONGODB_CLASSPATH`, or fix Gradle probe command/cwd
 - stale cache concerns: tune `artifactCache*` options or remove `.jongodb/cache` to force fresh probe


### PR DESCRIPTION
## Summary
- add fixed-port collision handling with next-port retries and configurable backoff (`portRetryAttempts`, `portRetryBackoffMs`)
- detect collision signatures (`EADDRINUSE` / address-in-use variants) and retry only when collision is observed
- add collision retry regression tests and update runtime/troubleshooting docs

## Testing
- npm run node:build
- node --test packages/memory-server/dist/esm/test/binary-launcher.test.js

Closes #288
