### PR TITLE
[node][runtime] Structured logging contract and level options (#289)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project are documented in this file.
 - Added local classpath-discovery artifact cache with TTL/quota pruning policy and configurable cache limits.
 - Added process-exit launcher cleanup hook (`cleanupOnProcessExit`) to reduce orphan runtime processes after abrupt test termination.
 - Added fixed-port collision retry/backoff strategy (`portRetryAttempts`, `portRetryBackoffMs`) with next-port fallback behavior.
+- Added structured runtime logging contract (`onLog`, `logFormat`) with expanded log levels (`error`/`warn`/`info`/`debug`).
 
 ## [0.1.3] - 2026-02-24
 

--- a/docs/NODE_TROUBLESHOOTING_PLAYBOOK.md
+++ b/docs/NODE_TROUBLESHOOTING_PLAYBOOK.md
@@ -71,6 +71,7 @@ rm -f .jongodb/jest-memory-server.json
 - `artifactCacheMaxEntries` / `artifactCacheMaxBytes` / `artifactCacheTtlMs` are positive values.
 - `cleanupOnProcessExit` is enabled unless you intentionally want detached/orphaned lifecycle behavior.
 - `portRetryAttempts` / `portRetryBackoffMs` are non-negative values for fixed-port collision handling.
+- `logLevel` is one of `silent`/`error`/`warn`/`info`/`debug` and `logFormat` is `plain` or `json`.
 - `host`, `port`, `databaseName` values are valid/non-empty.
 - `topologyProfile` and `replicaSetName` match expected URI contract.
 - `envVarName` / `envVarNames` are valid and unique for your test runtime.

--- a/packages/memory-server/README.md
+++ b/packages/memory-server/README.md
@@ -331,7 +331,9 @@ Core:
 - `stopTimeoutMs`: stop timeout before forced kill (default: `5000`)
 - `cleanupOnProcessExit`: send `SIGTERM` to non-detached launcher on parent process exit (default: `true`)
 - `env`: extra child process environment variables
-- `logLevel`: `silent` | `info` | `debug` (default: `silent`)
+- `logLevel`: `silent` | `error` | `warn` | `info` | `debug` (default: `silent`)
+- `logFormat`: `plain` | `json` console output format (default: `plain`)
+- `onLog`: structured runtime log hook (`timestamp`, `level`, `event`, `message`, `attempt`, `mode`, `source`, `port`, `stream`)
 - `onStartupTelemetry`: optional hook for startup attempt telemetry (`attempt`, `mode`, `source`, `startupDurationMs`, `success`, `errorMessage`)
 
 Runtime helper options:


### PR DESCRIPTION
## Summary
- add structured runtime log contract (`JongodbRuntimeLogEvent`) with `onLog` hook and `logFormat` (`plain`/`json`)
- expand `logLevel` semantics to `silent`/`error`/`warn`/`info`/`debug` and apply level filtering across launch lifecycle events
- add regression tests for structured log events and level filtering, and update runtime troubleshooting/docs

## Testing
- npm run node:build
- node --test packages/memory-server/dist/esm/test/binary-launcher.test.js

Closes #289
