### PR TITLE
[phase:r3] Close #396: support $expr $add certification subset

### DIFF
--- a/docs/COMPLEX_QUERY_CERTIFICATION.md
+++ b/docs/COMPLEX_QUERY_CERTIFICATION.md
@@ -11,7 +11,7 @@ It complements the broad scorecard/failure-ledger view with a focused complex-qu
 
 ## Pack Metadata
 
-- pack version: `complex-query-pack-v1`
+- pack version: `complex-query-pack-v2`
 - canonical pattern count: `24`
 - support classes:
   - `supported`
@@ -55,6 +55,9 @@ The above metadata is published in artifact JSON under:
 - `cq.exists-null-in`
 - `cq.type-and-size`
 - `cq.nested.array-branch-composition`
+- `cq.unsupported.query-mod`
+- `cq.unsupported.expr-add`
+- `cq.unsupported.query-bitsallset`
 
 ### Partial
 
@@ -67,10 +70,7 @@ The above metadata is published in artifact JSON under:
 
 ### Explicitly Unsupported
 
-- `cq.unsupported.query-mod`
-- `cq.unsupported.expr-add`
 - `cq.unsupported.aggregate-graphlookup`
-- `cq.unsupported.query-bitsallset`
 
 ## Runner
 

--- a/src/main/java/org/jongodb/testkit/ComplexQueryPatternPack.java
+++ b/src/main/java/org/jongodb/testkit/ComplexQueryPatternPack.java
@@ -10,7 +10,7 @@ import java.util.Objects;
  * Canonical complex-query certification pattern pack.
  */
 public final class ComplexQueryPatternPack {
-    public static final String PACK_VERSION = "complex-query-pack-v1";
+    public static final String PACK_VERSION = "complex-query-pack-v2";
 
     private static final List<PatternCase> PATTERNS = List.of(
             nestedLogicAndOrDotted(),
@@ -808,10 +808,10 @@ public final class ComplexQueryPatternPack {
     private static PatternCase unsupportedExprAdd() {
         return pattern(
                 "cq.unsupported.expr-add",
-                "unsupported expr add operator",
-                SupportClass.EXPLICITLY_UNSUPPORTED,
-                ExpectedOutcome.UNSUPPORTED_POLICY,
-                "Marks unsupported $expr arithmetic operator subset as explicit policy.",
+                "expr add arithmetic operator",
+                SupportClass.SUPPORTED,
+                ExpectedOutcome.MATCH,
+                "Validates certification subset for $expr arithmetic with $add.",
                 "inline total-cost expression",
                 command(
                         "insert",

--- a/src/test/java/org/jongodb/engine/QueryMatcherTest.java
+++ b/src/test/java/org/jongodb/engine/QueryMatcherTest.java
@@ -383,6 +383,32 @@ class QueryMatcherTest {
     }
 
     @Test
+    void supportsExprAddOperatorForNumericOperands() {
+        final Document document = new Document("price", 100).append("tax", 20).append("discount", -5);
+
+        assertTrue(
+                QueryMatcher.matches(
+                        document,
+                        new Document(
+                                "$expr",
+                                new Document("$eq", List.of(new Document("$add", List.of("$price", "$tax")), 120)))));
+        assertTrue(
+                QueryMatcher.matches(
+                        document,
+                        new Document(
+                                "$expr",
+                                new Document(
+                                        "$gt",
+                                        List.of(new Document("$add", List.of("$price", "$tax", "$discount")), 110)))));
+        assertFalse(
+                QueryMatcher.matches(
+                        document,
+                        new Document(
+                                "$expr",
+                                new Document("$eq", List.of(new Document("$add", List.of("$price", "$missing")), 100)))));
+    }
+
+    @Test
     void supportsExprPathResolutionWithArrayIndexes() {
         final Document document =
                 new Document("metrics", List.of(5, 2, 1))
@@ -445,6 +471,12 @@ class QueryMatcherTest {
                         QueryMatcher.matches(
                                 document,
                                 new Document("$expr", new Document("$eq", List.of("$score")))));
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        QueryMatcher.matches(
+                                document,
+                                new Document("$expr", new Document("$add", List.of("$score", "x")))));
         assertThrows(
                 IllegalArgumentException.class,
                 () ->

--- a/src/test/java/org/jongodb/testkit/ComplexQueryPatternPackTest.java
+++ b/src/test/java/org/jongodb/testkit/ComplexQueryPatternPackTest.java
@@ -34,7 +34,7 @@ class ComplexQueryPatternPackTest {
             }
         }
 
-        assertTrue(explicitlyUnsupportedCount >= 2, "expected explicit unsupported coverage in pattern pack");
+        assertTrue(explicitlyUnsupportedCount >= 1, "expected explicit unsupported coverage in pattern pack");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add `$expr.$add` evaluation support in `QueryMatcher` for certification-relevant numeric operands
- make `$expr` equality numeric-aware across numeric types so arithmetic output compares correctly
- reclassify `cq.unsupported.expr-add` from `EXPLICITLY_UNSUPPORTED/UNSUPPORTED_POLICY` to `SUPPORTED/MATCH`
- bump complex-query pack metadata to `complex-query-pack-v2` and refresh certification doc pattern classification

## Validation
- `./.tooling/gradle-8.10.2/bin/gradle --no-daemon --stacktrace test --tests org.jongodb.engine.QueryMatcherTest --tests org.jongodb.testkit.ComplexQueryPatternPackTest`
- `scripts/ci/bootstrap-replset.sh`
- `./.tooling/gradle-8.10.2/bin/gradle --no-daemon --stacktrace -PcomplexQueryOutputDir="build/reports/complex-query-certification-local" -PcomplexQueryMongoUri="mongodb://127.0.0.1:27017/?replicaSet=rs0&retryWrites=false&directConnection=true" -PcomplexQueryFailOnGate=true complexQueryCertificationEvidence`
- `scripts/ci/teardown-replset.sh`

## Evidence
- local certification summary: `packVersion=complex-query-pack-v2`, `supportedPatterns=17`, `unsupportedByPolicyCount=1`, `mismatchCount=0`, `errorCount=0`
- `cq.unsupported.expr-add` status in artifact JSON: `match` with `expectationSatisfied=true`

Closes #396
