### PR TITLE
feat(fixture): implement restore/reset utility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -391,6 +391,44 @@ tasks.register<JavaExec>("fixtureSanitize") {
     args(if (failOnPii) "--fail-on-pii" else "--no-fail-on-pii")
 }
 
+tasks.register<JavaExec>("fixtureRestore") {
+    group = "verification"
+    description = "Restores fixture ndjson into target MongoDB using replace/merge mode with diagnostics report."
+    classpath = sourceSets["main"].runtimeClasspath
+    mainClass.set("org.jongodb.testkit.FixtureRestoreTool")
+
+    val inputDir = (findProperty("fixtureRestoreInputDir") as String?)?.trim().orEmpty()
+    val mongoUri = (findProperty("fixtureRestoreMongoUri") as String?)?.trim().orEmpty()
+    val mode = (findProperty("fixtureRestoreMode") as String?)?.trim().orEmpty().ifBlank { "replace" }
+    val database = (findProperty("fixtureRestoreDatabase") as String?)?.trim().orEmpty()
+    val namespace = (findProperty("fixtureRestoreNamespace") as String?)?.trim().orEmpty()
+    val reportDir = (findProperty("fixtureRestoreReportDir") as String?)?.trim().orEmpty()
+
+    doFirst {
+        if (inputDir.isBlank()) {
+            throw GradleException("fixtureRestoreInputDir property is required")
+        }
+        if (mongoUri.isBlank()) {
+            throw GradleException("fixtureRestoreMongoUri property is required")
+        }
+    }
+
+    args(
+        "--input-dir=$inputDir",
+        "--mongo-uri=$mongoUri",
+        "--mode=$mode"
+    )
+    if (database.isNotBlank()) {
+        args("--database=$database")
+    }
+    if (namespace.isNotBlank()) {
+        args("--namespace=$namespace")
+    }
+    if (reportDir.isNotBlank()) {
+        args("--report-dir=$reportDir")
+    }
+}
+
 tasks.register<JavaExec>("complexQueryCertificationEvidence") {
     group = "verification"
     description = "Runs canonical complex-query certification pack and enforces gate policy."

--- a/docs/FIXTURE_RESTORE.md
+++ b/docs/FIXTURE_RESTORE.md
@@ -1,0 +1,32 @@
+# Fixture Restore Utility
+
+`#253` 구현 가이드입니다.
+
+## 목적
+- NDJSON fixture를 로컬/CI Mongo로 복원합니다.
+- `replace|merge` 모드와 DB/namespace 대상 선택을 지원합니다.
+- 복원 진단 리포트를 생성합니다.
+
+## 실행
+
+```bash
+.tooling/gradle-8.10.2/bin/gradle fixtureRestore \
+  -PfixtureRestoreInputDir=build/reports/fixture-sanitized \
+  -PfixtureRestoreMongoUri='mongodb://localhost:27017' \
+  -PfixtureRestoreMode=replace
+```
+
+## 주요 옵션
+- `--mode=replace|merge`
+- `--database=<db>`
+- `--namespace=<db.collection[,db.collection...]>`
+- `--report-dir=<dir>`
+
+## 산출물
+- `<reportDir>/fixture-restore-report.json`
+  - 컬렉션별 source/restored 문서 수
+  - 스키마 불일치 경고(top-level signature mix)
+
+## before-test hook
+- 테스트 프레임워크에서 `FixtureRestoreSupport.beforeEachReplace(mongoUri, fixtureDir)` 호출로
+  테스트 시작 전 상태를 반복 복원할 수 있습니다.

--- a/src/main/java/org/jongodb/testkit/FixtureRestoreSupport.java
+++ b/src/main/java/org/jongodb/testkit/FixtureRestoreSupport.java
@@ -1,0 +1,25 @@
+package org.jongodb.testkit;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * Convenience hook for test frameworks to reset/restore fixtures before each test.
+ */
+public final class FixtureRestoreSupport {
+    private FixtureRestoreSupport() {}
+
+    public static void beforeEachReplace(final String mongoUri, final Path fixtureDir) {
+        beforeEach(mongoUri, fixtureDir, FixtureRestoreTool.RestoreMode.REPLACE);
+    }
+
+    public static void beforeEach(
+            final String mongoUri,
+            final Path fixtureDir,
+            final FixtureRestoreTool.RestoreMode mode) {
+        Objects.requireNonNull(mongoUri, "mongoUri");
+        Objects.requireNonNull(fixtureDir, "fixtureDir");
+        Objects.requireNonNull(mode, "mode");
+        FixtureRestoreTool.resetAndRestore(mongoUri, fixtureDir, mode);
+    }
+}

--- a/src/main/java/org/jongodb/testkit/FixtureRestoreTool.java
+++ b/src/main/java/org/jongodb/testkit/FixtureRestoreTool.java
@@ -1,0 +1,366 @@
+package org.jongodb.testkit;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.ReplaceOptions;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.bson.Document;
+
+/**
+ * Fixture restore/reset/seed utility for local + CI integration tests.
+ */
+public final class FixtureRestoreTool {
+    private static final Pattern NDJSON_FILE = Pattern.compile("^([^.]+)\\.([^.]+)\\.ndjson$");
+    private static final String REPORT_FILE = "fixture-restore-report.json";
+
+    private FixtureRestoreTool() {}
+
+    public static void main(final String[] args) {
+        final int exitCode = run(args, System.out, System.err);
+        if (exitCode != 0) {
+            System.exit(exitCode);
+        }
+    }
+
+    static int run(final String[] args, final PrintStream out, final PrintStream err) {
+        Objects.requireNonNull(args, "args");
+        Objects.requireNonNull(out, "out");
+        Objects.requireNonNull(err, "err");
+
+        final Config config;
+        try {
+            config = Config.fromArgs(args);
+        } catch (final IllegalArgumentException exception) {
+            err.println(exception.getMessage());
+            printUsage(err);
+            return 2;
+        }
+
+        if (config.help()) {
+            printUsage(out);
+            return 0;
+        }
+
+        try {
+            final List<FixtureFile> files = discoverFixtureFiles(config.inputDir(), config);
+            final List<RestoreCollectionReport> reports = new ArrayList<>();
+            final List<String> diagnostics = new ArrayList<>();
+
+            final Instant startedAt = Instant.now();
+            try (MongoClient client = MongoClients.create(new ConnectionString(config.mongoUri()))) {
+                for (final FixtureFile file : files) {
+                    final List<Document> documents = readDocuments(file.path());
+                    final List<String> schemaWarnings = schemaWarnings(file.key(), documents);
+                    diagnostics.addAll(schemaWarnings);
+
+                    final MongoCollection<Document> collection =
+                            client.getDatabase(file.database()).getCollection(file.collection());
+                    final int restoredCount = restoreCollection(collection, documents, config.mode());
+                    reports.add(new RestoreCollectionReport(
+                            file.key(),
+                            file.path().toString(),
+                            documents.size(),
+                            restoredCount,
+                            schemaWarnings));
+                    out.println("Restored " + file.key() + " docs=" + restoredCount + " mode=" + config.mode().value());
+                }
+            }
+            final Instant finishedAt = Instant.now();
+
+            final RestoreReport report = new RestoreReport(
+                    startedAt.toString(),
+                    finishedAt.toString(),
+                    config.mode().value(),
+                    reports,
+                    diagnostics);
+            Files.writeString(config.reportDir().resolve(REPORT_FILE), report.toJson(), StandardCharsets.UTF_8);
+
+            out.println("Fixture restore finished");
+            out.println("- mode: " + config.mode().value());
+            out.println("- collections: " + reports.size());
+            out.println("- diagnostics: " + diagnostics.size());
+            out.println("- report: " + config.reportDir().resolve(REPORT_FILE));
+            return 0;
+        } catch (final IOException | RuntimeException exception) {
+            err.println("fixture restore failed: " + exception.getMessage());
+            return 1;
+        }
+    }
+
+    static void resetAndRestore(
+            final String mongoUri,
+            final Path inputDir,
+            final RestoreMode mode) {
+        final int exitCode = run(
+                new String[] {
+                    "--input-dir=" + inputDir.toAbsolutePath().normalize(),
+                    "--mongo-uri=" + mongoUri,
+                    "--mode=" + mode.value(),
+                    "--report-dir=" + inputDir.toAbsolutePath().normalize()
+                },
+                new PrintStream(System.out),
+                new PrintStream(System.err));
+        if (exitCode != 0) {
+            throw new IllegalStateException("fixture restore failed with exitCode=" + exitCode);
+        }
+    }
+
+    private static int restoreCollection(
+            final MongoCollection<Document> collection,
+            final List<Document> documents,
+            final RestoreMode mode) {
+        if (mode == RestoreMode.REPLACE) {
+            collection.deleteMany(new Document());
+            if (!documents.isEmpty()) {
+                collection.insertMany(documents);
+            }
+            return documents.size();
+        }
+
+        int restored = 0;
+        for (final Document document : documents) {
+            if (document.containsKey("_id")) {
+                final Document filter = new Document("_id", document.get("_id"));
+                collection.replaceOne(filter, document, new ReplaceOptions().upsert(true));
+                restored++;
+                continue;
+            }
+            collection.insertOne(document);
+            restored++;
+        }
+        return restored;
+    }
+
+    private static List<Document> readDocuments(final Path file) throws IOException {
+        final List<Document> documents = new ArrayList<>();
+        for (final String line : Files.readAllLines(file, StandardCharsets.UTF_8)) {
+            if (line == null || line.isBlank()) {
+                continue;
+            }
+            documents.add(Document.parse(line));
+        }
+        return List.copyOf(documents);
+    }
+
+    private static List<String> schemaWarnings(final String collectionKey, final List<Document> documents) {
+        final Set<String> signatures = new LinkedHashSet<>();
+        for (final Document document : documents) {
+            final List<String> keys = new ArrayList<>(document.keySet());
+            keys.sort(String::compareTo);
+            signatures.add(String.join(",", keys));
+        }
+        if (signatures.size() <= 1) {
+            return List.of();
+        }
+        return List.of(collectionKey + " has mixed top-level schema signatures: " + signatures.size());
+    }
+
+    private static List<FixtureFile> discoverFixtureFiles(final Path inputDir, final Config config) throws IOException {
+        if (!Files.exists(inputDir) || !Files.isDirectory(inputDir)) {
+            throw new IllegalArgumentException("input dir is missing: " + inputDir);
+        }
+
+        final List<FixtureFile> files = new ArrayList<>();
+        try (var stream = Files.list(inputDir)) {
+            stream.filter(path -> Files.isRegularFile(path) && path.getFileName().toString().endsWith(".ndjson"))
+                    .sorted(Comparator.comparing(path -> path.getFileName().toString()))
+                    .forEach(path -> {
+                        final String fileName = path.getFileName().toString();
+                        final java.util.regex.Matcher matcher = NDJSON_FILE.matcher(fileName);
+                        if (!matcher.matches()) {
+                            return;
+                        }
+                        final String database = matcher.group(1);
+                        final String collection = matcher.group(2);
+                        final String key = database + "." + collection;
+                        if (config.databaseFilter() != null && !config.databaseFilter().equals(database)) {
+                            return;
+                        }
+                        if (!config.namespaceFilter().isEmpty() && !config.namespaceFilter().contains(key)) {
+                            return;
+                        }
+                        files.add(new FixtureFile(database, collection, key, path));
+                    });
+        }
+        return List.copyOf(files);
+    }
+
+    private static void printUsage(final PrintStream stream) {
+        stream.println("Usage: FixtureRestoreTool --input-dir=<dir> --mongo-uri=<uri> [options]");
+        stream.println("  --input-dir=<dir>           Fixture ndjson directory");
+        stream.println("  --mongo-uri=<uri>           Target MongoDB URI");
+        stream.println("  --mode=replace|merge        Restore mode (default: replace)");
+        stream.println("  --database=<db>             Restore only one database");
+        stream.println("  --namespace=a.b,c.d         Restore only selected namespaces");
+        stream.println("  --report-dir=<dir>          Report output directory (default: input-dir)");
+        stream.println("  --help                      Show usage");
+    }
+
+    private record FixtureFile(
+            String database,
+            String collection,
+            String key,
+            Path path) {}
+
+    private record Config(
+            Path inputDir,
+            String mongoUri,
+            RestoreMode mode,
+            String databaseFilter,
+            Set<String> namespaceFilter,
+            Path reportDir,
+            boolean help) {
+        static Config fromArgs(final String[] args) {
+            Path inputDir = null;
+            String mongoUri = null;
+            RestoreMode mode = RestoreMode.REPLACE;
+            String databaseFilter = null;
+            final Set<String> namespaceFilter = new LinkedHashSet<>();
+            Path reportDir = null;
+            boolean help = false;
+
+            for (final String arg : args) {
+                if ("--help".equals(arg) || "-h".equals(arg)) {
+                    help = true;
+                    continue;
+                }
+                if (arg.startsWith("--input-dir=")) {
+                    inputDir = Path.of(valueAfterPrefix(arg, "--input-dir="));
+                    continue;
+                }
+                if (arg.startsWith("--mongo-uri=")) {
+                    mongoUri = valueAfterPrefix(arg, "--mongo-uri=");
+                    continue;
+                }
+                if (arg.startsWith("--mode=")) {
+                    mode = RestoreMode.fromText(valueAfterPrefix(arg, "--mode="));
+                    continue;
+                }
+                if (arg.startsWith("--database=")) {
+                    databaseFilter = valueAfterPrefix(arg, "--database=");
+                    continue;
+                }
+                if (arg.startsWith("--namespace=")) {
+                    for (final String item : valueAfterPrefix(arg, "--namespace=").split(",")) {
+                        final String namespace = item.trim();
+                        if (!namespace.isEmpty()) {
+                            namespaceFilter.add(namespace);
+                        }
+                    }
+                    continue;
+                }
+                if (arg.startsWith("--report-dir=")) {
+                    reportDir = Path.of(valueAfterPrefix(arg, "--report-dir="));
+                    continue;
+                }
+                throw new IllegalArgumentException("unknown argument: " + arg);
+            }
+
+            if (!help && inputDir == null) {
+                throw new IllegalArgumentException("--input-dir=<dir> is required");
+            }
+            if (!help && (mongoUri == null || mongoUri.isBlank())) {
+                throw new IllegalArgumentException("--mongo-uri=<uri> is required");
+            }
+            if (reportDir == null && inputDir != null) {
+                reportDir = inputDir;
+            }
+            return new Config(
+                    inputDir,
+                    mongoUri,
+                    mode,
+                    databaseFilter,
+                    Set.copyOf(namespaceFilter),
+                    reportDir,
+                    help);
+        }
+
+        private static String valueAfterPrefix(final String arg, final String prefix) {
+            final String value = arg.substring(prefix.length()).trim();
+            if (value.isEmpty()) {
+                throw new IllegalArgumentException(prefix + " must have a value");
+            }
+            return value;
+        }
+    }
+
+    enum RestoreMode {
+        REPLACE("replace"),
+        MERGE("merge");
+
+        private final String value;
+
+        RestoreMode(final String value) {
+            this.value = value;
+        }
+
+        String value() {
+            return value;
+        }
+
+        static RestoreMode fromText(final String rawValue) {
+            final String normalized = rawValue.trim().toLowerCase(Locale.ROOT);
+            for (final RestoreMode mode : values()) {
+                if (mode.value.equals(normalized)) {
+                    return mode;
+                }
+            }
+            throw new IllegalArgumentException("mode must be replace|merge");
+        }
+    }
+
+    private record RestoreCollectionReport(
+            String collection,
+            String file,
+            int sourceDocuments,
+            int restoredDocuments,
+            List<String> warnings) {
+        Map<String, Object> toMap() {
+            final Map<String, Object> root = new LinkedHashMap<>();
+            root.put("collection", collection);
+            root.put("file", file);
+            root.put("sourceDocuments", sourceDocuments);
+            root.put("restoredDocuments", restoredDocuments);
+            root.put("warnings", warnings);
+            return root;
+        }
+    }
+
+    private record RestoreReport(
+            String startedAt,
+            String finishedAt,
+            String mode,
+            List<RestoreCollectionReport> collections,
+            List<String> diagnostics) {
+        String toJson() {
+            final Map<String, Object> root = new LinkedHashMap<>();
+            root.put("startedAt", startedAt);
+            root.put("finishedAt", finishedAt);
+            root.put("mode", mode);
+            final List<Map<String, Object>> collectionItems = new ArrayList<>(collections.size());
+            for (final RestoreCollectionReport collection : collections) {
+                collectionItems.add(collection.toMap());
+            }
+            root.put("collections", collectionItems);
+            root.put("diagnostics", diagnostics);
+            return DiffSummaryGenerator.JsonEncoder.encode(root);
+        }
+    }
+}

--- a/src/test/java/org/jongodb/testkit/FixtureRestoreToolTest.java
+++ b/src/test/java/org/jongodb/testkit/FixtureRestoreToolTest.java
@@ -1,0 +1,101 @@
+package org.jongodb.testkit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.bson.Document;
+import org.jongodb.server.TcpMongoServer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class FixtureRestoreToolTest {
+    @Test
+    void restoreReplaceReplacesTargetCollection(@TempDir final Path tempDir) throws Exception {
+        final Path fixtureDir = tempDir.resolve("fixture");
+        Files.createDirectories(fixtureDir);
+        Files.writeString(
+                fixtureDir.resolve("app.users.ndjson"),
+                """
+                {"_id":1,"name":"alpha"}
+                {"_id":2,"name":"beta"}
+                """,
+                StandardCharsets.UTF_8);
+
+        try (TcpMongoServer server = TcpMongoServer.inMemory()) {
+            server.start();
+            final String uri = server.connectionString("app");
+            try (MongoClient client = MongoClients.create(uri)) {
+                final MongoCollection<Document> users = client.getDatabase("app").getCollection("users");
+                users.insertOne(new Document("_id", 99).append("name", "legacy"));
+            }
+
+            final int exitCode = FixtureRestoreTool.run(
+                    new String[] {
+                        "--input-dir=" + fixtureDir,
+                        "--mongo-uri=" + uri,
+                        "--mode=replace"
+                    },
+                    new PrintStream(new ByteArrayOutputStream()),
+                    new PrintStream(new ByteArrayOutputStream()));
+            assertEquals(0, exitCode);
+
+            try (MongoClient client = MongoClients.create(uri)) {
+                final MongoCollection<Document> users = client.getDatabase("app").getCollection("users");
+                assertEquals(2, users.countDocuments());
+                assertEquals("alpha", users.find(new Document("_id", 1)).first().getString("name"));
+                assertEquals("beta", users.find(new Document("_id", 2)).first().getString("name"));
+            }
+        }
+    }
+
+    @Test
+    void restoreMergeUpsertsWithoutDeletingExistingDocuments(@TempDir final Path tempDir) throws Exception {
+        final Path fixtureDir = tempDir.resolve("fixture");
+        Files.createDirectories(fixtureDir);
+        Files.writeString(
+                fixtureDir.resolve("app.users.ndjson"),
+                """
+                {"_id":1,"name":"merged"}
+                {"_id":4,"name":"new"}
+                """,
+                StandardCharsets.UTF_8);
+
+        try (TcpMongoServer server = TcpMongoServer.inMemory()) {
+            server.start();
+            final String uri = server.connectionString("app");
+            try (MongoClient client = MongoClients.create(uri)) {
+                final MongoCollection<Document> users = client.getDatabase("app").getCollection("users");
+                users.insertOne(new Document("_id", 1).append("name", "old"));
+                users.insertOne(new Document("_id", 3).append("name", "keep"));
+            }
+
+            final int exitCode = FixtureRestoreTool.run(
+                    new String[] {
+                        "--input-dir=" + fixtureDir,
+                        "--mongo-uri=" + uri,
+                        "--mode=merge"
+                    },
+                    new PrintStream(new ByteArrayOutputStream()),
+                    new PrintStream(new ByteArrayOutputStream()));
+            assertEquals(0, exitCode);
+
+            try (MongoClient client = MongoClients.create(uri)) {
+                final MongoCollection<Document> users = client.getDatabase("app").getCollection("users");
+                assertEquals(3, users.countDocuments());
+                assertEquals("merged", users.find(new Document("_id", 1)).first().getString("name"));
+                assertEquals("keep", users.find(new Document("_id", 3)).first().getString("name"));
+                assertEquals("new", users.find(new Document("_id", 4)).first().getString("name"));
+            }
+
+            assertTrue(Files.exists(fixtureDir.resolve("fixture-restore-report.json")));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `FixtureRestoreTool` for NDJSON fixture restore/reset with `replace|merge` modes
- support target scoping by database/namespace and emit restore diagnostics report
- add `FixtureRestoreSupport` before-test helper for reset/restore hook integration
- add Gradle task `fixtureRestore` and usage docs
- add e2e tests validating replace and merge restore semantics against `TcpMongoServer`

## Testing
- .tooling/gradle-8.10.2/bin/gradle test --tests org.jongodb.testkit.FixtureRestoreToolTest

Closes #253
