### PR TITLE
[r3][utf] Accept unordered bulkWrite/clientBulkWrite imports

### DIFF
--- a/src/main/java/org/jongodb/testkit/UnifiedSpecImporter.java
+++ b/src/main/java/org/jongodb/testkit/UnifiedSpecImporter.java
@@ -595,9 +595,7 @@ public final class UnifiedSpecImporter {
         if (orderedValue != null && !(orderedValue instanceof Boolean)) {
             throw new IllegalArgumentException("bulkWrite.arguments.ordered must be a boolean");
         }
-        if (Boolean.FALSE.equals(orderedValue)) {
-            throw new UnsupportedOperationException("unsupported UTF bulkWrite option: ordered=false");
-        }
+        final boolean ordered = orderedValue == null || Boolean.TRUE.equals(orderedValue);
 
         final List<Object> requests = asList(arguments.get("requests"), "bulkWrite.arguments.requests");
         if (requests.isEmpty()) {
@@ -640,7 +638,7 @@ public final class UnifiedSpecImporter {
         }
 
         final Map<String, Object> payload = commandEnvelope("bulkWrite", database, collection);
-        payload.put("ordered", true);
+        payload.put("ordered", ordered);
         payload.put("operations", List.copyOf(operations));
         return new ScenarioCommand("bulkWrite", immutableMap(payload));
     }
@@ -784,9 +782,7 @@ public final class UnifiedSpecImporter {
         if (orderedValue != null && !(orderedValue instanceof Boolean)) {
             throw new IllegalArgumentException("clientBulkWrite.arguments.ordered must be a boolean");
         }
-        if (Boolean.FALSE.equals(orderedValue)) {
-            throw new UnsupportedOperationException("unsupported UTF clientBulkWrite option: ordered=false");
-        }
+        final boolean ordered = orderedValue == null || Boolean.TRUE.equals(orderedValue);
         if (Boolean.TRUE.equals(arguments.get("verboseResults"))) {
             throw new UnsupportedOperationException("unsupported UTF clientBulkWrite option: verboseResults=true");
         }
@@ -834,7 +830,7 @@ public final class UnifiedSpecImporter {
                 ? new CollectionTarget(defaultDatabase, defaultCollection)
                 : namespace;
         final Map<String, Object> bulkWriteArguments = new LinkedHashMap<>();
-        bulkWriteArguments.put("ordered", true);
+        bulkWriteArguments.put("ordered", ordered);
         bulkWriteArguments.put("requests", List.copyOf(requests));
         return bulkWrite(bulkWriteArguments, resolved.database(), resolved.collection());
     }

--- a/src/test/java/org/jongodb/testkit/UnifiedSpecImporterTest.java
+++ b/src/test/java/org/jongodb/testkit/UnifiedSpecImporterTest.java
@@ -238,7 +238,7 @@ class UnifiedSpecImporterTest {
     }
 
     @Test
-    void marksBulkWriteOrderedFalseAsUnsupported() throws IOException {
+    void importsBulkWriteOrderedFalseForExecutionParity() throws IOException {
         Files.writeString(
                 tempDir.resolve("bulk-write-unsupported.json"),
                 """
@@ -267,11 +267,11 @@ class UnifiedSpecImporterTest {
         final UnifiedSpecImporter importer = new UnifiedSpecImporter();
         final UnifiedSpecImporter.ImportResult result = importer.importCorpus(tempDir);
 
-        assertEquals(0, result.importedCount());
-        assertEquals(1, result.unsupportedCount());
-        assertTrue(result.skippedCases().stream().anyMatch(skipped ->
-                skipped.kind() == UnifiedSpecImporter.SkipKind.UNSUPPORTED
-                        && skipped.reason().contains("bulkWrite option: ordered=false")));
+        assertEquals(1, result.importedCount());
+        assertEquals(0, result.unsupportedCount());
+        final Scenario scenario = result.importedScenarios().get(0).scenario();
+        assertEquals("bulkWrite", scenario.commands().get(0).commandName());
+        assertEquals(Boolean.FALSE, scenario.commands().get(0).payload().get("ordered"));
     }
 
     @Test
@@ -765,7 +765,7 @@ class UnifiedSpecImporterTest {
     }
 
     @Test
-    void marksClientBulkWriteOrderedFalseAsUnsupported() throws IOException {
+    void importsClientBulkWriteOrderedFalseForExecutionParity() throws IOException {
         Files.writeString(
                 tempDir.resolve("client-bulk-write-unordered.json"),
                 """
@@ -788,11 +788,11 @@ class UnifiedSpecImporterTest {
         final UnifiedSpecImporter importer = new UnifiedSpecImporter();
         final UnifiedSpecImporter.ImportResult result = importer.importCorpus(tempDir);
 
-        assertEquals(0, result.importedCount());
-        assertEquals(1, result.unsupportedCount());
-        assertTrue(result.skippedCases().stream().anyMatch(skipped ->
-                skipped.kind() == UnifiedSpecImporter.SkipKind.UNSUPPORTED
-                        && skipped.reason().contains("unsupported UTF clientBulkWrite option: ordered=false")));
+        assertEquals(1, result.importedCount());
+        assertEquals(0, result.unsupportedCount());
+        final Scenario scenario = result.importedScenarios().get(0).scenario();
+        assertEquals("bulkWrite", scenario.commands().get(0).commandName());
+        assertEquals(Boolean.FALSE, scenario.commands().get(0).payload().get("ordered"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- remove importer-level rejection for `bulkWrite` with `ordered=false`
- remove importer-level rejection for `clientBulkWrite` with `ordered=false`
- preserve incoming `ordered` value in translated `bulkWrite` payload instead of forcing `true`
- convert existing importer tests from "unsupported" expectation to import-success parity checks

## Validation
- `./.tooling/gradle-8.10.2/bin/gradle test --tests org.jongodb.testkit.UnifiedSpecImporterTest`

## Notes
- This PR is part of `phase:p1` orchestration. Dot/dollar key-path cases in #344 are handled by #343.

Closes #344
