### PR TITLE
feat(real-mongod): enforce differential threshold gate policy (#384)

### DIFF
--- a/.github/workflows/real-mongod-baseline.yml
+++ b/.github/workflows/real-mongod-baseline.yml
@@ -2,6 +2,24 @@ name: Real Mongod Baseline
 
 on:
   workflow_dispatch:
+    inputs:
+      max_mismatch:
+        description: "Maximum allowed mismatches"
+        required: false
+        default: "0"
+      max_error:
+        description: "Maximum allowed errors"
+        required: false
+        default: "0"
+      min_pass_rate:
+        description: "Optional minimum pass rate [0.0, 1.0]"
+        required: false
+        default: "1.0"
+      fail_on_gate:
+        description: "Fail workflow when gate fails"
+        required: false
+        type: boolean
+        default: true
   schedule:
     - cron: "0 3 * * *"
 
@@ -21,6 +39,9 @@ jobs:
       REPLSET_WAIT_INTERVAL_SECONDS: "2"
       REPLSET_DIAGNOSTICS_DIR: build/reports/replset-diagnostics
       REAL_MONGOD_OUTPUT_DIR: build/reports/real-mongod-baseline
+      REAL_MONGOD_MAX_MISMATCH: "0"
+      REAL_MONGOD_MAX_ERROR: "0"
+      REAL_MONGOD_MIN_PASS_RATE: "1.0"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -43,7 +64,62 @@ jobs:
         run: |
           gradle --no-daemon --stacktrace \
             -PrealMongodOutputDir="${REAL_MONGOD_OUTPUT_DIR}" \
+            -PrealMongodMaxMismatch="${{ github.event.inputs.max_mismatch || env.REAL_MONGOD_MAX_MISMATCH }}" \
+            -PrealMongodMaxError="${{ github.event.inputs.max_error || env.REAL_MONGOD_MAX_ERROR }}" \
+            -PrealMongodMinPassRate="${{ github.event.inputs.min_pass_rate || env.REAL_MONGOD_MIN_PASS_RATE }}" \
+            -PrealMongodFailOnGate="${{ github.event.inputs.fail_on_gate || 'true' }}" \
             realMongodDifferentialBaseline
+
+      - name: Publish baseline trend summary
+        if: always()
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          report_path = Path("build/reports/real-mongod-baseline/real-mongod-differential-baseline.json")
+          trend_path = Path("build/reports/real-mongod-baseline/real-mongod-baseline-trend.md")
+          if not report_path.exists():
+              trend_path.parent.mkdir(parents=True, exist_ok=True)
+              trend_path.write_text("# Real Mongod Baseline Trend\n\n- report: missing\n", encoding="utf-8")
+              print("report is missing; wrote fallback trend summary")
+              if summary := os.environ.get("GITHUB_STEP_SUMMARY"):
+                  with open(summary, "a", encoding="utf-8") as fp:
+                      fp.write(trend_path.read_text(encoding="utf-8"))
+              raise SystemExit(0)
+
+          report = json.loads(report_path.read_text(encoding="utf-8"))
+          summary = report.get("summary", {})
+          gate = report.get("gate", {})
+          thresholds = gate.get("thresholds", {})
+          measured = gate.get("measured", {})
+
+          lines = [
+              "# Real Mongod Baseline Trend",
+              "",
+              f"- total={summary.get('total', 0)} match={summary.get('match', 0)} mismatch={summary.get('mismatch', 0)} error={summary.get('error', 0)}",
+              f"- passRate={summary.get('passRate', 0.0):.4f}",
+              f"- gate={gate.get('status', 'UNKNOWN')}",
+              f"- thresholds: maxMismatch={thresholds.get('maxMismatch', 'n/a')} maxError={thresholds.get('maxError', 'n/a')} minPassRate={thresholds.get('minPassRate', 'none')}",
+              f"- measured: mismatch={measured.get('mismatch', 'n/a')} error={measured.get('error', 'n/a')} passRate={measured.get('passRate', 0.0):.4f}",
+          ]
+          reasons = gate.get("failureReasons", [])
+          if reasons:
+              lines.append("- failures:")
+              for reason in reasons:
+                  lines.append(f"  - {reason}")
+          else:
+              lines.append("- failures: none")
+          lines.append("")
+
+          trend_path.parent.mkdir(parents=True, exist_ok=True)
+          trend_path.write_text("\n".join(lines), encoding="utf-8")
+          print(trend_path.read_text(encoding="utf-8"))
+          if summary_path := os.environ.get("GITHUB_STEP_SUMMARY"):
+              with open(summary_path, "a", encoding="utf-8") as fp:
+                  fp.write(trend_path.read_text(encoding="utf-8"))
+          PY
 
       - name: Collect replica set diagnostics
         if: always()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -214,14 +214,24 @@ tasks.register<JavaExec>("realMongodDifferentialBaseline") {
     val seed = (findProperty("realMongodSeed") as String?) ?: "wire-vs-real-mongod-baseline-v1"
     val scenarioCount = (findProperty("realMongodScenarioCount") as String?) ?: "2000"
     val topRegressions = (findProperty("realMongodTopRegressions") as String?) ?: "10"
+    val maxMismatch = (findProperty("realMongodMaxMismatch") as String?) ?: "0"
+    val maxError = (findProperty("realMongodMaxError") as String?) ?: "0"
+    val minPassRate = (findProperty("realMongodMinPassRate") as String?)?.trim().orEmpty()
+    val failOnGate = (findProperty("realMongodFailOnGate") as String?)?.toBoolean() ?: true
     val mongoUri = (findProperty("realMongodUri") as String?) ?: (System.getenv("JONGODB_REAL_MONGOD_URI") ?: "")
 
     args(
         "--output-dir=$outputDir",
         "--seed=$seed",
         "--scenario-count=$scenarioCount",
-        "--top-regressions=$topRegressions"
+        "--top-regressions=$topRegressions",
+        "--max-mismatch=$maxMismatch",
+        "--max-error=$maxError",
+        if (failOnGate) "--fail-on-gate" else "--no-fail-on-gate"
     )
+    if (minPassRate.isNotBlank()) {
+        args("--min-pass-rate=$minPassRate")
+    }
     if (mongoUri.isNotBlank()) {
         args("--mongo-uri=$mongoUri")
     }

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -145,8 +145,19 @@ Official Suite Sharded UTF gate modes:
 Run differential baseline against real MongoDB:
 
 ```bash
-gradle realMongodDifferentialBaseline -PrealMongodUri="mongodb://localhost:27017"
+gradle realMongodDifferentialBaseline \
+  -PrealMongodUri="mongodb://localhost:27017" \
+  -PrealMongodMaxMismatch=0 \
+  -PrealMongodMaxError=0 \
+  -PrealMongodMinPassRate=1.0 \
+  -PrealMongodFailOnGate=true
 ```
+
+`realMongodDifferentialBaseline` gate options:
+- `realMongodMaxMismatch` (default `0`)
+- `realMongodMaxError` (default `0`)
+- `realMongodMinPassRate` (optional, range `0.0..1.0`)
+- `realMongodFailOnGate` (`true` by default)
 
 Run UTF corpus evidence:
 


### PR DESCRIPTION
## Summary
- add explicit real-mongod baseline gate thresholds (`maxMismatch`, `maxError`, optional `minPassRate`) in `RealMongodCorpusRunner`
- support `--fail-on-gate/--no-fail-on-gate` process behavior and emit gate status/reasons into JSON + markdown artifacts
- wire new Gradle properties (`realMongodMaxMismatch`, `realMongodMaxError`, `realMongodMinPassRate`, `realMongodFailOnGate`)
- update real-mongod baseline workflow with schedule/manual threshold inputs and publish `real-mongod-baseline-trend.md` + step summary
- document gate options in `docs/USAGE.md` and add unit tests for threshold parsing/evaluation

## Validation
- `./.tooling/gradle-8.10.2/bin/gradle --no-daemon --stacktrace test --tests org.jongodb.testkit.RealMongodCorpusRunnerTest --tests org.jongodb.testkit.RealMongodCorpusRunnerIntegrationTest`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/real-mongod-baseline.yml"); puts "yaml-ok"'`

Closes #384
