### PR TITLE
feat(fixture): add refresh workflow and approval gate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Fixture refresh ownership
+/testkit/fixture/ @hckim

--- a/.github/workflows/fixture-refresh-approval-gate.yml
+++ b/.github/workflows/fixture-refresh-approval-gate.yml
@@ -1,0 +1,54 @@
+name: Fixture Refresh Approval Gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  approval-gate:
+    name: fixture-refresh-approval-gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate fixture refresh approval label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pullRequest = context.payload.pull_request;
+            if (!pullRequest) {
+              core.setFailed('pull_request context is required');
+              return;
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullRequest.number,
+              per_page: 100
+            });
+
+            const touchesRefreshArtifacts = files.some((file) => {
+              const fixturePath = file.filename.startsWith('testkit/fixture/');
+              const refreshPayload = file.filename.endsWith('.ndjson')
+                || file.filename.includes('/artifacts/')
+                || file.filename.includes('/refreshed/');
+              return fixturePath && refreshPayload;
+            });
+
+            if (!touchesRefreshArtifacts) {
+              core.info('No fixture refresh artifact changes detected; gate passed.');
+              return;
+            }
+
+            const labels = (pullRequest.labels || []).map((label) => label.name);
+            const approved = labels.includes('fixture-refresh-approved');
+
+            if (!approved) {
+              core.setFailed('Fixture refresh artifact changes detected. Add label "fixture-refresh-approved" to proceed.');
+              return;
+            }
+
+            core.info('Approval label detected: fixture-refresh-approved');

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -419,6 +419,45 @@ tasks.register<JavaExec>("fixtureArtifactPack") {
     }
 }
 
+tasks.register<JavaExec>("fixtureRefresh") {
+    group = "verification"
+    description = "Runs full/incremental fixture refresh and writes diff report + refreshed ndjson output."
+    classpath = sourceSets["main"].runtimeClasspath
+    mainClass.set("org.jongodb.testkit.FixtureRefreshTool")
+
+    val baselineDir = (findProperty("fixtureRefreshBaselineDir") as String?)?.trim().orEmpty()
+    val candidateDir = (findProperty("fixtureRefreshCandidateDir") as String?)?.trim().orEmpty()
+    val outputDir = (findProperty("fixtureRefreshOutputDir") as String?)?.trim().orEmpty()
+    val mode = (findProperty("fixtureRefreshMode") as String?)?.trim().orEmpty().ifBlank { "full" }
+    val requireApproval = (findProperty("fixtureRefreshRequireApproval") as String?)?.toBoolean() ?: false
+    val approved = (findProperty("fixtureRefreshApproved") as String?)?.toBoolean() ?: false
+
+    doFirst {
+        if (baselineDir.isBlank()) {
+            throw GradleException("fixtureRefreshBaselineDir property is required")
+        }
+        if (candidateDir.isBlank()) {
+            throw GradleException("fixtureRefreshCandidateDir property is required")
+        }
+        if (outputDir.isBlank()) {
+            throw GradleException("fixtureRefreshOutputDir property is required")
+        }
+    }
+
+    args(
+        "--baseline-dir=$baselineDir",
+        "--candidate-dir=$candidateDir",
+        "--output-dir=$outputDir",
+        "--mode=$mode"
+    )
+    if (requireApproval) {
+        args("--require-approval")
+    }
+    if (approved) {
+        args("--approved")
+    }
+}
+
 tasks.register<JavaExec>("fixtureRestore") {
     group = "verification"
     description = "Restores fixture ndjson into target MongoDB using replace/merge mode with diagnostics report."

--- a/docs/FIXTURE_REFRESH.md
+++ b/docs/FIXTURE_REFRESH.md
@@ -1,0 +1,44 @@
+# Fixture Refresh Workflow
+
+`#254` 구현 가이드입니다.
+
+## 목적
+- fixture 갱신을 `full` / `incremental` 모드로 표준화합니다.
+- 실행마다 diff 리포트(JSON+Markdown)를 자동 생성합니다.
+- breaking refresh(삭제/필드 드롭)는 승인 없이 통과하지 않도록 게이트를 제공합니다.
+
+## 실행
+
+```bash
+.tooling/gradle-8.10.2/bin/gradle fixtureRefresh \
+  -PfixtureRefreshBaselineDir=build/reports/fixture-prev \
+  -PfixtureRefreshCandidateDir=build/reports/fixture-sanitized \
+  -PfixtureRefreshOutputDir=build/reports/fixture-refresh \
+  -PfixtureRefreshMode=incremental \
+  -PfixtureRefreshRequireApproval=true
+```
+
+승인된 실행:
+
+```bash
+.tooling/gradle-8.10.2/bin/gradle fixtureRefresh \
+  -PfixtureRefreshBaselineDir=build/reports/fixture-prev \
+  -PfixtureRefreshCandidateDir=build/reports/fixture-sanitized \
+  -PfixtureRefreshOutputDir=build/reports/fixture-refresh \
+  -PfixtureRefreshMode=full \
+  -PfixtureRefreshRequireApproval=true \
+  -PfixtureRefreshApproved=true
+```
+
+## 산출물
+- `<outputDir>/refreshed/*.ndjson`
+  - `full`: candidate 전체 결과
+  - `incremental`: 추가/변경 문서만 출력
+- `<outputDir>/fixture-refresh-report.json`
+- `<outputDir>/fixture-refresh-report.md`
+
+리포트에는 컬렉션별 `added/removed/changed`와 `risk(breaking|non-breaking)`가 포함됩니다.
+
+## 승인 게이트
+- `--require-approval` 사용 시 breaking change가 발견되면 `--approved` 없이 실패합니다.
+- CI에서는 PR 라벨 `fixture-refresh-approved`를 기준으로 승인 여부를 연결할 수 있습니다.

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@ Fixture workflows:
 - `docs/FIXTURE_EXTRACTION.md`
 - `docs/FIXTURE_SANITIZATION.md`
 - `docs/FIXTURE_ARTIFACTS.md`
+- `docs/FIXTURE_REFRESH.md`
 - `docs/FIXTURE_RESTORE.md`
 
 Research and design notes:

--- a/src/main/java/org/jongodb/testkit/FixtureRefreshTool.java
+++ b/src/main/java/org/jongodb/testkit/FixtureRefreshTool.java
@@ -1,0 +1,586 @@
+package org.jongodb.testkit;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.bson.Document;
+
+/**
+ * Standardized fixture refresh workflow runner (full/incremental) with diff report and approval gate.
+ */
+public final class FixtureRefreshTool {
+    private static final Pattern NDJSON_FILE = Pattern.compile("^([^.]+)\\.([^.]+)\\.ndjson$");
+    private static final String REFRESH_OUTPUT_DIR = "refreshed";
+    private static final String REPORT_JSON = "fixture-refresh-report.json";
+    private static final String REPORT_MD = "fixture-refresh-report.md";
+
+    private FixtureRefreshTool() {}
+
+    public static void main(final String[] args) {
+        final int exitCode = run(args, System.out, System.err);
+        if (exitCode != 0) {
+            System.exit(exitCode);
+        }
+    }
+
+    static int run(final String[] args, final PrintStream out, final PrintStream err) {
+        Objects.requireNonNull(args, "args");
+        Objects.requireNonNull(out, "out");
+        Objects.requireNonNull(err, "err");
+
+        final Config config;
+        try {
+            config = Config.fromArgs(args);
+        } catch (final IllegalArgumentException exception) {
+            err.println(exception.getMessage());
+            printUsage(err);
+            return 2;
+        }
+
+        if (config.help()) {
+            printUsage(out);
+            return 0;
+        }
+
+        try {
+            final Instant startedAt = Instant.now();
+            final Map<String, List<Document>> baseline = loadCollections(config.baselineDir());
+            final Map<String, List<Document>> candidate = loadCollections(config.candidateDir());
+
+            Files.createDirectories(config.outputDir());
+            final Path refreshOutputDir = config.outputDir().resolve(REFRESH_OUTPUT_DIR);
+            Files.createDirectories(refreshOutputDir);
+
+            final List<CollectionDiff> diffs = computeDiffs(baseline, candidate, config.mode(), refreshOutputDir);
+            final boolean requiresApproval = diffs.stream().anyMatch(CollectionDiff::requiresApproval);
+
+            final Instant finishedAt = Instant.now();
+            final RefreshReport report = RefreshReport.from(
+                    startedAt,
+                    finishedAt,
+                    config.mode(),
+                    baseline,
+                    candidate,
+                    diffs,
+                    requiresApproval,
+                    config.approved());
+
+            Files.writeString(config.outputDir().resolve(REPORT_JSON), report.toJson(), StandardCharsets.UTF_8);
+            Files.writeString(config.outputDir().resolve(REPORT_MD), report.toMarkdown(), StandardCharsets.UTF_8);
+
+            out.println("Fixture refresh finished");
+            out.println("- mode: " + config.mode().value());
+            out.println("- baselineCollections: " + baseline.size());
+            out.println("- candidateCollections: " + candidate.size());
+            out.println("- changedCollections: " + diffs.stream().filter(CollectionDiff::isChanged).count());
+            out.println("- requiresApproval: " + requiresApproval);
+            out.println("- outputDir: " + refreshOutputDir);
+            out.println("- reportJson: " + config.outputDir().resolve(REPORT_JSON));
+            out.println("- reportMd: " + config.outputDir().resolve(REPORT_MD));
+
+            if (config.requireApproval() && requiresApproval && !config.approved()) {
+                err.println("refresh includes breaking changes; rerun with --approved to acknowledge");
+                return 1;
+            }
+            return 0;
+        } catch (final IOException | RuntimeException exception) {
+            err.println("fixture refresh failed: " + exception.getMessage());
+            return 1;
+        }
+    }
+
+    private static List<CollectionDiff> computeDiffs(
+            final Map<String, List<Document>> baseline,
+            final Map<String, List<Document>> candidate,
+            final RefreshMode mode,
+            final Path outputDir) throws IOException {
+        final Set<String> union = new LinkedHashSet<>();
+        union.addAll(baseline.keySet());
+        union.addAll(candidate.keySet());
+
+        final List<String> namespaces = new ArrayList<>(union);
+        namespaces.sort(String::compareTo);
+
+        final List<CollectionDiff> result = new ArrayList<>(namespaces.size());
+        for (final String namespace : namespaces) {
+            final List<Document> baselineDocs = baseline.getOrDefault(namespace, List.of());
+            final List<Document> candidateDocs = candidate.getOrDefault(namespace, List.of());
+
+            final Map<String, Document> baselineIndex = indexDocuments(baselineDocs);
+            final Map<String, Document> candidateIndex = indexDocuments(candidateDocs);
+
+            final Set<String> keys = new LinkedHashSet<>();
+            keys.addAll(baselineIndex.keySet());
+            keys.addAll(candidateIndex.keySet());
+            final List<String> orderedKeys = new ArrayList<>(keys);
+            orderedKeys.sort(String::compareTo);
+
+            int added = 0;
+            int removed = 0;
+            int changed = 0;
+            int unchanged = 0;
+            boolean hasSchemaBreak = false;
+
+            final List<Document> incrementalDocs = new ArrayList<>();
+            for (final String key : orderedKeys) {
+                final Document before = baselineIndex.get(key);
+                final Document after = candidateIndex.get(key);
+                if (before == null && after != null) {
+                    added++;
+                    incrementalDocs.add(after);
+                    continue;
+                }
+                if (before != null && after == null) {
+                    removed++;
+                    continue;
+                }
+                if (before == null) {
+                    continue;
+                }
+
+                final String beforeCanonical = canonicalJson(before);
+                final String afterCanonical = canonicalJson(after);
+                if (beforeCanonical.equals(afterCanonical)) {
+                    unchanged++;
+                    continue;
+                }
+                changed++;
+                incrementalDocs.add(after);
+                if (hasFieldDrop(before, after)) {
+                    hasSchemaBreak = true;
+                }
+            }
+
+            final List<String> approvalReasons = new ArrayList<>();
+            if (removed > 0) {
+                approvalReasons.add("removed=" + removed);
+            }
+            if (hasSchemaBreak) {
+                approvalReasons.add("field-drop");
+            }
+            final boolean requiresApproval = !approvalReasons.isEmpty();
+
+            final List<Document> outputDocuments;
+            if (mode == RefreshMode.FULL) {
+                outputDocuments = sortForOutput(candidateIndex);
+            } else {
+                outputDocuments = sortDocuments(incrementalDocs);
+            }
+
+            final Path outputFile = outputDir.resolve(namespace + ".ndjson");
+            if (!outputDocuments.isEmpty()) {
+                writeNdjson(outputFile, outputDocuments);
+            } else {
+                Files.deleteIfExists(outputFile);
+            }
+
+            result.add(new CollectionDiff(
+                    namespace,
+                    baselineDocs.size(),
+                    candidateDocs.size(),
+                    added,
+                    removed,
+                    changed,
+                    unchanged,
+                    outputDocuments.size(),
+                    requiresApproval,
+                    List.copyOf(approvalReasons),
+                    outputFile.toString()));
+        }
+        return List.copyOf(result);
+    }
+
+    private static List<Document> sortForOutput(final Map<String, Document> indexed) {
+        final List<String> keys = new ArrayList<>(indexed.keySet());
+        keys.sort(String::compareTo);
+        final List<Document> docs = new ArrayList<>(keys.size());
+        for (final String key : keys) {
+            docs.add(indexed.get(key));
+        }
+        return List.copyOf(docs);
+    }
+
+    private static List<Document> sortDocuments(final List<Document> docs) {
+        final List<Document> sorted = new ArrayList<>(docs);
+        sorted.sort(Comparator.comparing(FixtureRefreshTool::documentKey));
+        return List.copyOf(sorted);
+    }
+
+    private static void writeNdjson(final Path file, final List<Document> documents) throws IOException {
+        final List<String> lines = new ArrayList<>(documents.size());
+        for (final Document document : documents) {
+            lines.add(canonicalJson(document));
+        }
+        final String content = lines.isEmpty() ? "" : String.join("\n", lines) + "\n";
+        Files.writeString(file, content, StandardCharsets.UTF_8);
+    }
+
+    private static Map<String, Document> indexDocuments(final List<Document> docs) {
+        final Map<String, Document> index = new LinkedHashMap<>();
+        for (final Document document : docs) {
+            index.put(documentKey(document), document);
+        }
+        return Map.copyOf(index);
+    }
+
+    private static boolean hasFieldDrop(final Document before, final Document after) {
+        final Set<String> beforeKeys = new LinkedHashSet<>(before.keySet());
+        final Set<String> afterKeys = new LinkedHashSet<>(after.keySet());
+        beforeKeys.removeAll(afterKeys);
+        return !beforeKeys.isEmpty();
+    }
+
+    private static String documentKey(final Document document) {
+        if (document.containsKey("_id")) {
+            return "_id:" + DiffSummaryGenerator.JsonEncoder.encode(canonicalizeValue(document.get("_id")));
+        }
+        return "hash:" + sha256(canonicalJson(document));
+    }
+
+    private static String canonicalJson(final Document document) {
+        return DiffSummaryGenerator.JsonEncoder.encode(canonicalizeValue(document));
+    }
+
+    private static String sha256(final String text) {
+        final MessageDigest digest;
+        try {
+            digest = MessageDigest.getInstance("SHA-256");
+        } catch (final NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256 unavailable", exception);
+        }
+        digest.update(text.getBytes(StandardCharsets.UTF_8));
+        final byte[] bytes = digest.digest();
+        final StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (final byte item : bytes) {
+            sb.append(String.format(Locale.ROOT, "%02x", item));
+        }
+        return sb.toString();
+    }
+
+    private static Object canonicalizeValue(final Object value) {
+        if (value instanceof Document document) {
+            final Map<String, Object> sorted = new TreeMap<>();
+            for (final Map.Entry<String, Object> entry : document.entrySet()) {
+                sorted.put(entry.getKey(), canonicalizeValue(entry.getValue()));
+            }
+            final Map<String, Object> normalized = new LinkedHashMap<>();
+            for (final Map.Entry<String, Object> entry : sorted.entrySet()) {
+                normalized.put(entry.getKey(), entry.getValue());
+            }
+            return normalized;
+        }
+        if (value instanceof Map<?, ?> map) {
+            final Map<String, Object> sorted = new TreeMap<>();
+            for (final Map.Entry<?, ?> entry : map.entrySet()) {
+                if (entry.getKey() instanceof String key) {
+                    sorted.put(key, canonicalizeValue(entry.getValue()));
+                }
+            }
+            final Map<String, Object> normalized = new LinkedHashMap<>();
+            for (final Map.Entry<String, Object> entry : sorted.entrySet()) {
+                normalized.put(entry.getKey(), entry.getValue());
+            }
+            return normalized;
+        }
+        if (value instanceof List<?> list) {
+            final List<Object> normalized = new ArrayList<>(list.size());
+            for (final Object item : list) {
+                normalized.add(canonicalizeValue(item));
+            }
+            return normalized;
+        }
+        return value;
+    }
+
+    private static Map<String, List<Document>> loadCollections(final Path inputDir) throws IOException {
+        if (!Files.exists(inputDir) || !Files.isDirectory(inputDir)) {
+            throw new IllegalArgumentException("input dir is missing: " + inputDir);
+        }
+
+        final Map<String, List<Document>> result = new LinkedHashMap<>();
+        try (var stream = Files.list(inputDir)) {
+            stream.filter(path -> Files.isRegularFile(path) && path.getFileName().toString().endsWith(".ndjson"))
+                    .sorted(Comparator.comparing(path -> path.getFileName().toString()))
+                    .forEach(path -> {
+                        final Matcher matcher = NDJSON_FILE.matcher(path.getFileName().toString());
+                        if (!matcher.matches()) {
+                            return;
+                        }
+                        final String namespace = matcher.group(1) + "." + matcher.group(2);
+                        final List<Document> docs = readNdjson(path);
+                        result.put(namespace, docs);
+                    });
+        }
+        return Map.copyOf(result);
+    }
+
+    private static List<Document> readNdjson(final Path file) {
+        final List<Document> docs = new ArrayList<>();
+        final List<String> lines;
+        try {
+            lines = Files.readAllLines(file, StandardCharsets.UTF_8);
+        } catch (final IOException exception) {
+            throw new IllegalStateException("failed to read ndjson: " + file, exception);
+        }
+        for (final String line : lines) {
+            if (line == null || line.isBlank()) {
+                continue;
+            }
+            docs.add(Document.parse(line));
+        }
+        return List.copyOf(docs);
+    }
+
+    private static void printUsage(final PrintStream stream) {
+        stream.println("Usage: FixtureRefreshTool --baseline-dir=<dir> --candidate-dir=<dir> --output-dir=<dir> [options]");
+        stream.println("  --baseline-dir=<dir>         Previous fixture ndjson directory");
+        stream.println("  --candidate-dir=<dir>        Newly extracted/sanitized ndjson directory");
+        stream.println("  --output-dir=<dir>           Output directory for refreshed artifacts + reports");
+        stream.println("  --mode=full|incremental      Refresh mode (default: full)");
+        stream.println("  --require-approval           Fail when breaking changes exist without --approved");
+        stream.println("  --approved                   Acknowledge and approve breaking refresh result");
+        stream.println("  --help                       Show usage");
+    }
+
+    private record Config(
+            Path baselineDir,
+            Path candidateDir,
+            Path outputDir,
+            RefreshMode mode,
+            boolean requireApproval,
+            boolean approved,
+            boolean help) {
+        static Config fromArgs(final String[] args) {
+            Path baselineDir = null;
+            Path candidateDir = null;
+            Path outputDir = null;
+            RefreshMode mode = RefreshMode.FULL;
+            boolean requireApproval = false;
+            boolean approved = false;
+            boolean help = false;
+
+            for (final String arg : args) {
+                if ("--help".equals(arg) || "-h".equals(arg)) {
+                    help = true;
+                    continue;
+                }
+                if (arg.startsWith("--baseline-dir=")) {
+                    baselineDir = Path.of(valueAfterPrefix(arg, "--baseline-dir="));
+                    continue;
+                }
+                if (arg.startsWith("--candidate-dir=")) {
+                    candidateDir = Path.of(valueAfterPrefix(arg, "--candidate-dir="));
+                    continue;
+                }
+                if (arg.startsWith("--output-dir=")) {
+                    outputDir = Path.of(valueAfterPrefix(arg, "--output-dir="));
+                    continue;
+                }
+                if (arg.startsWith("--mode=")) {
+                    mode = RefreshMode.fromText(valueAfterPrefix(arg, "--mode="));
+                    continue;
+                }
+                if ("--require-approval".equals(arg)) {
+                    requireApproval = true;
+                    continue;
+                }
+                if ("--approved".equals(arg)) {
+                    approved = true;
+                    continue;
+                }
+                throw new IllegalArgumentException("unknown argument: " + arg);
+            }
+
+            if (!help && baselineDir == null) {
+                throw new IllegalArgumentException("--baseline-dir=<dir> is required");
+            }
+            if (!help && candidateDir == null) {
+                throw new IllegalArgumentException("--candidate-dir=<dir> is required");
+            }
+            if (!help && outputDir == null) {
+                throw new IllegalArgumentException("--output-dir=<dir> is required");
+            }
+
+            return new Config(
+                    baselineDir,
+                    candidateDir,
+                    outputDir,
+                    mode,
+                    requireApproval,
+                    approved,
+                    help);
+        }
+
+        private static String valueAfterPrefix(final String arg, final String prefix) {
+            final String value = arg.substring(prefix.length()).trim();
+            if (value.isEmpty()) {
+                throw new IllegalArgumentException(prefix + " must have a value");
+            }
+            return value;
+        }
+    }
+
+    enum RefreshMode {
+        FULL("full"),
+        INCREMENTAL("incremental");
+
+        private final String value;
+
+        RefreshMode(final String value) {
+            this.value = value;
+        }
+
+        String value() {
+            return value;
+        }
+
+        static RefreshMode fromText(final String rawValue) {
+            final String value = rawValue.trim().toLowerCase(Locale.ROOT);
+            for (final RefreshMode mode : values()) {
+                if (mode.value.equals(value)) {
+                    return mode;
+                }
+            }
+            throw new IllegalArgumentException("mode must be full|incremental");
+        }
+    }
+
+    private record CollectionDiff(
+            String namespace,
+            int baselineCount,
+            int candidateCount,
+            int added,
+            int removed,
+            int changed,
+            int unchanged,
+            int outputDocuments,
+            boolean requiresApproval,
+            List<String> approvalReasons,
+            String outputFile) {
+        boolean isChanged() {
+            return added > 0 || removed > 0 || changed > 0;
+        }
+
+        Map<String, Object> toMap() {
+            final Map<String, Object> root = new LinkedHashMap<>();
+            root.put("namespace", namespace);
+            root.put("baselineCount", baselineCount);
+            root.put("candidateCount", candidateCount);
+            root.put("added", added);
+            root.put("removed", removed);
+            root.put("changed", changed);
+            root.put("unchanged", unchanged);
+            root.put("outputDocuments", outputDocuments);
+            root.put("risk", requiresApproval ? "breaking" : "non-breaking");
+            root.put("approvalReasons", approvalReasons);
+            root.put("outputFile", outputFile);
+            return root;
+        }
+    }
+
+    private record RefreshReport(
+            String startedAt,
+            String finishedAt,
+            String mode,
+            int baselineCollections,
+            int candidateCollections,
+            int changedCollections,
+            boolean requiresApproval,
+            boolean approved,
+            List<CollectionDiff> collections) {
+        static RefreshReport from(
+                final Instant startedAt,
+                final Instant finishedAt,
+                final RefreshMode mode,
+                final Map<String, List<Document>> baseline,
+                final Map<String, List<Document>> candidate,
+                final List<CollectionDiff> collections,
+                final boolean requiresApproval,
+                final boolean approved) {
+            final int changedCollections = (int) collections.stream().filter(CollectionDiff::isChanged).count();
+            return new RefreshReport(
+                    startedAt.toString(),
+                    finishedAt.toString(),
+                    mode.value(),
+                    baseline.size(),
+                    candidate.size(),
+                    changedCollections,
+                    requiresApproval,
+                    approved,
+                    collections);
+        }
+
+        String toJson() {
+            final Map<String, Object> root = new LinkedHashMap<>();
+            root.put("startedAt", startedAt);
+            root.put("finishedAt", finishedAt);
+            root.put("mode", mode);
+            root.put("baselineCollections", baselineCollections);
+            root.put("candidateCollections", candidateCollections);
+            root.put("changedCollections", changedCollections);
+            root.put("requiresApproval", requiresApproval);
+            root.put("approved", approved);
+            final List<Map<String, Object>> items = new ArrayList<>(collections.size());
+            for (final CollectionDiff collection : collections) {
+                items.add(collection.toMap());
+            }
+            root.put("collections", items);
+            return DiffSummaryGenerator.JsonEncoder.encode(root);
+        }
+
+        String toMarkdown() {
+            final StringBuilder sb = new StringBuilder();
+            sb.append("# Fixture Refresh Report\n\n");
+            sb.append("- mode: ").append(mode).append("\n");
+            sb.append("- baselineCollections: ").append(baselineCollections).append("\n");
+            sb.append("- candidateCollections: ").append(candidateCollections).append("\n");
+            sb.append("- changedCollections: ").append(changedCollections).append("\n");
+            sb.append("- requiresApproval: ").append(requiresApproval).append("\n");
+            sb.append("- approved: ").append(approved).append("\n\n");
+
+            sb.append("| namespace | baseline | candidate | added | removed | changed | risk | outputDocs |\n");
+            sb.append("|---|---:|---:|---:|---:|---:|---|---:|\n");
+            for (final CollectionDiff collection : collections) {
+                sb.append("| ").append(collection.namespace())
+                        .append(" | ").append(collection.baselineCount())
+                        .append(" | ").append(collection.candidateCount())
+                        .append(" | ").append(collection.added())
+                        .append(" | ").append(collection.removed())
+                        .append(" | ").append(collection.changed())
+                        .append(" | ").append(collection.requiresApproval() ? "breaking" : "non-breaking")
+                        .append(" | ").append(collection.outputDocuments())
+                        .append(" |\n");
+            }
+
+            final List<CollectionDiff> breaking = collections.stream()
+                    .filter(CollectionDiff::requiresApproval)
+                    .toList();
+            if (!breaking.isEmpty()) {
+                sb.append("\n## Approval Required\n");
+                for (final CollectionDiff diff : breaking) {
+                    sb.append("- ").append(diff.namespace())
+                            .append(": ").append(String.join(", ", diff.approvalReasons()))
+                            .append("\n");
+                }
+            }
+            return sb.toString();
+        }
+    }
+}

--- a/src/test/java/org/jongodb/testkit/FixtureRefreshToolTest.java
+++ b/src/test/java/org/jongodb/testkit/FixtureRefreshToolTest.java
@@ -1,0 +1,157 @@
+package org.jongodb.testkit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class FixtureRefreshToolTest {
+    @Test
+    void fullRefreshWritesCandidateSnapshotAndReport(@TempDir final Path tempDir) throws Exception {
+        final Path baselineDir = tempDir.resolve("baseline");
+        final Path candidateDir = tempDir.resolve("candidate");
+        final Path outputDir = tempDir.resolve("out");
+        Files.createDirectories(baselineDir);
+        Files.createDirectories(candidateDir);
+
+        Files.writeString(
+                baselineDir.resolve("app.users.ndjson"),
+                """
+                {"_id":1,"name":"alpha"}
+                {"_id":2,"name":"beta"}
+                """,
+                StandardCharsets.UTF_8);
+        Files.writeString(
+                candidateDir.resolve("app.users.ndjson"),
+                """
+                {"_id":1,"name":"alpha"}
+                {"_id":2,"name":"beta-updated"}
+                {"_id":3,"name":"gamma"}
+                """,
+                StandardCharsets.UTF_8);
+
+        final int exitCode = FixtureRefreshTool.run(
+                new String[] {
+                    "--baseline-dir=" + baselineDir,
+                    "--candidate-dir=" + candidateDir,
+                    "--output-dir=" + outputDir,
+                    "--mode=full"
+                },
+                new PrintStream(new ByteArrayOutputStream()),
+                new PrintStream(new ByteArrayOutputStream()));
+
+        assertEquals(0, exitCode);
+
+        final Path refreshed = outputDir.resolve("refreshed/app.users.ndjson");
+        assertTrue(Files.exists(refreshed));
+        assertEquals(3, Files.readAllLines(refreshed).size());
+
+        final Document report = Document.parse(Files.readString(
+                outputDir.resolve("fixture-refresh-report.json"),
+                StandardCharsets.UTF_8));
+        assertEquals("full", report.getString("mode"));
+        assertEquals(1, report.getInteger("changedCollections"));
+        assertEquals(false, report.getBoolean("requiresApproval"));
+    }
+
+    @Test
+    void incrementalRefreshWritesOnlyDeltaDocuments(@TempDir final Path tempDir) throws Exception {
+        final Path baselineDir = tempDir.resolve("baseline");
+        final Path candidateDir = tempDir.resolve("candidate");
+        final Path outputDir = tempDir.resolve("out");
+        Files.createDirectories(baselineDir);
+        Files.createDirectories(candidateDir);
+
+        Files.writeString(
+                baselineDir.resolve("app.users.ndjson"),
+                """
+                {"_id":1,"name":"same"}
+                {"_id":2,"name":"before"}
+                """,
+                StandardCharsets.UTF_8);
+        Files.writeString(
+                candidateDir.resolve("app.users.ndjson"),
+                """
+                {"_id":1,"name":"same"}
+                {"_id":2,"name":"after"}
+                {"_id":3,"name":"new"}
+                """,
+                StandardCharsets.UTF_8);
+
+        final int exitCode = FixtureRefreshTool.run(
+                new String[] {
+                    "--baseline-dir=" + baselineDir,
+                    "--candidate-dir=" + candidateDir,
+                    "--output-dir=" + outputDir,
+                    "--mode=incremental"
+                },
+                new PrintStream(new ByteArrayOutputStream()),
+                new PrintStream(new ByteArrayOutputStream()));
+
+        assertEquals(0, exitCode);
+
+        final List<String> lines = Files.readAllLines(outputDir.resolve("refreshed/app.users.ndjson"));
+        assertEquals(2, lines.size());
+        final String merged = String.join("\n", lines);
+        assertTrue(merged.contains("\"_id\":2"));
+        assertTrue(merged.contains("\"_id\":3"));
+        assertTrue(!merged.contains("\"_id\":1"));
+    }
+
+    @Test
+    void requiresApprovalWhenBreakingChangeDetected(@TempDir final Path tempDir) throws Exception {
+        final Path baselineDir = tempDir.resolve("baseline");
+        final Path candidateDir = tempDir.resolve("candidate");
+        final Path outputDir = tempDir.resolve("out");
+        Files.createDirectories(baselineDir);
+        Files.createDirectories(candidateDir);
+
+        Files.writeString(
+                baselineDir.resolve("app.users.ndjson"),
+                """
+                {"_id":1,"name":"alpha"}
+                {"_id":2,"name":"beta"}
+                """,
+                StandardCharsets.UTF_8);
+        Files.writeString(
+                candidateDir.resolve("app.users.ndjson"),
+                "{" + "\"_id\":1,\"name\":\"alpha\"}" + "\n",
+                StandardCharsets.UTF_8);
+
+        final ByteArrayOutputStream errBytes = new ByteArrayOutputStream();
+        final int exitCode = FixtureRefreshTool.run(
+                new String[] {
+                    "--baseline-dir=" + baselineDir,
+                    "--candidate-dir=" + candidateDir,
+                    "--output-dir=" + outputDir,
+                    "--mode=full",
+                    "--require-approval"
+                },
+                new PrintStream(new ByteArrayOutputStream()),
+                new PrintStream(errBytes));
+
+        assertEquals(1, exitCode);
+        assertTrue(errBytes.toString().contains("--approved"));
+
+        final int approvedExit = FixtureRefreshTool.run(
+                new String[] {
+                    "--baseline-dir=" + baselineDir,
+                    "--candidate-dir=" + candidateDir,
+                    "--output-dir=" + outputDir,
+                    "--mode=full",
+                    "--require-approval",
+                    "--approved"
+                },
+                new PrintStream(new ByteArrayOutputStream()),
+                new PrintStream(new ByteArrayOutputStream()));
+        assertEquals(0, approvedExit);
+    }
+}


### PR DESCRIPTION
## Summary
- add `FixtureRefreshTool` and `fixtureRefresh` Gradle task for standardized full/incremental refresh execution
- generate deterministic refresh outputs plus JSON/Markdown diff reports on every refresh run
- add breaking-change approval gate (`--require-approval` + `--approved`) based on removals/field drops
- add PR-level label gate workflow (`fixture-refresh-approved`) for fixture refresh artifact updates
- add CODEOWNERS path ownership for `testkit/fixture/*` and document refresh workflow

## Validation
- `.tooling/gradle-8.10.2/bin/gradle test --tests org.jongodb.testkit.FixtureRefreshToolTest --tests org.jongodb.testkit.FixtureArtifactToolTest --tests org.jongodb.testkit.FixtureRestoreToolTest`

Closes #254
