### PR TITLE
fix(testkit): normalize listLocalSessions aggregate subset

### DIFF
--- a/src/main/java/org/jongodb/testkit/UnifiedSpecImporter.java
+++ b/src/main/java/org/jongodb/testkit/UnifiedSpecImporter.java
@@ -410,7 +410,8 @@ public final class UnifiedSpecImporter {
 
     private static Map<String, Object> normalizeAggregateStage(final Map<String, Object> stage) {
         if (stage.containsKey("$listLocalSessions")) {
-            return Map.of("$limit", 0);
+            // Keep deterministic subset behavior while preserving valid aggregate semantics for real mongod.
+            return Map.of("$limit", 1);
         }
         return stage;
     }

--- a/src/test/java/org/jongodb/testkit/UnifiedSpecImporterTest.java
+++ b/src/test/java/org/jongodb/testkit/UnifiedSpecImporterTest.java
@@ -361,7 +361,7 @@ class UnifiedSpecImporterTest {
         assertEquals(3, pipeline.size());
         assertTrue(pipeline.get(0) instanceof java.util.Map<?, ?>);
         assertTrue(((java.util.Map<?, ?>) pipeline.get(0)).containsKey("$limit"));
-        assertEquals(0, ((java.util.Map<?, ?>) pipeline.get(0)).get("$limit"));
+        assertEquals(1, ((java.util.Map<?, ?>) pipeline.get(0)).get("$limit"));
 
         final WireCommandIngressBackend backend = new WireCommandIngressBackend("wire");
         final ScenarioOutcome outcome = backend.execute(scenario);


### PR DESCRIPTION
## Summary
- normalize UTF importer `$listLocalSessions` aggregate stage to a valid deterministic subset stage (`$limit: 1`)
- keep stage deterministic while avoiding invalid `$limit: 0` payloads that diverge on real mongod
- update importer test expectation for listLocalSessions subset normalization

## Why
Latest main official suite run (`22513632933`) and ledger run (`22513973560`) show 4 deterministic mismatches caused by listLocalSessions replay bundles using `$limit: 0`, which triggers real mongod error (`the limit must be positive`).

## Testing
- `.tooling/gradle-8.10.2/bin/gradle --no-daemon --stacktrace test --tests org.jongodb.testkit.UnifiedSpecImporterTest`

## Notes
- Existing replay bundles in historical artifacts still embed `$limit: 0`; this change affects newly imported official scenarios in subsequent suite runs.

Closes #375
