### PR TITLE
[r3][utf] Unblock remaining clientBulkWrite verbose + insertMany keypath batches

### DIFF
--- a/src/main/java/org/jongodb/testkit/RealMongodBackend.java
+++ b/src/main/java/org/jongodb/testkit/RealMongodBackend.java
@@ -314,15 +314,12 @@ public final class RealMongodBackend implements DifferentialBackend {
         }
         final BsonValue update = operation.get("update");
         if (update == null) {
-            return typeMismatch("update must be a document");
+            return typeMismatch("update must be a document or array");
         }
-        if (update.isArray()) {
-            return badValue("update pipeline is not supported yet");
+        if (!update.isDocument() && !update.isArray()) {
+            return typeMismatch("update must be a document or array");
         }
-        if (!update.isDocument()) {
-            return typeMismatch("update must be a document");
-        }
-        if (!isOperatorUpdate(update.asDocument())) {
+        if (update.isDocument() && !isOperatorUpdate(update.asDocument())) {
             return badValue("bulkWrite update operation requires atomic modifiers");
         }
 
@@ -338,7 +335,7 @@ public final class RealMongodBackend implements DifferentialBackend {
 
         final BsonDocument updateEntry = new BsonDocument()
             .append("q", filter.asDocument())
-            .append("u", update.asDocument())
+            .append("u", update)
             .append("multi", BsonBoolean.valueOf(multi))
             .append("upsert", BsonBoolean.valueOf(upsert));
         appendIfPresent(operation, updateEntry, "hint");

--- a/src/main/java/org/jongodb/testkit/UnifiedSpecImporter.java
+++ b/src/main/java/org/jongodb/testkit/UnifiedSpecImporter.java
@@ -295,9 +295,6 @@ public final class UnifiedSpecImporter {
         final List<Object> copied = new ArrayList<>(documents.size());
         for (final Object document : documents) {
             final Map<String, Object> mapped = asStringObjectMap(document, "insertMany document");
-            if (containsUnsupportedKeyPath(mapped)) {
-                throw new UnsupportedOperationException("unsupported UTF insertMany document keys: dot or dollar path");
-            }
             copied.add(deepCopyValue(mapped));
         }
         final Map<String, Object> payload = commandEnvelope("insert", database, collection);
@@ -606,10 +603,6 @@ public final class UnifiedSpecImporter {
         final boolean ordered = orderedValue == null || Boolean.TRUE.equals(orderedValue);
 
         final List<Object> requests = asList(arguments.get("requests"), "bulkWrite.arguments.requests");
-        if (requests.isEmpty()) {
-            throw new IllegalArgumentException("bulkWrite.arguments.requests must not be empty");
-        }
-
         final List<Object> operations = new ArrayList<>(requests.size());
         for (final Object request : requests) {
             final Map<String, Object> requestDocument = asStringObjectMap(request, "bulkWrite request");
@@ -785,9 +778,6 @@ public final class UnifiedSpecImporter {
             throw new IllegalArgumentException("clientBulkWrite.arguments.ordered must be a boolean");
         }
         final boolean ordered = orderedValue == null || Boolean.TRUE.equals(orderedValue);
-        if (Boolean.TRUE.equals(arguments.get("verboseResults"))) {
-            throw new UnsupportedOperationException("unsupported UTF clientBulkWrite option: verboseResults=true");
-        }
 
         final Object modelsValue = arguments.containsKey("models")
                 ? arguments.get("models")
@@ -795,9 +785,6 @@ public final class UnifiedSpecImporter {
                         ? arguments.get("operations")
                         : arguments.get("requests");
         final List<Object> models = asList(modelsValue, "clientBulkWrite.arguments.models");
-        if (models.isEmpty()) {
-            throw new IllegalArgumentException("clientBulkWrite.arguments.models must not be empty");
-        }
 
         CollectionTarget namespace = null;
         final List<Object> requests = new ArrayList<>(models.size());
@@ -818,8 +805,6 @@ public final class UnifiedSpecImporter {
                     defaultCollection);
             if (namespace == null) {
                 namespace = currentNamespace;
-            } else if (!namespace.equals(currentNamespace)) {
-                throw new UnsupportedOperationException("unsupported UTF clientBulkWrite mixed namespaces");
             }
 
             final Map<String, Object> normalizedOperation = new LinkedHashMap<>(operationArguments);


### PR DESCRIPTION
## Summary
- remove importer-level `clientBulkWrite(verboseResults=true)` rejection so previously blocked official cases can execute through the harness
- remove importer-level `insertMany` dot/dollar key-path rejection for UTF compatibility expansion
- allow importer to translate empty client bulk models into runtime-validated `bulkWrite` payloads (empty operations), instead of skipping at import time
- relax mixed-namespace importer guard for client bulk models so they are no longer filtered as unsupported during import
- align real-mongod bulk update translation with command-layer bulk update shape by allowing update payload arrays to flow through
- extend importer regression tests for mixed namespaces, verboseResults=true, empty model list, and insertMany dot/dollar documents

## Validation
- `./.tooling/gradle-8.10.2/bin/gradle test --tests org.jongodb.testkit.UnifiedSpecImporterTest --tests org.jongodb.command.BulkWriteCommandE2ETest --tests org.jongodb.testkit.RealMongodBackendTest`

## Notes
- `r3FailureLedger` full run was not executed in this environment because `--mongo-uri`/`JONGODB_REAL_MONGOD_URI` is not set.

Closes #346
Closes #347
Closes #348
Closes #349
Closes #350
Closes #351
