### PR TITLE
feat(spring-matrix): expand scenario/target scope and pattern mapping (#381)

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -210,6 +210,12 @@ gradle springCompatibilityMatrixEvidence
 
 Spring matrix artifacts include a dedicated `Complex Query Matrix` section aligned with
 `docs/COMPLEX_QUERY_CERTIFICATION.md` pattern IDs.
+Current default catalog scope:
+- targets: 5
+- scenarios: 15
+- certification-mapped scenarios: 8
+Artifact summaries now include a `Certification Pattern Mapping` section
+(`scenarioId ↔ certificationPatternId`) for quick cross-reference with certification runs.
 CI workflow: `.github/workflows/spring-complex-query-matrix.yml`
 
 Run R2 compatibility scorecard + support manifest:

--- a/testkit/spring-suite/src/test/java/org/jongodb/testkit/springsuite/SpringCompatibilityMatrixRunnerTest.java
+++ b/testkit/spring-suite/src/test/java/org/jongodb/testkit/springsuite/SpringCompatibilityMatrixRunnerTest.java
@@ -23,12 +23,18 @@ class SpringCompatibilityMatrixRunnerTest {
 
     @Test
     void defaultCatalogIncludesMultipleProjectTargetsAndScenarioCoverage() {
-        assertTrue(SpringCompatibilityMatrixRunner.defaultTargets().size() >= 4);
-        assertTrue(SpringCompatibilityMatrixRunner.defaultScenarios().size() >= 5);
+        assertTrue(SpringCompatibilityMatrixRunner.defaultTargets().size() >= 5);
+        assertTrue(SpringCompatibilityMatrixRunner.defaultScenarios().size() >= 15);
         assertTrue(
             SpringCompatibilityMatrixRunner.defaultScenarios().stream()
                 .anyMatch(SpringCompatibilityMatrixRunner.SpringScenario::isComplexQueryScenario),
             "expected at least one complex query scenario"
+        );
+        assertTrue(
+            SpringCompatibilityMatrixRunner.defaultScenarios().stream()
+                .filter(scenario -> scenario.certificationPatternId() != null)
+                .count() >= 8,
+            "expected expanded certification pattern mapping coverage"
         );
     }
 
@@ -108,18 +114,23 @@ class SpringCompatibilityMatrixRunnerTest {
         assertTrue(json.contains("\"surfaceSummary\""));
         assertTrue(json.contains("\"complexQuerySummary\""));
         assertTrue(json.contains("\"complexQueryScenarios\""));
+        assertTrue(json.contains("\"certificationPatternMapping\""));
         assertTrue(json.contains("\"certificationPatternId\""));
         assertTrue(json.contains("\"scenarioId\":\"spring.mongo-template.basic-crud\""));
         assertTrue(json.contains("\"scenarioId\":\"spring.transaction-template.multi-template.same-manager\""));
         assertTrue(json.contains("\"scenarioId\":\"spring.complex.aggregation.lookup-unwind-group\""));
+        assertTrue(json.contains("\"scenarioId\":\"spring.complex.query.array-index-comparison\""));
+        assertTrue(json.contains("\"scenarioId\":\"spring.complex.query.deep-array-document\""));
         assertTrue(json.contains("\"failureMinimization\":[]"));
 
         assertTrue(markdown.contains("# Spring Data Mongo Compatibility Matrix"));
         assertTrue(markdown.contains("## Matrix"));
         assertTrue(markdown.contains("## Complex Query Matrix"));
+        assertTrue(markdown.contains("## Certification Pattern Mapping"));
         assertTrue(markdown.contains("## Failure Minimization"));
         assertTrue(markdown.contains("spring.transaction-template.out-of-scope.same-namespace-interleaving"));
         assertTrue(markdown.contains("spring.complex.query.nested-criteria"));
+        assertTrue(markdown.contains("spring.complex.query.expr-array-index-comparison"));
         assertTrue(markdown.contains("| spring.transaction-template.commit | TransactionTemplate | PASS | PASS |"));
 
         assertEquals(0, report.failCount());


### PR DESCRIPTION
## Summary
- expand Spring matrix target catalog with one additional profile line (`analytics-boot-3.4-data-4.4`)
- expand scenario catalog with 3 new complex-query aligned scenarios:
  - `spring.complex.query.expr-array-index-comparison` -> `cq.expr.array-index-comparison`
  - `spring.complex.query.array-index-comparison` -> `cq.path.array-index-comparison`
  - `spring.complex.query.deep-array-document` -> `cq.path.deep-array-document`
- add a dedicated `Certification Pattern Mapping` section in matrix markdown artifacts
- add `certificationPatternMapping` section in matrix JSON artifacts
- update usage docs with expanded matrix scope and mapping summary guidance
- update/strengthen Spring matrix tests for expanded coverage and mapping artifacts

## Validation
- `./.tooling/gradle-8.10.2/bin/gradle --no-daemon --stacktrace test --tests org.jongodb.testkit.springsuite.SpringCompatibilityMatrixRunnerTest`
- `./.tooling/gradle-8.10.2/bin/gradle --no-daemon --stacktrace springCompatibilityMatrixEvidence -PspringMatrixOutputDir="build/reports/spring-matrix-local" -PspringMatrixFailOnFailures=true`

Closes #381
