### PR TITLE
feat(fixture): add artifact governance and compatibility policies

### DIFF
--- a/docs/FIXTURE_ARTIFACTS.md
+++ b/docs/FIXTURE_ARTIFACTS.md
@@ -16,20 +16,25 @@
 
 manifest에는 다음이 포함됩니다.
 - `schemaVersion`, `portableFormatVersion`, `fastFormatVersion`
+- `fixtureVersion`, `dataSchemaHash`, `artifactFormatVersion`
 - `engineVersion`
 - 각 아티팩트의 `sha256`
 - 컬렉션별 문서 수
+- `changelog`
 
 ## 실행
 
 ```bash
 .tooling/gradle-8.10.2/bin/gradle fixtureArtifactPack \
   -PfixtureArtifactInputDir=build/reports/fixture-sanitized \
-  -PfixtureArtifactOutputDir=build/reports/fixture-artifacts
+  -PfixtureArtifactOutputDir=build/reports/fixture-artifacts \
+  -PfixtureArtifactVersion=1.2.0
 ```
 
 옵션:
 - `-PfixtureArtifactEngineVersion=<version>`
+- `-PfixtureArtifactVersion=<semver>`
+- `-PfixtureArtifactPreviousManifest=<path>`
 
 ## 복원 시 호환성 정책
 `fixtureRestore`는 기본적으로 아래 순서로 입력을 선택합니다.
@@ -42,3 +47,5 @@ manifest에는 다음이 포함됩니다.
 체크섬 불일치가 감지되면 즉시 실패합니다.
 
 `fixtureRestore` 리포트(`fixture-restore-report.json`)의 `sourceFormat`으로 실제 경로를 확인할 수 있습니다.
+
+버전/보관/사용처 추적 정책은 `docs/FIXTURE_GOVERNANCE.md`를 참고하세요.

--- a/docs/FIXTURE_GOVERNANCE.md
+++ b/docs/FIXTURE_GOVERNANCE.md
@@ -1,0 +1,55 @@
+# Fixture Artifact Governance
+
+`#256` 구현 가이드입니다.
+
+## 목적
+- fixture artifact 버전(`fixtureSemVer`)과 스키마 해시(`dataSchemaHash`)를 명시적으로 관리합니다.
+- 보관 정책(최근 N개 + freeze 버전 유지)으로 불필요 artifact를 자동 정리합니다.
+- 사용처(consumer -> fixtureVersion) 인덱스를 유지해 어떤 테스트가 어떤 버전을 쓰는지 추적합니다.
+
+## Manifest 확장
+`fixtureArtifactPack` 결과 manifest(`fixture-artifact-manifest.json`)에는 아래 필드가 포함됩니다.
+
+- `fixtureVersion` (semver)
+- `dataSchemaHash`
+- `artifactFormatVersion`
+- `portableFormatVersion`
+- `fastFormatVersion`
+- `changelog[]`
+
+## 실행
+
+```bash
+.tooling/gradle-8.10.2/bin/gradle fixtureArtifactGovernance \
+  -PfixtureArtifactRoot=build/reports/fixture-artifacts \
+  -PfixtureArtifactRetain=5 \
+  -PfixtureArtifactFreezeVersion=1.0.0,1.1.0 \
+  -PfixtureArtifactDryRun=true
+```
+
+consumer 사용처 등록:
+
+```bash
+.tooling/gradle-8.10.2/bin/gradle fixtureArtifactGovernance \
+  -PfixtureArtifactRoot=build/reports/fixture-artifacts \
+  -PfixtureArtifactRegisterConsumer=spring-smoke \
+  -PfixtureArtifactRegisterVersion=1.2.0
+```
+
+## 산출물
+- `<reportDir>/fixture-artifact-governance-report.json`
+- `<reportDir>/fixture-artifact-governance-report.md`
+- `<reportDir>/fixture-artifact-changelog.md`
+- `<artifactRoot>/fixture-usage-index.json` (등록 시)
+
+## 호환성 검사
+복원 시 필수 버전을 강제하려면:
+
+```bash
+.tooling/gradle-8.10.2/bin/gradle fixtureRestore \
+  -PfixtureRestoreInputDir=build/reports/fixture-artifacts/v1.2.0 \
+  -PfixtureRestoreMongoUri='mongodb://localhost:27017' \
+  -PfixtureRestoreRequiredFixtureVersion=1.2.0
+```
+
+필수 버전과 불일치하면 복원을 차단하고 대응 안내 메시지를 출력합니다.

--- a/docs/FIXTURE_RESTORE.md
+++ b/docs/FIXTURE_RESTORE.md
@@ -23,6 +23,7 @@
 - `--namespace=<db.collection[,db.collection...]>`
 - `--report-dir=<dir>`
 - `--no-regenerate-fast-cache` (portable fallback 이후 fast cache 재생성 비활성화)
+- `--required-fixture-version=<semver>` (명시 버전 불일치 시 복원 차단)
 
 ## 산출물
 - `<reportDir>/fixture-restore-report.json`

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ Fixture workflows:
 - `docs/FIXTURE_SANITIZATION.md`
 - `docs/FIXTURE_ARTIFACTS.md`
 - `docs/FIXTURE_REFRESH.md`
+- `docs/FIXTURE_GOVERNANCE.md`
 - `docs/FIXTURE_RESTORE.md`
 
 Research and design notes:

--- a/src/main/java/org/jongodb/testkit/FixtureArtifactGovernanceTool.java
+++ b/src/main/java/org/jongodb/testkit/FixtureArtifactGovernanceTool.java
@@ -1,0 +1,514 @@
+package org.jongodb.testkit;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.bson.Document;
+
+/**
+ * Artifact governance utility for versioning, retention, compatibility visibility and usage traceability.
+ */
+public final class FixtureArtifactGovernanceTool {
+    private static final String REPORT_JSON = "fixture-artifact-governance-report.json";
+    private static final String REPORT_MD = "fixture-artifact-governance-report.md";
+    private static final String CHANGELOG_MD = "fixture-artifact-changelog.md";
+    private static final Pattern SEMVER =
+            Pattern.compile("^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:[-+][0-9A-Za-z.-]+)?$");
+
+    private FixtureArtifactGovernanceTool() {}
+
+    public static void main(final String[] args) {
+        final int exitCode = run(args, System.out, System.err);
+        if (exitCode != 0) {
+            System.exit(exitCode);
+        }
+    }
+
+    static int run(final String[] args, final PrintStream out, final PrintStream err) {
+        Objects.requireNonNull(args, "args");
+        Objects.requireNonNull(out, "out");
+        Objects.requireNonNull(err, "err");
+
+        final Config config;
+        try {
+            config = Config.fromArgs(args);
+        } catch (final IllegalArgumentException exception) {
+            err.println(exception.getMessage());
+            printUsage(err);
+            return 2;
+        }
+
+        if (config.help()) {
+            printUsage(out);
+            return 0;
+        }
+
+        try {
+            Files.createDirectories(config.reportDir());
+            Files.createDirectories(config.artifactRoot());
+
+            final Map<String, String> usageIndex = loadUsageIndex(config.usageIndexPath());
+            if (config.registerConsumer() != null) {
+                usageIndex.put(config.registerConsumer(), config.registerVersion());
+                writeUsageIndex(config.usageIndexPath(), usageIndex);
+            }
+
+            final List<ArtifactEntry> artifacts = discoverArtifacts(config.artifactRoot());
+            final List<ArtifactEntry> sorted = artifacts.stream()
+                    .sorted(Comparator.comparing((ArtifactEntry item) -> item.versionSemver()).reversed())
+                    .toList();
+
+            final Set<String> keepVersions = new LinkedHashSet<>();
+            for (int i = 0; i < sorted.size() && i < config.retain(); i++) {
+                keepVersions.add(sorted.get(i).fixtureVersion());
+            }
+            keepVersions.addAll(config.freezeVersions());
+
+            final List<ArtifactEntry> kept = new ArrayList<>();
+            final List<ArtifactEntry> pruned = new ArrayList<>();
+            for (final ArtifactEntry artifact : sorted) {
+                if (keepVersions.contains(artifact.fixtureVersion())) {
+                    kept.add(artifact);
+                } else {
+                    pruned.add(artifact);
+                }
+            }
+
+            if (!config.dryRun()) {
+                for (final ArtifactEntry artifact : pruned) {
+                    deleteRecursively(artifact.artifactDir());
+                }
+            }
+
+            final Map<String, String> unresolvedUsage = new LinkedHashMap<>();
+            final Set<String> availableVersions = new LinkedHashSet<>();
+            for (final ArtifactEntry artifact : kept) {
+                availableVersions.add(artifact.fixtureVersion());
+            }
+            for (final Map.Entry<String, String> usage : usageIndex.entrySet()) {
+                if (!availableVersions.contains(usage.getValue())) {
+                    unresolvedUsage.put(usage.getKey(), usage.getValue());
+                }
+            }
+
+            final GovernanceReport report = new GovernanceReport(
+                    Instant.now().toString(),
+                    config.retain(),
+                    List.copyOf(config.freezeVersions()),
+                    config.dryRun(),
+                    kept,
+                    pruned,
+                    Map.copyOf(usageIndex),
+                    Map.copyOf(unresolvedUsage));
+
+            Files.writeString(config.reportDir().resolve(REPORT_JSON), report.toJson(), StandardCharsets.UTF_8);
+            Files.writeString(config.reportDir().resolve(REPORT_MD), report.toMarkdown(), StandardCharsets.UTF_8);
+            Files.writeString(config.reportDir().resolve(CHANGELOG_MD), report.toChangelogMarkdown(), StandardCharsets.UTF_8);
+
+            out.println("Fixture artifact governance finished");
+            out.println("- retain: " + config.retain());
+            out.println("- freezeVersions: " + config.freezeVersions().size());
+            out.println("- kept: " + kept.size());
+            out.println("- pruned: " + pruned.size());
+            out.println("- unresolvedUsage: " + unresolvedUsage.size());
+            out.println("- reportJson: " + config.reportDir().resolve(REPORT_JSON));
+            out.println("- reportMd: " + config.reportDir().resolve(REPORT_MD));
+            out.println("- changelogMd: " + config.reportDir().resolve(CHANGELOG_MD));
+            return 0;
+        } catch (final IOException | RuntimeException exception) {
+            err.println("fixture artifact governance failed: " + exception.getMessage());
+            return 1;
+        }
+    }
+
+    private static List<ArtifactEntry> discoverArtifacts(final Path artifactRoot) throws IOException {
+        if (!Files.exists(artifactRoot) || !Files.isDirectory(artifactRoot)) {
+            return List.of();
+        }
+
+        final List<ArtifactEntry> entries = new ArrayList<>();
+        try (Stream<Path> stream = Files.walk(artifactRoot, 3)) {
+            stream.filter(path -> Files.isRegularFile(path)
+                            && FixtureArtifactBundle.MANIFEST_FILE.equals(path.getFileName().toString()))
+                    .forEach(path -> {
+                        final Document manifest = readManifest(path);
+                        final String fixtureVersion = manifest.getString("fixtureVersion");
+                        if (fixtureVersion == null || !SEMVER.matcher(fixtureVersion).matches()) {
+                            return;
+                        }
+                        final Path artifactDir = path.getParent();
+                        final String createdAt = manifest.getString("createdAt") == null
+                                ? ""
+                                : manifest.getString("createdAt");
+                        entries.add(new ArtifactEntry(
+                                fixtureVersion,
+                                parseSemver(fixtureVersion),
+                                artifactDir,
+                                path,
+                                manifest.getString("artifactFormatVersion"),
+                                manifest.getString("portableFormatVersion"),
+                                manifest.getString("fastFormatVersion"),
+                                manifest.getString("engineVersion"),
+                                manifest.getString("dataSchemaHash"),
+                                createdAt,
+                                extractChangelog(manifest)));
+                    });
+        }
+        return List.copyOf(entries);
+    }
+
+    private static Document readManifest(final Path path) {
+        try {
+            return Document.parse(Files.readString(path, StandardCharsets.UTF_8));
+        } catch (final IOException exception) {
+            throw new IllegalStateException("failed to read manifest: " + path, exception);
+        }
+    }
+
+    private static List<String> extractChangelog(final Document manifest) {
+        final Object raw = manifest.get("changelog");
+        if (!(raw instanceof List<?> list)) {
+            return List.of();
+        }
+        final List<String> lines = new ArrayList<>();
+        for (final Object item : list) {
+            if (item instanceof String text && !text.isBlank()) {
+                lines.add(text);
+            }
+        }
+        return List.copyOf(lines);
+    }
+
+    private static Map<String, String> loadUsageIndex(final Path usageIndexPath) throws IOException {
+        if (!Files.exists(usageIndexPath)) {
+            return new LinkedHashMap<>();
+        }
+        final Document document = Document.parse(Files.readString(usageIndexPath, StandardCharsets.UTF_8));
+        final Object raw = document.get("consumers");
+        if (!(raw instanceof Document consumers)) {
+            return new LinkedHashMap<>();
+        }
+        final Map<String, String> index = new LinkedHashMap<>();
+        for (final Map.Entry<String, Object> entry : consumers.entrySet()) {
+            if (entry.getValue() instanceof String version && !version.isBlank()) {
+                index.put(entry.getKey(), version);
+            }
+        }
+        return index;
+    }
+
+    private static void writeUsageIndex(final Path usageIndexPath, final Map<String, String> usageIndex) throws IOException {
+        final Document root = new Document();
+        root.put("updatedAt", Instant.now().toString());
+        root.put("consumers", new Document(usageIndex));
+        Files.createDirectories(usageIndexPath.getParent());
+        Files.writeString(usageIndexPath, DiffSummaryGenerator.JsonEncoder.encode(root), StandardCharsets.UTF_8);
+    }
+
+    private static void deleteRecursively(final Path target) throws IOException {
+        if (!Files.exists(target)) {
+            return;
+        }
+        try (Stream<Path> walk = Files.walk(target)) {
+            walk.sorted(Comparator.reverseOrder()).forEach(path -> {
+                try {
+                    Files.deleteIfExists(path);
+                } catch (final IOException exception) {
+                    throw new IllegalStateException("failed to delete " + path, exception);
+                }
+            });
+        }
+    }
+
+    private static SemVer parseSemver(final String rawVersion) {
+        final Matcher matcher = SEMVER.matcher(rawVersion);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("invalid fixture semver: " + rawVersion);
+        }
+        return new SemVer(
+                Integer.parseInt(matcher.group(1)),
+                Integer.parseInt(matcher.group(2)),
+                Integer.parseInt(matcher.group(3)));
+    }
+
+    private static void printUsage(final PrintStream stream) {
+        stream.println("Usage: FixtureArtifactGovernanceTool --artifact-root=<dir> [options]");
+        stream.println("  --artifact-root=<dir>          Root directory containing versioned artifact folders");
+        stream.println("  --retain=<n>                   Number of recent versions to keep (default: 5)");
+        stream.println("  --freeze-version=v1,v2         Frozen versions to keep regardless of retention");
+        stream.println("  --usage-index=<file>           Usage index json path (default: <artifact-root>/fixture-usage-index.json)");
+        stream.println("  --register-consumer=<id>       Register consumer id in usage index");
+        stream.println("  --register-version=<semver>    Version value for register-consumer");
+        stream.println("  --report-dir=<dir>             Report output directory (default: artifact-root)");
+        stream.println("  --dry-run                      Report only; do not delete old artifact directories");
+        stream.println("  --help                         Show usage");
+    }
+
+    private record Config(
+            Path artifactRoot,
+            int retain,
+            Set<String> freezeVersions,
+            Path usageIndexPath,
+            String registerConsumer,
+            String registerVersion,
+            Path reportDir,
+            boolean dryRun,
+            boolean help) {
+        static Config fromArgs(final String[] args) {
+            Path artifactRoot = null;
+            int retain = 5;
+            final Set<String> freezeVersions = new LinkedHashSet<>();
+            Path usageIndexPath = null;
+            String registerConsumer = null;
+            String registerVersion = null;
+            Path reportDir = null;
+            boolean dryRun = false;
+            boolean help = false;
+
+            for (final String arg : args) {
+                if ("--help".equals(arg) || "-h".equals(arg)) {
+                    help = true;
+                    continue;
+                }
+                if (arg.startsWith("--artifact-root=")) {
+                    artifactRoot = Path.of(valueAfterPrefix(arg, "--artifact-root="));
+                    continue;
+                }
+                if (arg.startsWith("--retain=")) {
+                    retain = Integer.parseInt(valueAfterPrefix(arg, "--retain="));
+                    continue;
+                }
+                if (arg.startsWith("--freeze-version=")) {
+                    for (final String token : valueAfterPrefix(arg, "--freeze-version=").split(",")) {
+                        final String version = token.trim();
+                        if (!version.isBlank()) {
+                            freezeVersions.add(version);
+                        }
+                    }
+                    continue;
+                }
+                if (arg.startsWith("--usage-index=")) {
+                    usageIndexPath = Path.of(valueAfterPrefix(arg, "--usage-index="));
+                    continue;
+                }
+                if (arg.startsWith("--register-consumer=")) {
+                    registerConsumer = valueAfterPrefix(arg, "--register-consumer=");
+                    continue;
+                }
+                if (arg.startsWith("--register-version=")) {
+                    registerVersion = valueAfterPrefix(arg, "--register-version=");
+                    continue;
+                }
+                if (arg.startsWith("--report-dir=")) {
+                    reportDir = Path.of(valueAfterPrefix(arg, "--report-dir="));
+                    continue;
+                }
+                if ("--dry-run".equals(arg)) {
+                    dryRun = true;
+                    continue;
+                }
+                throw new IllegalArgumentException("unknown argument: " + arg);
+            }
+
+            if (!help && artifactRoot == null) {
+                throw new IllegalArgumentException("--artifact-root=<dir> is required");
+            }
+            if (!help && retain < 1) {
+                throw new IllegalArgumentException("--retain must be >= 1");
+            }
+            if (!help && registerConsumer != null && (registerVersion == null || registerVersion.isBlank())) {
+                throw new IllegalArgumentException("--register-version is required when --register-consumer is set");
+            }
+            if (!help && registerVersion != null && !SEMVER.matcher(registerVersion).matches()) {
+                throw new IllegalArgumentException("--register-version must be semantic version");
+            }
+
+            if (usageIndexPath == null && artifactRoot != null) {
+                usageIndexPath = artifactRoot.resolve("fixture-usage-index.json");
+            }
+            if (reportDir == null && artifactRoot != null) {
+                reportDir = artifactRoot;
+            }
+
+            return new Config(
+                    artifactRoot,
+                    retain,
+                    Set.copyOf(freezeVersions),
+                    usageIndexPath,
+                    registerConsumer,
+                    registerVersion,
+                    reportDir,
+                    dryRun,
+                    help);
+        }
+
+        private static String valueAfterPrefix(final String arg, final String prefix) {
+            final String value = arg.substring(prefix.length()).trim();
+            if (value.isEmpty()) {
+                throw new IllegalArgumentException(prefix + " must have a value");
+            }
+            return value;
+        }
+    }
+
+    private record ArtifactEntry(
+            String fixtureVersion,
+            SemVer versionSemver,
+            Path artifactDir,
+            Path manifestPath,
+            String artifactFormatVersion,
+            String portableFormatVersion,
+            String fastFormatVersion,
+            String engineVersion,
+            String dataSchemaHash,
+            String createdAt,
+            List<String> changelog) {
+        Map<String, Object> toMap() {
+            final Map<String, Object> root = new LinkedHashMap<>();
+            root.put("fixtureVersion", fixtureVersion);
+            root.put("artifactDir", artifactDir.toString());
+            root.put("manifestPath", manifestPath.toString());
+            root.put("artifactFormatVersion", artifactFormatVersion);
+            root.put("portableFormatVersion", portableFormatVersion);
+            root.put("fastFormatVersion", fastFormatVersion);
+            root.put("engineVersion", engineVersion);
+            root.put("dataSchemaHash", dataSchemaHash);
+            root.put("createdAt", createdAt);
+            root.put("changelog", changelog);
+            return root;
+        }
+    }
+
+    private record GovernanceReport(
+            String generatedAt,
+            int retain,
+            List<String> freezeVersions,
+            boolean dryRun,
+            List<ArtifactEntry> kept,
+            List<ArtifactEntry> pruned,
+            Map<String, String> usageIndex,
+            Map<String, String> unresolvedUsage) {
+        String toJson() {
+            final Map<String, Object> root = new LinkedHashMap<>();
+            root.put("generatedAt", generatedAt);
+            root.put("retain", retain);
+            root.put("freezeVersions", freezeVersions);
+            root.put("dryRun", dryRun);
+            root.put("keptCount", kept.size());
+            root.put("prunedCount", pruned.size());
+            root.put("usageIndex", usageIndex);
+            root.put("unresolvedUsage", unresolvedUsage);
+
+            final List<Map<String, Object>> keptItems = new ArrayList<>(kept.size());
+            for (final ArtifactEntry item : kept) {
+                keptItems.add(item.toMap());
+            }
+            root.put("kept", keptItems);
+
+            final List<Map<String, Object>> prunedItems = new ArrayList<>(pruned.size());
+            for (final ArtifactEntry item : pruned) {
+                prunedItems.add(item.toMap());
+            }
+            root.put("pruned", prunedItems);
+
+            return DiffSummaryGenerator.JsonEncoder.encode(root);
+        }
+
+        String toMarkdown() {
+            final StringBuilder sb = new StringBuilder();
+            sb.append("# Fixture Artifact Governance Report\n\n");
+            sb.append("- retain: ").append(retain).append("\n");
+            sb.append("- freezeVersions: ").append(freezeVersions).append("\n");
+            sb.append("- dryRun: ").append(dryRun).append("\n");
+            sb.append("- keptCount: ").append(kept.size()).append("\n");
+            sb.append("- prunedCount: ").append(pruned.size()).append("\n");
+            sb.append("- unresolvedUsage: ").append(unresolvedUsage.size()).append("\n\n");
+
+            sb.append("## Kept Versions\n");
+            for (final ArtifactEntry item : kept) {
+                sb.append("- ").append(item.fixtureVersion())
+                        .append(" (engine=").append(item.engineVersion())
+                        .append(", hash=").append(item.dataSchemaHash())
+                        .append(")\n");
+            }
+
+            sb.append("\n## Pruned Versions\n");
+            if (pruned.isEmpty()) {
+                sb.append("- none\n");
+            } else {
+                for (final ArtifactEntry item : pruned) {
+                    sb.append("- ").append(item.fixtureVersion()).append(" -> ").append(item.artifactDir()).append("\n");
+                }
+            }
+
+            sb.append("\n## Usage Index\n");
+            if (usageIndex.isEmpty()) {
+                sb.append("- empty\n");
+            } else {
+                for (final Map.Entry<String, String> entry : usageIndex.entrySet()) {
+                    sb.append("- ").append(entry.getKey()).append(": ").append(entry.getValue()).append("\n");
+                }
+            }
+
+            if (!unresolvedUsage.isEmpty()) {
+                sb.append("\n## Unresolved Usage\n");
+                for (final Map.Entry<String, String> entry : unresolvedUsage.entrySet()) {
+                    sb.append("- ").append(entry.getKey()).append(": ").append(entry.getValue()).append("\n");
+                }
+            }
+            return sb.toString();
+        }
+
+        String toChangelogMarkdown() {
+            final StringBuilder sb = new StringBuilder();
+            sb.append("# Fixture Artifact Changelog\n\n");
+            for (final ArtifactEntry item : kept) {
+                sb.append("## ").append(item.fixtureVersion()).append("\n");
+                if (item.changelog().isEmpty()) {
+                    sb.append("- no changelog entries\n\n");
+                    continue;
+                }
+                for (final String line : item.changelog()) {
+                    sb.append("- ").append(line).append("\n");
+                }
+                sb.append("\n");
+            }
+            return sb.toString();
+        }
+    }
+
+    private record SemVer(int major, int minor, int patch) implements Comparable<SemVer> {
+        @Override
+        public int compareTo(final SemVer other) {
+            int compare = Integer.compare(major, other.major);
+            if (compare != 0) {
+                return compare;
+            }
+            compare = Integer.compare(minor, other.minor);
+            if (compare != 0) {
+                return compare;
+            }
+            return Integer.compare(patch, other.patch);
+        }
+
+        @Override
+        public String toString() {
+            return major + "." + minor + "." + patch;
+        }
+    }
+}

--- a/src/main/java/org/jongodb/testkit/FixtureRestoreTool.java
+++ b/src/main/java/org/jongodb/testkit/FixtureRestoreTool.java
@@ -135,6 +135,7 @@ public final class FixtureRestoreTool {
                 config.inputDir(),
                 config.regenerateFastCache(),
                 FixtureArtifactBundle.currentEngineVersion(),
+                config.requiredFixtureVersion(),
                 out);
 
         if (bundleResult != null) {
@@ -283,6 +284,7 @@ public final class FixtureRestoreTool {
         stream.println("  --report-dir=<dir>             Report output directory (default: input-dir)");
         stream.println("  --regenerate-fast-cache        Regenerate fast cache when portable fallback is used (default)");
         stream.println("  --no-regenerate-fast-cache     Do not regenerate fast cache on fallback");
+        stream.println("  --required-fixture-version=v   Required fixture version for compatibility check");
         stream.println("  --help                         Show usage");
     }
 
@@ -311,6 +313,7 @@ public final class FixtureRestoreTool {
             String databaseFilter,
             Set<String> namespaceFilter,
             Path reportDir,
+            String requiredFixtureVersion,
             boolean regenerateFastCache,
             boolean help) {
         static Config fromArgs(final String[] args) {
@@ -320,6 +323,7 @@ public final class FixtureRestoreTool {
             String databaseFilter = null;
             final Set<String> namespaceFilter = new LinkedHashSet<>();
             Path reportDir = null;
+            String requiredFixtureVersion = null;
             boolean regenerateFastCache = true;
             boolean help = false;
 
@@ -357,6 +361,10 @@ public final class FixtureRestoreTool {
                     reportDir = Path.of(valueAfterPrefix(arg, "--report-dir="));
                     continue;
                 }
+                if (arg.startsWith("--required-fixture-version=")) {
+                    requiredFixtureVersion = valueAfterPrefix(arg, "--required-fixture-version=");
+                    continue;
+                }
                 if ("--regenerate-fast-cache".equals(arg)) {
                     regenerateFastCache = true;
                     continue;
@@ -384,6 +392,7 @@ public final class FixtureRestoreTool {
                     databaseFilter,
                     Set.copyOf(namespaceFilter),
                     reportDir,
+                    requiredFixtureVersion,
                     regenerateFastCache,
                     help);
         }

--- a/src/test/java/org/jongodb/testkit/FixtureArtifactGovernanceToolTest.java
+++ b/src/test/java/org/jongodb/testkit/FixtureArtifactGovernanceToolTest.java
@@ -1,0 +1,81 @@
+package org.jongodb.testkit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class FixtureArtifactGovernanceToolTest {
+    @Test
+    void prunesOldArtifactsWhileKeepingFrozenVersions(@TempDir final Path tempDir) throws Exception {
+        final Path inputDir = tempDir.resolve("input");
+        final Path artifactRoot = tempDir.resolve("artifacts");
+        Files.createDirectories(inputDir);
+
+        Files.writeString(inputDir.resolve("app.users.ndjson"), "{\"_id\":1,\"name\":\"alpha\"}\n", StandardCharsets.UTF_8);
+        assertEquals(0, pack(inputDir, artifactRoot.resolve("v1.0.0"), "1.0.0", null));
+
+        Files.writeString(inputDir.resolve("app.users.ndjson"),
+                "{\"_id\":1,\"name\":\"alpha\"}\n{\"_id\":2,\"name\":\"beta\"}\n",
+                StandardCharsets.UTF_8);
+        assertEquals(0, pack(inputDir, artifactRoot.resolve("v1.1.0"), "1.1.0", artifactRoot.resolve("v1.0.0/fixture-artifact-manifest.json")));
+
+        Files.writeString(inputDir.resolve("app.users.ndjson"),
+                "{\"_id\":1,\"name\":\"alpha\"}\n{\"_id\":2,\"name\":\"beta\"}\n{\"_id\":3,\"name\":\"gamma\"}\n",
+                StandardCharsets.UTF_8);
+        assertEquals(0, pack(inputDir, artifactRoot.resolve("v1.2.0"), "1.2.0", artifactRoot.resolve("v1.1.0/fixture-artifact-manifest.json")));
+
+        final int governanceExit = FixtureArtifactGovernanceTool.run(
+                new String[] {
+                    "--artifact-root=" + artifactRoot,
+                    "--retain=1",
+                    "--freeze-version=1.0.0",
+                    "--register-consumer=spring-smoke",
+                    "--register-version=1.2.0"
+                },
+                new PrintStream(new ByteArrayOutputStream()),
+                new PrintStream(new ByteArrayOutputStream()));
+        assertEquals(0, governanceExit);
+
+        assertTrue(Files.exists(artifactRoot.resolve("v1.0.0")));
+        assertTrue(!Files.exists(artifactRoot.resolve("v1.1.0")));
+        assertTrue(Files.exists(artifactRoot.resolve("v1.2.0")));
+
+        final Document report = Document.parse(Files.readString(
+                artifactRoot.resolve("fixture-artifact-governance-report.json"),
+                StandardCharsets.UTF_8));
+        assertEquals(2, report.getInteger("keptCount"));
+        assertEquals(1, report.getInteger("prunedCount"));
+
+        final Document usageIndex = Document.parse(Files.readString(
+                artifactRoot.resolve("fixture-usage-index.json"),
+                StandardCharsets.UTF_8));
+        final Document consumers = usageIndex.get("consumers", Document.class);
+        assertEquals("1.2.0", consumers.getString("spring-smoke"));
+    }
+
+    private static int pack(
+            final Path inputDir,
+            final Path outputDir,
+            final String fixtureVersion,
+            final Path previousManifest) {
+        final java.util.List<String> args = new java.util.ArrayList<>();
+        args.add("--input-dir=" + inputDir);
+        args.add("--output-dir=" + outputDir);
+        args.add("--fixture-version=" + fixtureVersion);
+        if (previousManifest != null) {
+            args.add("--previous-manifest=" + previousManifest);
+        }
+        return FixtureArtifactTool.run(
+                args.toArray(new String[0]),
+                new PrintStream(new ByteArrayOutputStream()),
+                new PrintStream(new ByteArrayOutputStream()));
+    }
+}

--- a/src/test/java/org/jongodb/testkit/FixtureArtifactToolTest.java
+++ b/src/test/java/org/jongodb/testkit/FixtureArtifactToolTest.java
@@ -32,7 +32,8 @@ class FixtureArtifactToolTest {
                 new String[] {
                     "--input-dir=" + inputDir,
                     "--output-dir=" + outputDir,
-                    "--engine-version=test-engine-v1"
+                    "--engine-version=test-engine-v1",
+                    "--fixture-version=1.2.3"
                 },
                 new PrintStream(new ByteArrayOutputStream()),
                 new PrintStream(new ByteArrayOutputStream()));
@@ -46,7 +47,10 @@ class FixtureArtifactToolTest {
                 outputDir.resolve("fixture-artifact-manifest.json"),
                 StandardCharsets.UTF_8));
         assertEquals("fixture-artifact.v1", manifest.getString("schemaVersion"));
+        assertEquals("dual-artifact.v1", manifest.getString("artifactFormatVersion"));
         assertEquals("test-engine-v1", manifest.getString("engineVersion"));
+        assertEquals("1.2.3", manifest.getString("fixtureVersion"));
+        assertTrue(manifest.getString("dataSchemaHash").length() >= 32);
         assertEquals("fast-snapshot.v1", manifest.getString("fastFormatVersion"));
 
         final Document totals = manifest.get("totals", Document.class);
@@ -57,5 +61,50 @@ class FixtureArtifactToolTest {
         final Document fast = manifest.get("fast", Document.class);
         assertEquals(64, portable.getString("sha256").length());
         assertEquals(64, fast.getString("sha256").length());
+    }
+
+    @Test
+    void generatesChangelogWhenPreviousManifestIsProvided(@TempDir final Path tempDir) throws Exception {
+        final Path inputDir = tempDir.resolve("fixture-ndjson");
+        final Path outputV1 = tempDir.resolve("artifact-v1");
+        final Path outputV2 = tempDir.resolve("artifact-v2");
+        Files.createDirectories(inputDir);
+
+        Files.writeString(
+                inputDir.resolve("app.users.ndjson"),
+                "{\"_id\":1,\"name\":\"alpha\"}\n",
+                StandardCharsets.UTF_8);
+
+        assertEquals(0, FixtureArtifactTool.run(
+                new String[] {
+                    "--input-dir=" + inputDir,
+                    "--output-dir=" + outputV1,
+                    "--fixture-version=1.0.0"
+                },
+                new PrintStream(new ByteArrayOutputStream()),
+                new PrintStream(new ByteArrayOutputStream())));
+
+        Files.writeString(
+                inputDir.resolve("app.users.ndjson"),
+                "{\"_id\":1,\"name\":\"alpha\"}\n{\"_id\":2,\"name\":\"beta\"}\n",
+                StandardCharsets.UTF_8);
+
+        assertEquals(0, FixtureArtifactTool.run(
+                new String[] {
+                    "--input-dir=" + inputDir,
+                    "--output-dir=" + outputV2,
+                    "--fixture-version=1.1.0",
+                    "--previous-manifest=" + outputV1.resolve("fixture-artifact-manifest.json")
+                },
+                new PrintStream(new ByteArrayOutputStream()),
+                new PrintStream(new ByteArrayOutputStream())));
+
+        final Document manifestV2 = Document.parse(Files.readString(
+                outputV2.resolve("fixture-artifact-manifest.json"),
+                StandardCharsets.UTF_8));
+        @SuppressWarnings("unchecked")
+        final java.util.List<String> changelog = (java.util.List<String>) manifestV2.get("changelog");
+        assertTrue(!changelog.isEmpty());
+        assertTrue(changelog.stream().anyMatch(item -> item.contains("documents:")));
     }
 }


### PR DESCRIPTION
## Summary
- extend fixture artifact manifest with governance metadata: `fixtureVersion`, `dataSchemaHash`, `artifactFormatVersion`, and auto-generated `changelog`
- add `FixtureArtifactGovernanceTool` + `fixtureArtifactGovernance` task for retention policy (recent N + frozen versions), compatibility visibility, and usage index tracking
- add restore-time compatibility enforcement via `--required-fixture-version` with clear mismatch guidance
- update artifact pack task/CLI to accept semantic fixture version and previous manifest for changelog generation
- add tests covering changelog generation, governance prune behavior, usage index registration, and restore compatibility blocking
- document governance workflow and updated artifact/restore options

## Validation
- `.tooling/gradle-8.10.2/bin/gradle test --tests org.jongodb.testkit.FixtureArtifactToolTest --tests org.jongodb.testkit.FixtureArtifactGovernanceToolTest --tests org.jongodb.testkit.FixtureRestoreToolTest --tests org.jongodb.testkit.FixtureRefreshToolTest`

Closes #256
