### PR TITLE
feat(fixture): add portable and fast dual artifact format

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -391,6 +391,34 @@ tasks.register<JavaExec>("fixtureSanitize") {
     args(if (failOnPii) "--fail-on-pii" else "--no-fail-on-pii")
 }
 
+tasks.register<JavaExec>("fixtureArtifactPack") {
+    group = "verification"
+    description = "Packs fixture ndjson into portable + fast dual artifacts with checksum manifest."
+    classpath = sourceSets["main"].runtimeClasspath
+    mainClass.set("org.jongodb.testkit.FixtureArtifactTool")
+
+    val inputDir = (findProperty("fixtureArtifactInputDir") as String?)?.trim().orEmpty()
+    val outputDir = (findProperty("fixtureArtifactOutputDir") as String?)?.trim().orEmpty()
+    val engineVersion = (findProperty("fixtureArtifactEngineVersion") as String?)?.trim().orEmpty()
+
+    doFirst {
+        if (inputDir.isBlank()) {
+            throw GradleException("fixtureArtifactInputDir property is required")
+        }
+        if (outputDir.isBlank()) {
+            throw GradleException("fixtureArtifactOutputDir property is required")
+        }
+    }
+
+    args(
+        "--input-dir=$inputDir",
+        "--output-dir=$outputDir"
+    )
+    if (engineVersion.isNotBlank()) {
+        args("--engine-version=$engineVersion")
+    }
+}
+
 tasks.register<JavaExec>("fixtureRestore") {
     group = "verification"
     description = "Restores fixture ndjson into target MongoDB using replace/merge mode with diagnostics report."
@@ -403,6 +431,7 @@ tasks.register<JavaExec>("fixtureRestore") {
     val database = (findProperty("fixtureRestoreDatabase") as String?)?.trim().orEmpty()
     val namespace = (findProperty("fixtureRestoreNamespace") as String?)?.trim().orEmpty()
     val reportDir = (findProperty("fixtureRestoreReportDir") as String?)?.trim().orEmpty()
+    val regenerateFastCache = (findProperty("fixtureRestoreRegenerateFastCache") as String?)?.toBoolean() ?: true
 
     doFirst {
         if (inputDir.isBlank()) {
@@ -427,6 +456,7 @@ tasks.register<JavaExec>("fixtureRestore") {
     if (reportDir.isNotBlank()) {
         args("--report-dir=$reportDir")
     }
+    args(if (regenerateFastCache) "--regenerate-fast-cache" else "--no-regenerate-fast-cache")
 }
 
 tasks.register<JavaExec>("complexQueryCertificationEvidence") {

--- a/docs/FIXTURE_ARTIFACTS.md
+++ b/docs/FIXTURE_ARTIFACTS.md
@@ -1,0 +1,44 @@
+# Fixture Dual Artifacts (Portable + Fast)
+
+`#252` 구현 가이드입니다.
+
+## 목적
+- fixture를 두 가지 포맷으로 동시 관리합니다.
+- `portable`: 이식성과 장기 보관 중심 (`.ejsonl.gz`)
+- `fast`: 복원 속도 중심 (`.bin` 스냅샷)
+
+## 산출물
+`fixtureArtifactPack` 실행 시 아래 파일이 생성됩니다.
+
+- `fixture-artifact-manifest.json`
+- `fixture-portable.ejsonl.gz`
+- `fixture-fast-snapshot.bin`
+
+manifest에는 다음이 포함됩니다.
+- `schemaVersion`, `portableFormatVersion`, `fastFormatVersion`
+- `engineVersion`
+- 각 아티팩트의 `sha256`
+- 컬렉션별 문서 수
+
+## 실행
+
+```bash
+.tooling/gradle-8.10.2/bin/gradle fixtureArtifactPack \
+  -PfixtureArtifactInputDir=build/reports/fixture-sanitized \
+  -PfixtureArtifactOutputDir=build/reports/fixture-artifacts
+```
+
+옵션:
+- `-PfixtureArtifactEngineVersion=<version>`
+
+## 복원 시 호환성 정책
+`fixtureRestore`는 기본적으로 아래 순서로 입력을 선택합니다.
+
+1. fast snapshot 사용 시도
+2. fast 포맷/엔진 버전 불일치 시 portable fallback
+3. 필요 시 portable로부터 fast cache 재생성
+4. artifact가 없으면 기존 ndjson 복원 경로 사용
+
+체크섬 불일치가 감지되면 즉시 실패합니다.
+
+`fixtureRestore` 리포트(`fixture-restore-report.json`)의 `sourceFormat`으로 실제 경로를 확인할 수 있습니다.

--- a/docs/FIXTURE_RESTORE.md
+++ b/docs/FIXTURE_RESTORE.md
@@ -4,6 +4,7 @@
 
 ## 목적
 - NDJSON fixture를 로컬/CI Mongo로 복원합니다.
+- dual artifact(Portable + Fast) 입력을 자동 인식해 복원합니다.
 - `replace|merge` 모드와 DB/namespace 대상 선택을 지원합니다.
 - 복원 진단 리포트를 생성합니다.
 
@@ -21,9 +22,11 @@
 - `--database=<db>`
 - `--namespace=<db.collection[,db.collection...]>`
 - `--report-dir=<dir>`
+- `--no-regenerate-fast-cache` (portable fallback 이후 fast cache 재생성 비활성화)
 
 ## 산출물
 - `<reportDir>/fixture-restore-report.json`
+  - `sourceFormat` (`FAST`, `PORTABLE_FALLBACK`, `NDJSON`)
   - 컬렉션별 source/restored 문서 수
   - 스키마 불일치 경고(top-level signature mix)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,14 @@ Runtime and compatibility:
 - `docs/RELEASE_CHECKLIST.md`
 - `docs/ROADMAP.md`
 
+Fixture workflows:
+- `docs/FIXTURE_MANIFEST.md`
+- `docs/FIXTURE_PLAYBOOK.md`
+- `docs/FIXTURE_EXTRACTION.md`
+- `docs/FIXTURE_SANITIZATION.md`
+- `docs/FIXTURE_ARTIFACTS.md`
+- `docs/FIXTURE_RESTORE.md`
+
 Research and design notes:
 - `docs/research/README.md`
 - `docs/research/17-reference-implementation-status.md`

--- a/src/main/java/org/jongodb/testkit/FixtureArtifactBundle.java
+++ b/src/main/java/org/jongodb/testkit/FixtureArtifactBundle.java
@@ -1,0 +1,504 @@
+package org.jongodb.testkit;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+import org.bson.Document;
+
+/**
+ * Portable + fast dual fixture artifact encoder/decoder.
+ */
+final class FixtureArtifactBundle {
+    static final String MANIFEST_FILE = "fixture-artifact-manifest.json";
+    static final String PORTABLE_FILE = "fixture-portable.ejsonl.gz";
+    static final String FAST_FILE = "fixture-fast-snapshot.bin";
+    static final String SCHEMA_VERSION = "fixture-artifact.v1";
+    static final String PORTABLE_FORMAT_VERSION = "portable-ejsonl-gzip.v1";
+    static final String FAST_FORMAT_VERSION = "fast-snapshot.v1";
+
+    private static final int FAST_MAGIC = 0x4a464658;
+    private static final int FAST_LAYOUT_VERSION = 1;
+    private static final Pattern NDJSON_FILE = Pattern.compile("^([^.]+)\\.([^.]+)\\.ndjson$");
+
+    private FixtureArtifactBundle() {}
+
+    static WriteResult writeBundleFromNdjson(
+            final Path inputDir,
+            final Path outputDir,
+            final String engineVersion) throws IOException {
+        final Map<String, List<Document>> collections = loadNdjsonCollections(inputDir);
+        if (collections.isEmpty()) {
+            throw new IllegalArgumentException("no ndjson files found in input dir: " + inputDir);
+        }
+
+        Files.createDirectories(outputDir);
+
+        final Path portablePath = outputDir.resolve(PORTABLE_FILE);
+        final int totalDocuments = writePortable(collections, portablePath);
+
+        final Path fastPath = outputDir.resolve(FAST_FILE);
+        writeFast(collections, fastPath);
+
+        final String portableSha = sha256Hex(portablePath);
+        final String fastSha = sha256Hex(fastPath);
+
+        writeManifest(
+                outputDir.resolve(MANIFEST_FILE),
+                manifestDocument(collections, totalDocuments, engineVersion, portableSha, fastSha));
+
+        return new WriteResult(
+                outputDir.resolve(MANIFEST_FILE),
+                portablePath,
+                fastPath,
+                collections.size(),
+                totalDocuments,
+                portableSha,
+                fastSha,
+                engineVersion);
+    }
+
+    static LoadResult tryLoadBundle(
+            final Path inputDir,
+            final boolean regenerateFastCache,
+            final String currentEngineVersion,
+            final PrintStream out) throws IOException {
+        final Path manifestPath = inputDir.resolve(MANIFEST_FILE);
+        if (!Files.exists(manifestPath)) {
+            return null;
+        }
+
+        final List<String> diagnostics = new ArrayList<>();
+        final Document manifest = Document.parse(Files.readString(manifestPath, StandardCharsets.UTF_8));
+        final String schemaVersion = manifest.getString("schemaVersion");
+        if (!SCHEMA_VERSION.equals(schemaVersion)) {
+            diagnostics.add("artifact manifest schemaVersion is unsupported: " + schemaVersion);
+            return new LoadResult(SourceFormat.NDJSON, Map.of(), List.copyOf(diagnostics));
+        }
+
+        final String manifestFastVersion = manifest.getString("fastFormatVersion");
+        final String manifestEngineVersion = manifest.getString("engineVersion");
+        final ManifestEntry fastEntry = entryFrom(manifest, "fast", FAST_FILE);
+        final ManifestEntry portableEntry = entryFrom(manifest, "portable", PORTABLE_FILE);
+
+        final Path fastPath = inputDir.resolve(fastEntry.file());
+        final Path portablePath = inputDir.resolve(portableEntry.file());
+
+        final boolean fastCompatible = FAST_FORMAT_VERSION.equals(manifestFastVersion)
+                && Objects.equals(currentEngineVersion, manifestEngineVersion);
+        if (fastCompatible && Files.exists(fastPath)) {
+            verifyChecksum(fastPath, fastEntry.sha256(), "fast");
+            final Map<String, List<Document>> collections = readFast(fastPath);
+            diagnostics.add("loaded fast snapshot");
+            return new LoadResult(SourceFormat.FAST, collections, List.copyOf(diagnostics));
+        }
+
+        if (!fastCompatible) {
+            diagnostics.add("fast snapshot compatibility mismatch (manifest engine="
+                    + manifestEngineVersion
+                    + ", runtime engine="
+                    + currentEngineVersion
+                    + ", format="
+                    + manifestFastVersion
+                    + ")");
+        }
+
+        if (Files.exists(portablePath)) {
+            verifyChecksum(portablePath, portableEntry.sha256(), "portable");
+            final Map<String, List<Document>> collections = readPortable(portablePath);
+            diagnostics.add("loaded portable bundle");
+
+            if (regenerateFastCache) {
+                writeFast(collections, fastPath);
+                final String regeneratedFastSha = sha256Hex(fastPath);
+
+                final Document nextManifest = new Document(manifest);
+                nextManifest.put("engineVersion", currentEngineVersion);
+                nextManifest.put("fastFormatVersion", FAST_FORMAT_VERSION);
+                nextManifest.put("updatedAt", Instant.now().toString());
+                nextManifest.put(
+                        "fast",
+                        new Document("file", fastEntry.file())
+                                .append("sha256", regeneratedFastSha)
+                                .append("documents", countDocuments(collections)));
+                writeManifest(manifestPath, nextManifest);
+                diagnostics.add("regenerated fast snapshot from portable bundle");
+                out.println("Regenerated fast fixture cache: " + fastPath);
+            }
+
+            return new LoadResult(SourceFormat.PORTABLE_FALLBACK, collections, List.copyOf(diagnostics));
+        }
+
+        diagnostics.add("portable bundle is missing; fallback to ndjson files");
+        return new LoadResult(SourceFormat.NDJSON, Map.of(), List.copyOf(diagnostics));
+    }
+
+    static String currentEngineVersion() {
+        final Package pkg = FixtureArtifactBundle.class.getPackage();
+        final String packageVersion = pkg == null ? null : pkg.getImplementationVersion();
+        if (packageVersion != null && !packageVersion.isBlank()) {
+            return packageVersion.trim();
+        }
+
+        final String propertyVersion = System.getProperty("jongodb.version", "").trim();
+        if (!propertyVersion.isEmpty()) {
+            return propertyVersion;
+        }
+        return "dev";
+    }
+
+    private static Map<String, List<Document>> loadNdjsonCollections(final Path inputDir) throws IOException {
+        final Map<String, List<Document>> collections = new LinkedHashMap<>();
+        if (!Files.exists(inputDir) || !Files.isDirectory(inputDir)) {
+            throw new IllegalArgumentException("input dir is missing: " + inputDir);
+        }
+
+        try (var stream = Files.list(inputDir)) {
+            stream.filter(path -> Files.isRegularFile(path) && path.getFileName().toString().endsWith(".ndjson"))
+                    .sorted(Comparator.comparing(path -> path.getFileName().toString()))
+                    .forEach(path -> {
+                        final Matcher matcher = NDJSON_FILE.matcher(path.getFileName().toString());
+                        if (!matcher.matches()) {
+                            return;
+                        }
+                        final String namespace = matcher.group(1) + "." + matcher.group(2);
+                        final List<Document> documents = readNdjsonFile(path);
+                        collections.put(namespace, documents);
+                    });
+        }
+        return Map.copyOf(collections);
+    }
+
+    private static List<Document> readNdjsonFile(final Path file) {
+        final List<Document> documents = new ArrayList<>();
+        try {
+            for (final String line : Files.readAllLines(file, StandardCharsets.UTF_8)) {
+                if (line == null || line.isBlank()) {
+                    continue;
+                }
+                documents.add(Document.parse(line));
+            }
+        } catch (final IOException ioException) {
+            throw new IllegalStateException("failed to read ndjson file: " + file, ioException);
+        }
+        return List.copyOf(documents);
+    }
+
+    private static int writePortable(
+            final Map<String, List<Document>> collections,
+            final Path portablePath) throws IOException {
+        int totalDocuments = 0;
+        try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(
+                new GZIPOutputStream(Files.newOutputStream(portablePath)),
+                StandardCharsets.UTF_8))) {
+            final List<String> namespaces = new ArrayList<>(collections.keySet());
+            namespaces.sort(String::compareTo);
+            for (final String namespace : namespaces) {
+                for (final Document document : collections.getOrDefault(namespace, List.of())) {
+                    final Map<String, Object> envelope = new LinkedHashMap<>();
+                    envelope.put("ns", namespace);
+                    envelope.put("doc", canonicalizeValue(document));
+                    writer.write(DiffSummaryGenerator.JsonEncoder.encode(envelope));
+                    writer.newLine();
+                    totalDocuments++;
+                }
+            }
+        }
+        return totalDocuments;
+    }
+
+    private static void writeFast(
+            final Map<String, List<Document>> collections,
+            final Path fastPath) throws IOException {
+        try (DataOutputStream out = new DataOutputStream(new BufferedOutputStream(Files.newOutputStream(fastPath)))) {
+            out.writeInt(FAST_MAGIC);
+            out.writeInt(FAST_LAYOUT_VERSION);
+
+            final List<String> namespaces = new ArrayList<>(collections.keySet());
+            namespaces.sort(String::compareTo);
+            out.writeInt(namespaces.size());
+            for (final String namespace : namespaces) {
+                out.writeUTF(namespace);
+                final List<Document> documents = collections.getOrDefault(namespace, List.of());
+                out.writeInt(documents.size());
+                for (final Document document : documents) {
+                    final String canonicalJson = DiffSummaryGenerator.JsonEncoder.encode(canonicalizeValue(document));
+                    final byte[] bytes = canonicalJson.getBytes(StandardCharsets.UTF_8);
+                    out.writeInt(bytes.length);
+                    out.write(bytes);
+                }
+            }
+        }
+    }
+
+    private static Map<String, List<Document>> readPortable(final Path portablePath) throws IOException {
+        final Map<String, List<Document>> mutable = new LinkedHashMap<>();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(
+                new GZIPInputStream(Files.newInputStream(portablePath)),
+                StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.isBlank()) {
+                    continue;
+                }
+                final Document envelope = Document.parse(line);
+                final String namespace = envelope.getString("ns");
+                if (namespace == null || namespace.isBlank()) {
+                    throw new IllegalArgumentException("portable entry missing 'ns' field");
+                }
+                final Object docRaw = envelope.get("doc");
+                if (!(docRaw instanceof Document document)) {
+                    throw new IllegalArgumentException("portable entry missing 'doc' object for namespace=" + namespace);
+                }
+                mutable.computeIfAbsent(namespace, key -> new ArrayList<>()).add(document);
+            }
+        }
+        return immutableCopy(mutable);
+    }
+
+    private static Map<String, List<Document>> readFast(final Path fastPath) throws IOException {
+        try (DataInputStream in = new DataInputStream(new BufferedInputStream(Files.newInputStream(fastPath)))) {
+            final int magic = in.readInt();
+            if (magic != FAST_MAGIC) {
+                throw new IllegalArgumentException("invalid fast snapshot magic");
+            }
+            final int layoutVersion = in.readInt();
+            if (layoutVersion != FAST_LAYOUT_VERSION) {
+                throw new IllegalArgumentException("unsupported fast snapshot layout version: " + layoutVersion);
+            }
+
+            final int namespaceCount = in.readInt();
+            final Map<String, List<Document>> mutable = new LinkedHashMap<>();
+            for (int i = 0; i < namespaceCount; i++) {
+                final String namespace = in.readUTF();
+                final int documentCount = in.readInt();
+                final List<Document> docs = new ArrayList<>(documentCount);
+                for (int j = 0; j < documentCount; j++) {
+                    final int payloadLength = in.readInt();
+                    if (payloadLength < 0) {
+                        throw new IllegalArgumentException("invalid fast snapshot payload length: " + payloadLength);
+                    }
+                    final byte[] payload = in.readNBytes(payloadLength);
+                    if (payload.length != payloadLength) {
+                        throw new IllegalArgumentException("unexpected EOF while reading fast snapshot payload");
+                    }
+                    final String json = new String(payload, StandardCharsets.UTF_8);
+                    docs.add(Document.parse(json));
+                }
+                mutable.put(namespace, List.copyOf(docs));
+            }
+            return Map.copyOf(mutable);
+        }
+    }
+
+    private static Document manifestDocument(
+            final Map<String, List<Document>> collections,
+            final int totalDocuments,
+            final String engineVersion,
+            final String portableSha,
+            final String fastSha) {
+        final Document root = new Document();
+        root.put("schemaVersion", SCHEMA_VERSION);
+        root.put("portableFormatVersion", PORTABLE_FORMAT_VERSION);
+        root.put("fastFormatVersion", FAST_FORMAT_VERSION);
+        root.put("engineVersion", engineVersion);
+        root.put("createdAt", Instant.now().toString());
+
+        root.put(
+                "portable",
+                new Document("file", PORTABLE_FILE)
+                        .append("sha256", portableSha)
+                        .append("documents", totalDocuments));
+        root.put(
+                "fast",
+                new Document("file", FAST_FILE)
+                        .append("sha256", fastSha)
+                        .append("documents", totalDocuments));
+
+        final List<Document> collectionSummaries = new ArrayList<>();
+        final List<String> namespaces = new ArrayList<>(collections.keySet());
+        namespaces.sort(String::compareTo);
+        for (final String namespace : namespaces) {
+            collectionSummaries.add(new Document("namespace", namespace)
+                    .append("documents", collections.getOrDefault(namespace, List.of()).size()));
+        }
+        root.put("collections", collectionSummaries);
+
+        root.put("totals", new Document("collections", collectionSummaries.size()).append("documents", totalDocuments));
+        return root;
+    }
+
+    private static void writeManifest(final Path manifestPath, final Document document) throws IOException {
+        Files.writeString(
+                manifestPath,
+                DiffSummaryGenerator.JsonEncoder.encode(canonicalizeValue(document)),
+                StandardCharsets.UTF_8);
+    }
+
+    private static ManifestEntry entryFrom(
+            final Document manifest,
+            final String key,
+            final String defaultFileName) {
+        final Object raw = manifest.get(key);
+        if (!(raw instanceof Document entry)) {
+            return new ManifestEntry(defaultFileName, "");
+        }
+
+        final String file = entry.getString("file") == null || entry.getString("file").isBlank()
+                ? defaultFileName
+                : entry.getString("file");
+        final String sha256 = entry.getString("sha256") == null ? "" : entry.getString("sha256");
+        return new ManifestEntry(file, sha256);
+    }
+
+    private static void verifyChecksum(
+            final Path file,
+            final String expectedSha256,
+            final String label) throws IOException {
+        if (expectedSha256 == null || expectedSha256.isBlank()) {
+            return;
+        }
+        final String actual = sha256Hex(file);
+        if (!expectedSha256.equals(actual)) {
+            throw new IllegalArgumentException(
+                    label + " checksum mismatch: expected=" + expectedSha256 + " actual=" + actual);
+        }
+    }
+
+    private static String sha256Hex(final Path file) throws IOException {
+        final MessageDigest digest = sha256();
+        try (InputStream in = Files.newInputStream(file)) {
+            final byte[] buffer = new byte[8192];
+            int read;
+            while ((read = in.read(buffer)) >= 0) {
+                if (read == 0) {
+                    continue;
+                }
+                digest.update(buffer, 0, read);
+            }
+        }
+        return toHex(digest.digest());
+    }
+
+    private static MessageDigest sha256() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (final NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256 unavailable", exception);
+        }
+    }
+
+    private static String toHex(final byte[] bytes) {
+        final StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (final byte item : bytes) {
+            sb.append(String.format(Locale.ROOT, "%02x", item));
+        }
+        return sb.toString();
+    }
+
+    private static int countDocuments(final Map<String, List<Document>> collections) {
+        int total = 0;
+        for (final List<Document> docs : collections.values()) {
+            total += docs.size();
+        }
+        return total;
+    }
+
+    private static Object canonicalizeValue(final Object value) {
+        if (value instanceof Document document) {
+            final Map<String, Object> sorted = new TreeMap<>();
+            for (final Map.Entry<String, Object> entry : document.entrySet()) {
+                sorted.put(entry.getKey(), canonicalizeValue(entry.getValue()));
+            }
+            final Map<String, Object> normalized = new LinkedHashMap<>();
+            for (final Map.Entry<String, Object> entry : sorted.entrySet()) {
+                normalized.put(entry.getKey(), entry.getValue());
+            }
+            return normalized;
+        }
+
+        if (value instanceof Map<?, ?> map) {
+            final Map<String, Object> sorted = new TreeMap<>();
+            for (final Map.Entry<?, ?> entry : map.entrySet()) {
+                final Object rawKey = entry.getKey();
+                if (!(rawKey instanceof String key)) {
+                    continue;
+                }
+                sorted.put(key, canonicalizeValue(entry.getValue()));
+            }
+            final Map<String, Object> normalized = new LinkedHashMap<>();
+            for (final Map.Entry<String, Object> entry : sorted.entrySet()) {
+                normalized.put(entry.getKey(), entry.getValue());
+            }
+            return normalized;
+        }
+
+        if (value instanceof List<?> list) {
+            final List<Object> normalized = new ArrayList<>(list.size());
+            for (final Object item : list) {
+                normalized.add(canonicalizeValue(item));
+            }
+            return normalized;
+        }
+
+        return value;
+    }
+
+    private static Map<String, List<Document>> immutableCopy(final Map<String, List<Document>> source) {
+        final Map<String, List<Document>> result = new LinkedHashMap<>();
+        for (final Map.Entry<String, List<Document>> entry : source.entrySet()) {
+            result.put(entry.getKey(), List.copyOf(entry.getValue()));
+        }
+        return Map.copyOf(result);
+    }
+
+    record WriteResult(
+            Path manifestPath,
+            Path portablePath,
+            Path fastPath,
+            int collections,
+            int documents,
+            String portableSha256,
+            String fastSha256,
+            String engineVersion) {}
+
+    record LoadResult(
+            SourceFormat sourceFormat,
+            Map<String, List<Document>> collections,
+            List<String> diagnostics) {}
+
+    record ManifestEntry(
+            String file,
+            String sha256) {}
+
+    enum SourceFormat {
+        FAST,
+        PORTABLE_FALLBACK,
+        NDJSON
+    }
+}

--- a/src/main/java/org/jongodb/testkit/FixtureArtifactTool.java
+++ b/src/main/java/org/jongodb/testkit/FixtureArtifactTool.java
@@ -1,0 +1,118 @@
+package org.jongodb.testkit;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * Packs fixture ndjson files into dual artifacts (portable + fast).
+ */
+public final class FixtureArtifactTool {
+    private FixtureArtifactTool() {}
+
+    public static void main(final String[] args) {
+        final int exitCode = run(args, System.out, System.err);
+        if (exitCode != 0) {
+            System.exit(exitCode);
+        }
+    }
+
+    static int run(final String[] args, final PrintStream out, final PrintStream err) {
+        Objects.requireNonNull(args, "args");
+        Objects.requireNonNull(out, "out");
+        Objects.requireNonNull(err, "err");
+
+        final Config config;
+        try {
+            config = Config.fromArgs(args);
+        } catch (final IllegalArgumentException exception) {
+            err.println(exception.getMessage());
+            printUsage(err);
+            return 2;
+        }
+
+        if (config.help()) {
+            printUsage(out);
+            return 0;
+        }
+
+        try {
+            final FixtureArtifactBundle.WriteResult result = FixtureArtifactBundle.writeBundleFromNdjson(
+                    config.inputDir(),
+                    config.outputDir(),
+                    config.engineVersion());
+            out.println("Fixture artifact pack finished");
+            out.println("- engineVersion: " + result.engineVersion());
+            out.println("- collections: " + result.collections());
+            out.println("- documents: " + result.documents());
+            out.println("- portable: " + result.portablePath());
+            out.println("- fast: " + result.fastPath());
+            out.println("- manifest: " + result.manifestPath());
+            return 0;
+        } catch (final IOException | RuntimeException exception) {
+            err.println("fixture artifact pack failed: " + exception.getMessage());
+            return 1;
+        }
+    }
+
+    private static void printUsage(final PrintStream stream) {
+        stream.println("Usage: FixtureArtifactTool --input-dir=<dir> --output-dir=<dir> [options]");
+        stream.println("  --input-dir=<dir>           Fixture ndjson directory");
+        stream.println("  --output-dir=<dir>          Output artifact directory");
+        stream.println("  --engine-version=<value>    Engine compatibility version (default: runtime version)");
+        stream.println("  --help                      Show usage");
+    }
+
+    private record Config(
+            Path inputDir,
+            Path outputDir,
+            String engineVersion,
+            boolean help) {
+        static Config fromArgs(final String[] args) {
+            Path inputDir = null;
+            Path outputDir = null;
+            String engineVersion = null;
+            boolean help = false;
+
+            for (final String arg : args) {
+                if ("--help".equals(arg) || "-h".equals(arg)) {
+                    help = true;
+                    continue;
+                }
+                if (arg.startsWith("--input-dir=")) {
+                    inputDir = Path.of(valueAfterPrefix(arg, "--input-dir="));
+                    continue;
+                }
+                if (arg.startsWith("--output-dir=")) {
+                    outputDir = Path.of(valueAfterPrefix(arg, "--output-dir="));
+                    continue;
+                }
+                if (arg.startsWith("--engine-version=")) {
+                    engineVersion = valueAfterPrefix(arg, "--engine-version=");
+                    continue;
+                }
+                throw new IllegalArgumentException("unknown argument: " + arg);
+            }
+
+            if (!help && inputDir == null) {
+                throw new IllegalArgumentException("--input-dir=<dir> is required");
+            }
+            if (!help && outputDir == null) {
+                throw new IllegalArgumentException("--output-dir=<dir> is required");
+            }
+            if (engineVersion == null || engineVersion.isBlank()) {
+                engineVersion = FixtureArtifactBundle.currentEngineVersion();
+            }
+            return new Config(inputDir, outputDir, engineVersion, help);
+        }
+
+        private static String valueAfterPrefix(final String arg, final String prefix) {
+            final String value = arg.substring(prefix.length()).trim();
+            if (value.isEmpty()) {
+                throw new IllegalArgumentException(prefix + " must have a value");
+            }
+            return value;
+        }
+    }
+}

--- a/src/test/java/org/jongodb/testkit/FixtureArtifactToolTest.java
+++ b/src/test/java/org/jongodb/testkit/FixtureArtifactToolTest.java
@@ -1,0 +1,61 @@
+package org.jongodb.testkit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class FixtureArtifactToolTest {
+    @Test
+    void packsPortableAndFastArtifactsWithManifest(@TempDir final Path tempDir) throws Exception {
+        final Path inputDir = tempDir.resolve("fixture-ndjson");
+        final Path outputDir = tempDir.resolve("artifact");
+        Files.createDirectories(inputDir);
+
+        Files.writeString(
+                inputDir.resolve("app.users.ndjson"),
+                "{\"_id\":1,\"name\":\"alpha\"}\n{\"_id\":2,\"name\":\"beta\"}\n",
+                StandardCharsets.UTF_8);
+        Files.writeString(
+                inputDir.resolve("app.orders.ndjson"),
+                "{\"_id\":101,\"amount\":10}\n",
+                StandardCharsets.UTF_8);
+
+        final int exitCode = FixtureArtifactTool.run(
+                new String[] {
+                    "--input-dir=" + inputDir,
+                    "--output-dir=" + outputDir,
+                    "--engine-version=test-engine-v1"
+                },
+                new PrintStream(new ByteArrayOutputStream()),
+                new PrintStream(new ByteArrayOutputStream()));
+
+        assertEquals(0, exitCode);
+        assertTrue(Files.exists(outputDir.resolve("fixture-artifact-manifest.json")));
+        assertTrue(Files.exists(outputDir.resolve("fixture-portable.ejsonl.gz")));
+        assertTrue(Files.exists(outputDir.resolve("fixture-fast-snapshot.bin")));
+
+        final Document manifest = Document.parse(Files.readString(
+                outputDir.resolve("fixture-artifact-manifest.json"),
+                StandardCharsets.UTF_8));
+        assertEquals("fixture-artifact.v1", manifest.getString("schemaVersion"));
+        assertEquals("test-engine-v1", manifest.getString("engineVersion"));
+        assertEquals("fast-snapshot.v1", manifest.getString("fastFormatVersion"));
+
+        final Document totals = manifest.get("totals", Document.class);
+        assertEquals(2, totals.getInteger("collections"));
+        assertEquals(3, totals.getInteger("documents"));
+
+        final Document portable = manifest.get("portable", Document.class);
+        final Document fast = manifest.get("fast", Document.class);
+        assertEquals(64, portable.getString("sha256").length());
+        assertEquals(64, fast.getString("sha256").length());
+    }
+}


### PR DESCRIPTION
## Summary
- add `FixtureArtifactTool` + `fixtureArtifactPack` task to generate dual artifacts (`portable` gzip ejsonl + `fast` snapshot)
- add checksum-backed artifact manifest with format/engine compatibility metadata
- extend `FixtureRestoreTool` to prefer fast artifact, fallback to portable on mismatch, and regenerate fast cache
- add tests for artifact packing, fast restore path, and portable fallback path
- document dual artifact workflow and restore behavior

## Validation
- `.tooling/gradle-8.10.2/bin/gradle test --tests org.jongodb.testkit.FixtureArtifactToolTest --tests org.jongodb.testkit.FixtureRestoreToolTest --tests org.jongodb.testkit.FixtureSanitizationToolTest --tests org.jongodb.testkit.FixtureExtractionToolTest`

Closes #252
