### PR TITLE
refactor(build): split runtime and testkit module boundaries

### DIFF
--- a/docs/ARCH_MODULE_BOUNDARIES.md
+++ b/docs/ARCH_MODULE_BOUNDARIES.md
@@ -1,0 +1,21 @@
+# Runtime/Testkit Module Boundaries
+
+`#222` 구조 분리 가이드입니다.
+
+## 목적
+- 런타임 코드와 검증 하네스(testkit) 코드를 모듈 단위로 분리합니다.
+- 런타임 산출물에 `org.jongodb.testkit.*` 클래스가 포함되지 않도록 보장합니다.
+- 런타임에서 testkit 패키지로 향하는 의존을 CI에서 빠르게 차단합니다.
+
+## 모듈 구조
+- 루트 프로젝트(`:`): runtime 모듈 (`src/main/java` 중 `org/jongodb/testkit/**` 제외)
+- `:jongodb-testkit`: testkit 모듈 (`src/main/java/org/jongodb/testkit/**`)
+- `:jongodb-spring-suite`: spring suite 모듈 (`testkit/spring-suite/src/main/java/**`)
+
+## 실행 방식
+- 기존 커맨드(`gradle fixtureRefresh`, `gradle r3FailureLedger`, `gradle springCompatibilityMatrixEvidence`)는 루트에서 그대로 실행됩니다.
+- 해당 태스크들은 내부적으로 testkit/spring-suite 모듈 런타임 classpath를 사용합니다.
+
+## 가드레일
+- `RuntimeLayeringGuardTest`가 런타임 패키지에서 `org.jongodb.testkit..` 의존을 금지합니다.
+- 위반 시 `gradle test`에서 실패합니다.

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ Runtime and compatibility:
 - `docs/NODE_SEMVER_POLICY.md`
 - `docs/NODE_TROUBLESHOOTING_PLAYBOOK.md`
 - `docs/SUPPORT_MATRIX.md`
+- `docs/ARCH_MODULE_BOUNDARIES.md`
 - `docs/RELEASE_CHECKLIST.md`
 - `docs/ROADMAP.md`
 

--- a/jongodb-spring-suite/build.gradle.kts
+++ b/jongodb-spring-suite/build.gradle.kts
@@ -1,0 +1,36 @@
+plugins {
+    `java-library`
+}
+
+repositories {
+    mavenCentral()
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+sourceSets {
+    named("main") {
+        java.setSrcDirs(listOf("../testkit/spring-suite/src/main/java"))
+    }
+    named("test") {
+        java.setSrcDirs(listOf("../testkit/spring-suite/src/test/java"))
+    }
+}
+
+dependencies {
+    implementation(project(":jongodb-testkit"))
+
+    testImplementation(platform("org.junit:junit-bom:5.10.2"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
+    filter {
+        isFailOnNoMatchingTests = false
+    }
+    workingDir = rootProject.projectDir
+}

--- a/jongodb-testkit/build.gradle.kts
+++ b/jongodb-testkit/build.gradle.kts
@@ -1,0 +1,40 @@
+plugins {
+    `java-library`
+}
+
+repositories {
+    mavenCentral()
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+sourceSets {
+    named("main") {
+        java.setSrcDirs(listOf("../src/main/java"))
+        java.include("org/jongodb/testkit/**")
+    }
+    named("test") {
+        java.setSrcDirs(listOf("../src/test/java"))
+        java.include("org/jongodb/testkit/**")
+    }
+}
+
+dependencies {
+    implementation(project(":"))
+    implementation("org.mongodb:mongodb-driver-sync:4.11.2")
+    implementation("org.yaml:snakeyaml:2.2")
+
+    testImplementation(platform("org.junit:junit-bom:5.10.2"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
+    filter {
+        isFailOnNoMatchingTests = false
+    }
+    workingDir = rootProject.projectDir
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,4 @@
 rootProject.name = "jongodb"
+
+include("jongodb-testkit")
+include("jongodb-spring-suite")

--- a/src/main/java/org/jongodb/spring/test/InProcessIntegrationTemplate.java
+++ b/src/main/java/org/jongodb/spring/test/InProcessIntegrationTemplate.java
@@ -1,4 +1,4 @@
-package org.jongodb.testkit;
+package org.jongodb.spring.test;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;

--- a/src/main/java/org/jongodb/spring/test/JongodbInProcessInitializer.java
+++ b/src/main/java/org/jongodb/spring/test/JongodbInProcessInitializer.java
@@ -4,7 +4,6 @@ import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
-import org.jongodb.testkit.InProcessIntegrationTemplate;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.event.ContextClosedEvent;

--- a/src/main/java/org/jongodb/spring/test/JongodbInProcessResetSupport.java
+++ b/src/main/java/org/jongodb/spring/test/JongodbInProcessResetSupport.java
@@ -1,7 +1,6 @@
 package org.jongodb.spring.test;
 
 import java.util.Objects;
-import org.jongodb.testkit.InProcessIntegrationTemplate;
 import org.springframework.context.ApplicationContext;
 
 /**

--- a/src/test/java/org/jongodb/arch/RuntimeLayeringGuardTest.java
+++ b/src/test/java/org/jongodb/arch/RuntimeLayeringGuardTest.java
@@ -1,0 +1,26 @@
+package org.jongodb.arch;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+@AnalyzeClasses(packages = "org.jongodb", importOptions = ImportOption.DoNotIncludeTests.class)
+class RuntimeLayeringGuardTest {
+    @ArchTest
+    static final ArchRule runtime_does_not_depend_on_testkit = noClasses()
+            .that()
+            .resideInAnyPackage(
+                    "org.jongodb.command..",
+                    "org.jongodb.engine..",
+                    "org.jongodb.obs..",
+                    "org.jongodb.server..",
+                    "org.jongodb.spring..",
+                    "org.jongodb.txn..",
+                    "org.jongodb.wire..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAnyPackage("org.jongodb.testkit..", "org.jongodb.testkit.springsuite..");
+}

--- a/src/test/java/org/jongodb/spring/test/InProcessIntegrationTemplateTest.java
+++ b/src/test/java/org/jongodb/spring/test/InProcessIntegrationTemplateTest.java
@@ -1,4 +1,4 @@
-package org.jongodb.testkit;
+package org.jongodb.spring.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/org/jongodb/spring/test/JongodbInProcessInitializerTest.java
+++ b/src/test/java/org/jongodb/spring/test/JongodbInProcessInitializerTest.java
@@ -8,7 +8,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import org.bson.BsonDocument;
-import org.jongodb.testkit.InProcessIntegrationTemplate;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;

--- a/src/test/java/org/jongodb/spring/test/JongodbInProcessTestDefaultWiringTest.java
+++ b/src/test/java/org/jongodb/spring/test/JongodbInProcessTestDefaultWiringTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
 import org.bson.BsonDocument;
-import org.jongodb.testkit.InProcessIntegrationTemplate;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
## Summary
- split runtime/testkit concerns with dedicated modules `:jongodb-testkit` and `:jongodb-spring-suite`
- keep root runtime artifact focused on non-testkit packages and route verification JavaExec tasks through testkit/spring-suite runtime classpath
- move `InProcessIntegrationTemplate` into runtime spring package to remove runtime -> testkit compile dependency
- add runtime layering guard test (`RuntimeLayeringGuardTest`) and module-boundary documentation

## Validation
- `.tooling/gradle-8.10.2/bin/gradle --no-daemon --stacktrace projects`
- `.tooling/gradle-8.10.2/bin/gradle --no-daemon --stacktrace jar`
- `jar tf build/libs/jongodb-0.1.3-SNAPSHOT.jar | rg "org/jongodb/testkit|org/jongodb/testkit/springsuite"` (no matches)
- `.tooling/gradle-8.10.2/bin/gradle --no-daemon --stacktrace test --tests org.jongodb.arch.RuntimeLayeringGuardTest`
- `.tooling/gradle-8.10.2/bin/gradle --no-daemon --stacktrace :test --tests org.jongodb.spring.test.InProcessIntegrationTemplateTest --tests org.jongodb.spring.test.JongodbInProcessInitializerTest`
- `.tooling/gradle-8.10.2/bin/gradle --no-daemon --stacktrace :jongodb-testkit:test --tests org.jongodb.testkit.FixtureExtractionPlannerTest --tests org.jongodb.testkit.FixtureManifestLoaderTest --tests org.jongodb.testkit.FixtureManifestToolTest`
- `.tooling/gradle-8.10.2/bin/gradle --no-daemon --stacktrace test --tests org.jongodb.testkit.FixtureExtractionToolTest --tests org.jongodb.testkit.FixtureSanitizationToolTest --tests org.jongodb.testkit.FixtureArtifactToolTest --tests org.jongodb.testkit.FixtureRestoreToolTest`
- `.tooling/gradle-8.10.2/bin/gradle --no-daemon --stacktrace fixtureManifestPlan -PfixtureManifestPath=testkit/fixture/manifests/baseline-dev-smoke-full.json -PfixtureProfile=dev`
- `.tooling/gradle-8.10.2/bin/gradle --no-daemon --stacktrace fixtureRefresh -PfixtureRefreshBaselineDir=testkit/fixture/nightly/dev/baseline -PfixtureRefreshCandidateDir=testkit/fixture/nightly/dev/candidate -PfixtureRefreshOutputDir=build/reports/fixture-refresh-module-split-smoke -PfixtureRefreshMode=incremental -PfixtureRefreshWarnThreshold=0.25 -PfixtureRefreshFailThreshold=0.60 -PfixtureRefreshFailOnThreshold=true`
- `.tooling/gradle-8.10.2/bin/gradle --no-daemon --stacktrace springCompatibilityMatrixEvidence -PspringMatrixOutputDir=build/reports/spring-matrix-smoke -PspringMatrixFailOnFailures=false`

## Notes
- Full `clean test`/`test` runs can be long in this repo; this PR validates `#222`-related runtime layering and existing evidence/fixture task paths directly.

Closes #222
