### PR TITLE
[phase:r3] Close #397: minimal $graphLookup certification subset

### DIFF
--- a/docs/COMPLEX_QUERY_CERTIFICATION.md
+++ b/docs/COMPLEX_QUERY_CERTIFICATION.md
@@ -11,7 +11,7 @@ It complements the broad scorecard/failure-ledger view with a focused complex-qu
 
 ## Pack Metadata
 
-- pack version: `complex-query-pack-v2`
+- pack version: `complex-query-pack-v3`
 - canonical pattern count: `24`
 - support classes:
   - `supported`
@@ -67,10 +67,23 @@ The above metadata is published in artifact JSON under:
 - `cq.aggregate.sortbycount-after-project`
 - `cq.aggregate.unionwith-and-match`
 - `cq.expr.array-index-comparison`
+- `cq.unsupported.aggregate-graphlookup`
 
 ### Explicitly Unsupported
 
-- `cq.unsupported.aggregate-graphlookup`
+- _(none in current canonical pack)_
+
+### `$graphLookup` Certification Subset
+
+Supported option set in current engine subset:
+- `from`
+- `startWith`
+- `connectFromField`
+- `connectToField`
+- `as`
+- `maxDepth` (optional non-negative integer)
+
+Out-of-subset options (for example `depthField`, `restrictSearchWithMatch`) are rejected as `NotImplemented` by design.
 
 ## Runner
 

--- a/src/main/java/org/jongodb/testkit/ComplexQueryPatternPack.java
+++ b/src/main/java/org/jongodb/testkit/ComplexQueryPatternPack.java
@@ -10,7 +10,7 @@ import java.util.Objects;
  * Canonical complex-query certification pattern pack.
  */
 public final class ComplexQueryPatternPack {
-    public static final String PACK_VERSION = "complex-query-pack-v2";
+    public static final String PACK_VERSION = "complex-query-pack-v3";
 
     private static final List<PatternCase> PATTERNS = List.of(
             nestedLogicAndOrDotted(),
@@ -834,10 +834,10 @@ public final class ComplexQueryPatternPack {
     private static PatternCase unsupportedAggregateGraphLookup() {
         return pattern(
                 "cq.unsupported.aggregate-graphlookup",
-                "unsupported graphLookup stage",
-                SupportClass.EXPLICITLY_UNSUPPORTED,
-                ExpectedOutcome.UNSUPPORTED_POLICY,
-                "Keeps unsupported complex join stage under deterministic explicit policy.",
+                "graphLookup stage (minimal subset)",
+                SupportClass.PARTIAL,
+                ExpectedOutcome.MATCH,
+                "Validates minimal graph traversal subset for certification hierarchy expansion.",
                 "hierarchy traversal",
                 command(
                         "insert",

--- a/src/test/java/org/jongodb/testkit/ComplexQueryPatternPackTest.java
+++ b/src/test/java/org/jongodb/testkit/ComplexQueryPatternPackTest.java
@@ -34,7 +34,7 @@ class ComplexQueryPatternPackTest {
             }
         }
 
-        assertTrue(explicitlyUnsupportedCount >= 1, "expected explicit unsupported coverage in pattern pack");
+        assertEquals(0, explicitlyUnsupportedCount, "expected no explicitly unsupported patterns in pack");
     }
 
     @Test
@@ -47,7 +47,7 @@ class ComplexQueryPatternPackTest {
     }
 
     @Test
-    void queryModAndBitsAllSetPatternsExecuteAsSupportedMatches() {
+    void queryModBitsAllSetAndGraphLookupPatternsExecuteAsSupportedMatches() {
         final WireCommandIngressBackend backend = new WireCommandIngressBackend("wire");
 
         final ScenarioOutcome modOutcome = backend.execute(findPattern("cq.unsupported.query-mod").scenario());
@@ -57,6 +57,13 @@ class ComplexQueryPatternPackTest {
         final ScenarioOutcome bitsOutcome = backend.execute(findPattern("cq.unsupported.query-bitsallset").scenario());
         assertTrue(bitsOutcome.success(), bitsOutcome.errorMessage().orElse("expected bitsAllSet scenario success"));
         assertEquals(1, findFirstBatchSize(bitsOutcome));
+
+        final ScenarioOutcome graphLookupOutcome =
+                backend.execute(findPattern("cq.unsupported.aggregate-graphlookup").scenario());
+        assertTrue(
+                graphLookupOutcome.success(),
+                graphLookupOutcome.errorMessage().orElse("expected graphLookup scenario success"));
+        assertEquals(3, findFirstBatchSize(graphLookupOutcome));
     }
 
     private static ComplexQueryPatternPack.PatternCase findPattern(final String patternId) {


### PR DESCRIPTION
## Summary
- add minimal `$graphLookup` stage support to `AggregationPipeline` with deterministic traversal behavior for certification use cases
- support option subset: `from`, `startWith`, `connectFromField`, `connectToField`, `as`, optional `maxDepth`
- reject out-of-subset `$graphLookup` options as `NotImplemented` to keep boundaries explicit
- reclassify `cq.unsupported.aggregate-graphlookup` to `PARTIAL/MATCH` and bump pack version to `complex-query-pack-v3`
- document the certification subset boundaries in `docs/COMPLEX_QUERY_CERTIFICATION.md`

## Validation
- `./.tooling/gradle-8.10.2/bin/gradle --no-daemon --stacktrace test --tests org.jongodb.command.AggregateCommandE2ETest --tests org.jongodb.testkit.ComplexQueryPatternPackTest`
- `scripts/ci/bootstrap-replset.sh`
- `./.tooling/gradle-8.10.2/bin/gradle --no-daemon --stacktrace -PcomplexQueryOutputDir="build/reports/complex-query-certification-local" -PcomplexQueryMongoUri="mongodb://127.0.0.1:27017/?replicaSet=rs0&retryWrites=false&directConnection=true" -PcomplexQueryFailOnGate=true complexQueryCertificationEvidence`
- `scripts/ci/teardown-replset.sh`

## Evidence
- local certification summary: `packVersion=complex-query-pack-v3`, `supportedPatterns=17`, `mismatchCount=0`, `errorCount=0`, `unsupportedByPolicyCount=0`
- `cq.unsupported.aggregate-graphlookup` status: `match` (`expectationSatisfied=true`)
- `cq.unsupported.expr-add` remains `match` (`expectationSatisfied=true`)

Closes #397
