### PR TITLE
feat(testkit): implement in-process integration template

### DIFF
--- a/docs/IN_PROCESS_TEMPLATE_GUIDE.md
+++ b/docs/IN_PROCESS_TEMPLATE_GUIDE.md
@@ -1,0 +1,45 @@
+# In-Process Integration Template Guide
+
+`#261` 구현 가이드입니다.
+
+## 제공 기능
+- JUnit/Spring 진입점
+  - `org.jongodb.testkit.InProcessIntegrationTemplate`
+  - `@JongodbInProcessTest` + `JongodbInProcessInitializer`
+- fixture helper
+  - `seedDocuments(database, collection, documents)`
+  - `findAll(database, collection)`
+  - `reset()`
+  - `JongodbInProcessResetSupport.reset(context)`
+- 실패 시 trace artifact 자동 수집(옵션)
+  - snapshot / invariant / triage / repro / response 파일 생성
+
+## JUnit 사용 예
+
+```java
+InProcessIntegrationTemplate template = new InProcessIntegrationTemplate();
+template.seedDocuments("app", "users", List.of(BsonDocument.parse("{\"_id\":1}")));
+BsonDocument result = template.findAll("app", "users");
+template.reset();
+```
+
+## Spring 사용 예
+
+```java
+@ExtendWith(SpringExtension.class)
+@JongodbInProcessTest(classes = TestConfig.class)
+class SampleTest {
+  @Autowired InProcessIntegrationTemplate template;
+}
+```
+
+## Trace Artifact 옵션
+- Spring Property
+  - `jongodb.inprocess.traceArtifacts.enabled=true`
+  - `jongodb.inprocess.traceArtifacts.dir=<outputDir>`
+- 실패 명령 발생 시 `<outputDir>` 아래 파일 생성:
+  - `*-snapshot.json`
+  - `*-invariant.json`
+  - `*-triage.json`
+  - `*-repro.jsonl`
+  - `*-response.json`

--- a/src/main/java/org/jongodb/spring/test/JongodbInProcessInitializer.java
+++ b/src/main/java/org/jongodb/spring/test/JongodbInProcessInitializer.java
@@ -1,0 +1,51 @@
+package org.jongodb.spring.test;
+
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import org.jongodb.testkit.InProcessIntegrationTemplate;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.core.env.MapPropertySource;
+
+/**
+ * Spring initializer that registers {@link InProcessIntegrationTemplate} bean for command-level integration tests.
+ */
+public final class JongodbInProcessInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+    public static final String TEMPLATE_BEAN_NAME = "jongodbInProcessTemplate";
+    public static final String TRACE_ARTIFACTS_ENABLED_PROPERTY = "jongodb.inprocess.traceArtifacts.enabled";
+    public static final String TRACE_ARTIFACTS_DIR_PROPERTY = "jongodb.inprocess.traceArtifacts.dir";
+    public static final String DEFAULT_TRACE_ARTIFACTS_DIR = "build/reports/in-process-template/traces";
+
+    @Override
+    public void initialize(final ConfigurableApplicationContext context) {
+        Objects.requireNonNull(context, "context");
+        final InProcessIntegrationTemplate template = new InProcessIntegrationTemplate();
+        configureTraceArtifacts(context, template);
+
+        final Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("jongodb.inprocess.enabled", "true");
+        context.getEnvironment().getPropertySources().addFirst(new MapPropertySource("jongodbInProcessTemplate", properties));
+        context.getBeanFactory().registerSingleton(TEMPLATE_BEAN_NAME, template);
+        context.addApplicationListener(event -> {
+            if (event instanceof ContextClosedEvent) {
+                template.disableFailureTraceArtifacts();
+                template.reset();
+            }
+        });
+    }
+
+    private static void configureTraceArtifacts(
+            final ConfigurableApplicationContext context,
+            final InProcessIntegrationTemplate template) {
+        final boolean enabled = Boolean.parseBoolean(
+                context.getEnvironment().getProperty(TRACE_ARTIFACTS_ENABLED_PROPERTY, "false"));
+        if (!enabled) {
+            return;
+        }
+        final String path = context.getEnvironment().getProperty(TRACE_ARTIFACTS_DIR_PROPERTY, DEFAULT_TRACE_ARTIFACTS_DIR);
+        template.enableFailureTraceArtifacts(Path.of(path));
+    }
+}

--- a/src/main/java/org/jongodb/spring/test/JongodbInProcessResetSupport.java
+++ b/src/main/java/org/jongodb/spring/test/JongodbInProcessResetSupport.java
@@ -1,0 +1,19 @@
+package org.jongodb.spring.test;
+
+import java.util.Objects;
+import org.jongodb.testkit.InProcessIntegrationTemplate;
+import org.springframework.context.ApplicationContext;
+
+/**
+ * Reset helper for Spring contexts using {@link JongodbInProcessInitializer}.
+ */
+public final class JongodbInProcessResetSupport {
+    private JongodbInProcessResetSupport() {}
+
+    public static void reset(final ApplicationContext context) {
+        Objects.requireNonNull(context, "context");
+        final InProcessIntegrationTemplate template =
+                context.getBean(JongodbInProcessInitializer.TEMPLATE_BEAN_NAME, InProcessIntegrationTemplate.class);
+        template.reset();
+    }
+}

--- a/src/main/java/org/jongodb/spring/test/JongodbInProcessTest.java
+++ b/src/main/java/org/jongodb/spring/test/JongodbInProcessTest.java
@@ -1,0 +1,23 @@
+package org.jongodb.spring.test;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * Spring test entrypoint for in-process command-level integration template.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@ContextConfiguration(initializers = JongodbInProcessInitializer.class)
+public @interface JongodbInProcessTest {
+    @AliasFor(annotation = ContextConfiguration.class, attribute = "classes")
+    Class<?>[] classes() default {};
+}

--- a/src/main/java/org/jongodb/testkit/InProcessIntegrationTemplate.java
+++ b/src/main/java/org/jongodb/testkit/InProcessIntegrationTemplate.java
@@ -1,0 +1,149 @@
+package org.jongodb.testkit;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+import org.jongodb.server.WireCommandIngress;
+import org.jongodb.wire.OpMsg;
+import org.jongodb.wire.OpMsgCodec;
+
+/**
+ * In-process integration-test template with fixture helpers and optional trace artifact dump.
+ */
+public final class InProcessIntegrationTemplate {
+    private static final String DEFAULT_DATABASE = "test";
+
+    private final OpMsgCodec codec = new OpMsgCodec();
+    private final AtomicInteger requestId = new AtomicInteger(1_000);
+
+    private volatile WireCommandIngress ingress;
+    private volatile TraceArtifactConfig traceArtifactConfig;
+
+    public InProcessIntegrationTemplate() {
+        this.ingress = WireCommandIngress.inMemory();
+    }
+
+    public synchronized void reset() {
+        this.ingress = WireCommandIngress.inMemory();
+    }
+
+    public synchronized void enableFailureTraceArtifacts(final Path outputDir) {
+        Objects.requireNonNull(outputDir, "outputDir");
+        this.traceArtifactConfig = new TraceArtifactConfig(outputDir.toAbsolutePath().normalize());
+    }
+
+    public synchronized void disableFailureTraceArtifacts() {
+        this.traceArtifactConfig = null;
+    }
+
+    public BsonDocument runCommand(final BsonDocument command) {
+        Objects.requireNonNull(command, "command");
+        final BsonDocument response = dispatch(command);
+        if (isFailure(response)) {
+            maybeWriteFailureArtifacts(command, response);
+        }
+        return response;
+    }
+
+    public BsonDocument runCommand(final String commandJson) {
+        return runCommand(BsonDocument.parse(Objects.requireNonNull(commandJson, "commandJson")));
+    }
+
+    public BsonDocument seedDocuments(
+            final String database,
+            final String collection,
+            final List<BsonDocument> documents) {
+        Objects.requireNonNull(documents, "documents");
+        final BsonArray bsonDocuments = new BsonArray();
+        for (final BsonDocument document : documents) {
+            bsonDocuments.add(Objects.requireNonNull(document, "documents entries must not be null").clone());
+        }
+        final BsonDocument command = new BsonDocument()
+                .append("insert", new BsonString(requireText(collection, "collection")))
+                .append("$db", new BsonString(normalizeDatabase(database)))
+                .append("documents", bsonDocuments);
+        return runCommand(command);
+    }
+
+    public BsonDocument findAll(final String database, final String collection) {
+        final BsonDocument command = new BsonDocument()
+                .append("find", new BsonString(requireText(collection, "collection")))
+                .append("$db", new BsonString(normalizeDatabase(database)))
+                .append("filter", new BsonDocument());
+        return runCommand(command);
+    }
+
+    private BsonDocument dispatch(final BsonDocument command) {
+        final WireCommandIngress currentIngress = ingress;
+        final OpMsg request = new OpMsg(requestId.getAndIncrement(), 0, 0, command.clone());
+        final OpMsg response = codec.decode(currentIngress.handle(codec.encode(request)));
+        return response.body().clone();
+    }
+
+    private void maybeWriteFailureArtifacts(final BsonDocument command, final BsonDocument response) {
+        final TraceArtifactConfig config = traceArtifactConfig;
+        if (config == null) {
+            return;
+        }
+
+        final String commandName = command.isEmpty() ? "unknown" : command.getFirstKey().toLowerCase(Locale.ROOT);
+        final String timestamp = Instant.now().toString().replace(":", "-");
+        final String baseName = timestamp + "-" + commandName;
+
+        try {
+            Files.createDirectories(config.outputDir());
+            final Path snapshotPath = config.outputDir().resolve(baseName + "-snapshot.json");
+            final Path invariantPath = config.outputDir().resolve(baseName + "-invariant.json");
+            final Path triagePath = config.outputDir().resolve(baseName + "-triage.json");
+            final Path reproPath = config.outputDir().resolve(baseName + "-repro.jsonl");
+            final Path responsePath = config.outputDir().resolve(baseName + "-response.json");
+
+            final WireCommandIngress currentIngress = ingress;
+            Files.writeString(snapshotPath, currentIngress.dumpDiagnosticSnapshotJson(), StandardCharsets.UTF_8);
+            Files.writeString(invariantPath, currentIngress.dumpInvariantReportJson(), StandardCharsets.UTF_8);
+            Files.writeString(triagePath, currentIngress.dumpFailureTriageReportJson(), StandardCharsets.UTF_8);
+            Files.writeString(reproPath, currentIngress.exportReproJsonLines(), StandardCharsets.UTF_8);
+            Files.writeString(responsePath, response.toJson(), StandardCharsets.UTF_8);
+        } catch (final IOException ioException) {
+            throw new IllegalStateException("failed to write trace artifacts: " + ioException.getMessage(), ioException);
+        }
+    }
+
+    private static boolean isFailure(final BsonDocument response) {
+        if (response == null) {
+            return true;
+        }
+        final BsonValue ok = response.get("ok");
+        if (ok == null || !ok.isNumber()) {
+            return true;
+        }
+        return ok.asNumber().doubleValue() != 1.0d;
+    }
+
+    private static String normalizeDatabase(final String database) {
+        if (database == null || database.isBlank()) {
+            return DEFAULT_DATABASE;
+        }
+        return database.trim();
+    }
+
+    private static String requireText(final String value, final String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " must not be blank");
+        }
+        return value.trim();
+    }
+
+    private record TraceArtifactConfig(Path outputDir) {}
+}

--- a/src/test/java/org/jongodb/spring/test/JongodbInProcessInitializerTest.java
+++ b/src/test/java/org/jongodb/spring/test/JongodbInProcessInitializerTest.java
@@ -1,0 +1,45 @@
+package org.jongodb.spring.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.bson.BsonDocument;
+import org.jongodb.testkit.InProcessIntegrationTemplate;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.core.env.MapPropertySource;
+
+final class JongodbInProcessInitializerTest {
+    @Test
+    void registersTemplateBeanAndConfiguresTraceArtifacts(@TempDir final Path tempDir) throws Exception {
+        final AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        context.getEnvironment().getPropertySources().addFirst(new MapPropertySource(
+                "jongodbInProcessProps",
+                java.util.Map.of(
+                        JongodbInProcessInitializer.TRACE_ARTIFACTS_ENABLED_PROPERTY, "true",
+                        JongodbInProcessInitializer.TRACE_ARTIFACTS_DIR_PROPERTY, tempDir.toString())));
+
+        new JongodbInProcessInitializer().initialize(context);
+        context.refresh();
+
+        final InProcessIntegrationTemplate template =
+                context.getBean(JongodbInProcessInitializer.TEMPLATE_BEAN_NAME, InProcessIntegrationTemplate.class);
+        assertNotNull(template);
+
+        final BsonDocument ping = template.runCommand("{\"ping\":1,\"$db\":\"admin\"}");
+        assertEquals(1.0d, ping.getNumber("ok").doubleValue());
+
+        final BsonDocument failed = template.runCommand("{\"doesNotExist\":1,\"$db\":\"admin\"}");
+        assertEquals(0.0d, failed.getNumber("ok").doubleValue());
+
+        final List<Path> traces = Files.list(tempDir).toList();
+        assertTrue(traces.stream().anyMatch(path -> path.getFileName().toString().endsWith("-triage.json")));
+
+        context.close();
+    }
+}

--- a/src/test/java/org/jongodb/spring/test/JongodbInProcessTestDefaultWiringTest.java
+++ b/src/test/java/org/jongodb/spring/test/JongodbInProcessTestDefaultWiringTest.java
@@ -1,0 +1,46 @@
+package org.jongodb.spring.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+import org.bson.BsonDocument;
+import org.jongodb.testkit.InProcessIntegrationTemplate;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@JongodbInProcessTest(classes = JongodbInProcessTestDefaultWiringTest.TestConfig.class)
+final class JongodbInProcessTestDefaultWiringTest {
+    @Autowired
+    private InProcessIntegrationTemplate template;
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Test
+    void providesInProcessTemplateWithResetSupport() {
+        assertNotNull(template);
+
+        template.seedDocuments(
+                "app",
+                "users",
+                List.of(BsonDocument.parse("{\"_id\":1,\"name\":\"alpha\"}")));
+        final BsonDocument beforeReset = template.findAll("app", "users");
+        assertEquals(1, beforeReset.getDocument("cursor").getArray("firstBatch").size());
+
+        JongodbInProcessResetSupport.reset(context);
+
+        final BsonDocument afterReset = template.findAll("app", "users");
+        assertEquals(0, afterReset.getDocument("cursor").getArray("firstBatch").size());
+    }
+
+    @Configuration
+    static class TestConfig {}
+}

--- a/src/test/java/org/jongodb/testkit/InProcessIntegrationTemplateTest.java
+++ b/src/test/java/org/jongodb/testkit/InProcessIntegrationTemplateTest.java
@@ -1,0 +1,47 @@
+package org.jongodb.testkit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.bson.BsonDocument;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class InProcessIntegrationTemplateTest {
+    @Test
+    void seedFindAndResetFlowWorks() {
+        final InProcessIntegrationTemplate template = new InProcessIntegrationTemplate();
+        template.seedDocuments(
+                "app",
+                "users",
+                List.of(
+                        BsonDocument.parse("{\"_id\":1,\"name\":\"alpha\"}"),
+                        BsonDocument.parse("{\"_id\":2,\"name\":\"beta\"}")));
+
+        final BsonDocument beforeReset = template.findAll("app", "users");
+        assertEquals(2, beforeReset.getDocument("cursor").getArray("firstBatch").size());
+
+        template.reset();
+        final BsonDocument afterReset = template.findAll("app", "users");
+        assertEquals(0, afterReset.getDocument("cursor").getArray("firstBatch").size());
+    }
+
+    @Test
+    void writesTraceArtifactsOnFailureWhenEnabled(@TempDir final Path tempDir) throws Exception {
+        final InProcessIntegrationTemplate template = new InProcessIntegrationTemplate();
+        template.enableFailureTraceArtifacts(tempDir);
+
+        final BsonDocument failed = template.runCommand("{\"doesNotExist\":1,\"$db\":\"admin\"}");
+        assertEquals(0.0d, failed.getNumber("ok").doubleValue());
+
+        final List<Path> files = Files.list(tempDir).toList();
+        assertTrue(files.stream().anyMatch(path -> path.getFileName().toString().endsWith("-snapshot.json")));
+        assertTrue(files.stream().anyMatch(path -> path.getFileName().toString().endsWith("-invariant.json")));
+        assertTrue(files.stream().anyMatch(path -> path.getFileName().toString().endsWith("-triage.json")));
+        assertTrue(files.stream().anyMatch(path -> path.getFileName().toString().endsWith("-repro.jsonl")));
+        assertTrue(files.stream().anyMatch(path -> path.getFileName().toString().endsWith("-response.json")));
+    }
+}


### PR DESCRIPTION
## Summary
- add `InProcessIntegrationTemplate` for command-level in-process integration tests
- provide fixture seed/find/reset helpers and failure-triggered trace artifact auto-dump option
- add Spring entrypoint via `@JongodbInProcessTest` and `JongodbInProcessInitializer`
- add Spring reset helper (`JongodbInProcessResetSupport`) and example wiring tests
- add usage guide with JUnit/Spring examples and trace artifact configuration

## Testing
- .tooling/gradle-8.10.2/bin/gradle test --tests org.jongodb.testkit.InProcessIntegrationTemplateTest --tests org.jongodb.spring.test.JongodbInProcessInitializerTest --tests org.jongodb.spring.test.JongodbInProcessTestDefaultWiringTest

Closes #261
