### PR TITLE
feat(query): support mod/bitsAllSet and reduce unsupported debt

### DIFF
--- a/src/main/java/org/jongodb/testkit/ComplexQueryPatternPack.java
+++ b/src/main/java/org/jongodb/testkit/ComplexQueryPatternPack.java
@@ -784,10 +784,10 @@ public final class ComplexQueryPatternPack {
     private static PatternCase unsupportedQueryMod() {
         return pattern(
                 "cq.unsupported.query-mod",
-                "unsupported query operator mod",
-                SupportClass.EXPLICITLY_UNSUPPORTED,
-                ExpectedOutcome.UNSUPPORTED_POLICY,
-                "Documents out-of-scope operator behavior as deterministic unsupported policy.",
+                "query operator mod",
+                SupportClass.SUPPORTED,
+                ExpectedOutcome.MATCH,
+                "Validates modulo predicate semantics in query operator evaluation.",
                 "legacy modulo filtering",
                 command(
                         "insert",
@@ -875,10 +875,10 @@ public final class ComplexQueryPatternPack {
     private static PatternCase unsupportedQueryBitsAllSet() {
         return pattern(
                 "cq.unsupported.query-bitsallset",
-                "unsupported bitwise query operator",
-                SupportClass.EXPLICITLY_UNSUPPORTED,
-                ExpectedOutcome.UNSUPPORTED_POLICY,
-                "Tracks bitwise predicate operators as explicitly unsupported policy.",
+                "bitwise query operator bitsAllSet",
+                SupportClass.SUPPORTED,
+                ExpectedOutcome.MATCH,
+                "Covers bitwise mask predicate subset for feature-flag style filtering.",
                 "feature-flag bitmask query",
                 command(
                         "insert",

--- a/src/test/java/org/jongodb/engine/QueryMatcherTest.java
+++ b/src/test/java/org/jongodb/engine/QueryMatcherTest.java
@@ -98,6 +98,27 @@ class QueryMatcherTest {
     }
 
     @Test
+    void supportsModOperator() {
+        final Document document = new Document("qty", 6).append("samples", Arrays.asList(1, 2, 3));
+
+        assertTrue(QueryMatcher.matches(document, new Document("qty", new Document("$mod", List.of(2, 0)))));
+        assertFalse(QueryMatcher.matches(document, new Document("qty", new Document("$mod", List.of(4, 1)))));
+        assertTrue(QueryMatcher.matches(document, new Document("samples", new Document("$mod", List.of(3, 0)))));
+        assertFalse(QueryMatcher.matches(document, new Document("missing", new Document("$mod", List.of(2, 0)))));
+    }
+
+    @Test
+    void supportsBitsAllSetOperator() {
+        final Document document = new Document("flags", 3).append("moreFlags", Arrays.asList(4, 6));
+
+        assertTrue(QueryMatcher.matches(document, new Document("flags", new Document("$bitsAllSet", 1))));
+        assertTrue(QueryMatcher.matches(document, new Document("flags", new Document("$bitsAllSet", List.of(0, 1)))));
+        assertFalse(QueryMatcher.matches(document, new Document("flags", new Document("$bitsAllSet", 4))));
+        assertTrue(QueryMatcher.matches(document, new Document("moreFlags", new Document("$bitsAllSet", 2))));
+        assertFalse(QueryMatcher.matches(document, new Document("missing", new Document("$bitsAllSet", 1))));
+    }
+
+    @Test
     void supportsLogicalAndOrNotNorOperators() {
         Document document = new Document("role", "user").append("active", true).append("score", 7);
 


### PR DESCRIPTION
## Summary
- implement query operator support for `$mod` and `$bitsAllSet` in `QueryMatcher`
- update complex-query pattern pack so:
  - `cq.unsupported.query-mod` is now `SUPPORTED + MATCH`
  - `cq.unsupported.query-bitsallset` is now `SUPPORTED + MATCH`
- align `$expr` path semantics for array-index style paths with mongod behavior (`$metrics.0` no direct index interpretation)
- add/adjust regression coverage in:
  - `QueryMatcherTest` (`$mod`, `$bitsAllSet`, `$expr` array-index semantics)
  - `ComplexQueryPatternPackTest` (pattern-level execution checks)

## Impact
- reduces complex-query unsupported-policy debt by 2 patterns (from 4 -> 2)
- remaining explicit unsupported patterns are still tracked:
  - `cq.unsupported.expr-add`
  - `cq.unsupported.aggregate-graphlookup`

## Verification
- `./.tooling/gradle-8.10.2/bin/gradle --no-daemon --stacktrace test --tests org.jongodb.engine.QueryMatcherTest --tests org.jongodb.testkit.ComplexQueryPatternPackTest --tests org.jongodb.testkit.ComplexQueryCertificationRunnerTest`

Closes #380
