### PR TITLE
fix(complex-query): align expr array-index path semantics

### DIFF
--- a/src/main/java/org/jongodb/engine/QueryMatcher.java
+++ b/src/main/java/org/jongodb/engine/QueryMatcher.java
@@ -256,13 +256,9 @@ final class QueryMatcher {
                 current = mapValue.get(segment);
                 continue;
             }
-            if (current instanceof List<?> listValue) {
-                final Integer index = parseArrayIndexSegment(segment);
-                if (index == null || index < 0 || index >= listValue.size()) {
-                    return null;
-                }
-                current = listValue.get(index);
-                continue;
+            if (current instanceof List<?>) {
+                // $expr paths follow aggregation-style traversal and do not support direct array index segments.
+                return null;
             }
             return null;
         }

--- a/src/test/java/org/jongodb/engine/QueryMatcherTest.java
+++ b/src/test/java/org/jongodb/engine/QueryMatcherTest.java
@@ -370,8 +370,12 @@ class QueryMatcherTest {
         assertTrue(
                 QueryMatcher.matches(
                         document,
+                        new Document("$expr", new Document("$eq", List.of("$metrics", List.of(5, 2, 1))))));
+        assertFalse(
+                QueryMatcher.matches(
+                        document,
                         new Document("$expr", new Document("$eq", List.of("$metrics.0", 5)))));
-        assertTrue(
+        assertFalse(
                 QueryMatcher.matches(
                         document,
                         new Document("$expr", new Document("$gt", List.of("$series.0.value", "$series.1.value")))));

--- a/src/test/java/org/jongodb/testkit/ComplexQueryPatternPackTest.java
+++ b/src/test/java/org/jongodb/testkit/ComplexQueryPatternPackTest.java
@@ -2,10 +2,12 @@ package org.jongodb.testkit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
@@ -32,5 +34,39 @@ class ComplexQueryPatternPackTest {
         }
 
         assertTrue(explicitlyUnsupportedCount >= 3, "expected explicit unsupported coverage in pattern pack");
+    }
+
+    @Test
+    void exprArrayIndexComparisonPatternUsesMongodCompatibleExprPathSemantics() {
+        final ComplexQueryPatternPack.PatternCase pattern = ComplexQueryPatternPack.patterns().stream()
+                .filter(candidate -> "cq.expr.array-index-comparison".equals(candidate.id()))
+                .findFirst()
+                .orElseThrow();
+
+        final ScenarioOutcome outcome = new WireCommandIngressBackend("wire").execute(pattern.scenario());
+        assertTrue(outcome.success(), outcome.errorMessage().orElse("expected successful scenario execution"));
+        assertEquals(2, outcome.commandResults().size());
+
+        final Map<String, Object> findResult = asMap(outcome.commandResults().get(1), "find result");
+        final Map<String, Object> cursor = asMap(findResult.get("cursor"), "find cursor");
+        final List<?> firstBatch = asList(cursor.get("firstBatch"), "find firstBatch");
+        assertEquals(0, firstBatch.size(), "expected no matches for $expr path '$metrics.0' against array values");
+    }
+
+    private static Map<String, Object> asMap(final Object value, final String fieldName) {
+        assertNotNull(value, fieldName + " must not be null");
+        assertTrue(value instanceof Map<?, ?>, fieldName + " must be an object");
+        final Map<?, ?> raw = (Map<?, ?>) value;
+        final java.util.LinkedHashMap<String, Object> normalized = new java.util.LinkedHashMap<>();
+        for (final Map.Entry<?, ?> entry : raw.entrySet()) {
+            normalized.put(String.valueOf(entry.getKey()), entry.getValue());
+        }
+        return normalized;
+    }
+
+    private static List<?> asList(final Object value, final String fieldName) {
+        assertNotNull(value, fieldName + " must not be null");
+        assertTrue(value instanceof List<?>, fieldName + " must be an array");
+        return (List<?>) value;
     }
 }


### PR DESCRIPTION
## Summary
- fix `$expr` path resolution to stop treating numeric segments as array indexes
- align with mongod aggregation-style expression traversal semantics for paths like `$metrics.0`
- add regression coverage in `ComplexQueryPatternPackTest` for `cq.expr.array-index-comparison`
- update `QueryMatcherTest` expectations to reflect mongod-compatible behavior

## Why
Latest complex-query certification run reported 1 mismatch on `cq.expr.array-index-comparison` with:
- `$.commandResults[1].cursor.firstBatch.length: list size mismatch`

Root cause: wire backend interpreted `$metrics.0` as direct array indexing, while real mongod does not.

## Verification
- `./.tooling/gradle-8.10.2/bin/gradle --no-daemon --stacktrace test --tests org.jongodb.engine.QueryMatcherTest --tests org.jongodb.testkit.ComplexQueryPatternPackTest --tests org.jongodb.testkit.ComplexQueryCertificationRunnerTest`

Closes #379
