### PR TITLE
feat(testkit): evaluate test-level runOn requirements and preserve ledger parity

### DIFF
--- a/src/main/java/org/jongodb/command/CommandStore.java
+++ b/src/main/java/org/jongodb/command/CommandStore.java
@@ -108,7 +108,11 @@ public interface CommandStore {
         }
     }
 
-    record CreateIndexesResult(int numIndexesBefore, int numIndexesAfter) {}
+    record CreateIndexesResult(int numIndexesBefore, int numIndexesAfter, boolean createdCollectionAutomatically) {
+        public CreateIndexesResult(final int numIndexesBefore, final int numIndexesAfter) {
+            this(numIndexesBefore, numIndexesAfter, false);
+        }
+    }
 
     record IndexMetadata(
             String name,

--- a/src/main/java/org/jongodb/command/CreateIndexesCommandHandler.java
+++ b/src/main/java/org/jongodb/command/CreateIndexesCommandHandler.java
@@ -119,11 +119,18 @@ public final class CreateIndexesCommandHandler implements CommandHandler {
             return CommandErrors.duplicateKey(exception.getMessage());
         }
 
-        return new BsonDocument()
-                .append("createdCollectionAutomatically", BsonBoolean.FALSE)
+        final BsonDocument response = new BsonDocument()
+                .append(
+                        "createdCollectionAutomatically",
+                        BsonBoolean.valueOf(result.createdCollectionAutomatically()))
                 .append("numIndexesBefore", new BsonInt32(result.numIndexesBefore()))
                 .append("numIndexesAfter", new BsonInt32(result.numIndexesAfter()))
                 .append("ok", new BsonDouble(1.0));
+        final BsonValue commitQuorum = command.get("commitQuorum");
+        response.append(
+                "commitQuorum",
+                commitQuorum == null ? new BsonString("votingMembers") : commitQuorum);
+        return response;
     }
 
     private static String readDatabase(final BsonDocument command) {

--- a/src/main/java/org/jongodb/command/EngineBackedCommandStore.java
+++ b/src/main/java/org/jongodb/command/EngineBackedCommandStore.java
@@ -174,6 +174,7 @@ public final class EngineBackedCommandStore implements CommandStore {
     public CreateIndexesResult createIndexes(
             final String database, final String collection, final List<IndexRequest> indexes) {
         Objects.requireNonNull(indexes, "indexes");
+        final boolean existedBefore = engineStore.collectionExists(database, collection);
         final CollectionStore collectionStore = engineStore.collection(database, collection);
 
         final List<CollectionStore.IndexDefinition> converted = new ArrayList<>(indexes.size());
@@ -190,7 +191,7 @@ public final class EngineBackedCommandStore implements CommandStore {
         }
 
         final CollectionStore.CreateIndexesResult result = collectionStore.createIndexes(List.copyOf(converted));
-        return new CreateIndexesResult(result.numIndexesBefore(), result.numIndexesAfter());
+        return new CreateIndexesResult(result.numIndexesBefore(), result.numIndexesAfter(), !existedBefore);
     }
 
     @Override

--- a/src/main/java/org/jongodb/engine/EngineStore.java
+++ b/src/main/java/org/jongodb/engine/EngineStore.java
@@ -6,7 +6,15 @@ package org.jongodb.engine;
 public interface EngineStore {
     CollectionStore collection(Namespace namespace);
 
+    default boolean collectionExists(final Namespace namespace) {
+        return false;
+    }
+
     default CollectionStore collection(String database, String collection) {
         return collection(Namespace.of(database, collection));
+    }
+
+    default boolean collectionExists(final String database, final String collection) {
+        return collectionExists(Namespace.of(database, collection));
     }
 }

--- a/src/main/java/org/jongodb/engine/InMemoryEngineStore.java
+++ b/src/main/java/org/jongodb/engine/InMemoryEngineStore.java
@@ -20,6 +20,12 @@ public final class InMemoryEngineStore implements EngineStore {
         return collections.computeIfAbsent(namespace, key -> new InMemoryCollectionStore());
     }
 
+    @Override
+    public boolean collectionExists(final Namespace namespace) {
+        Objects.requireNonNull(namespace, "namespace");
+        return collections.containsKey(namespace);
+    }
+
     public synchronized InMemoryEngineStore snapshot() {
         final InMemoryEngineStore snapshot = new InMemoryEngineStore();
         for (final var entry : collections.entrySet()) {

--- a/src/test/java/org/jongodb/command/CommandDispatcherE2ETest.java
+++ b/src/test/java/org/jongodb/command/CommandDispatcherE2ETest.java
@@ -623,6 +623,7 @@ class CommandDispatcherE2ETest {
         assertEquals(false, response.getBoolean("createdCollectionAutomatically").getValue());
         assertEquals(0, response.getInt32("numIndexesBefore").getValue());
         assertEquals(1, response.getInt32("numIndexesAfter").getValue());
+        assertEquals("votingMembers", response.getString("commitQuorum").getValue());
         assertEquals("app", store.lastCreateIndexesDatabase);
         assertEquals("users", store.lastCreateIndexesCollection);
         assertEquals(1, store.lastCreateIndexesRequests.size());
@@ -660,6 +661,19 @@ class CommandDispatcherE2ETest {
         assertEquals("en", store.lastCreateIndexesRequests.get(0).collation().getString("locale").getValue());
         assertEquals(2, store.lastCreateIndexesRequests.get(0).collation().getInt32("strength").getValue());
         assertEquals(3600L, store.lastCreateIndexesRequests.get(0).expireAfterSeconds());
+    }
+
+    @Test
+    void createIndexesCommandEchoesCommitQuorumInResponse() {
+        final RecordingStore store = new RecordingStore();
+        store.createIndexesResult = new CommandStore.CreateIndexesResult(0, 1);
+        final CommandDispatcher dispatcher = new CommandDispatcher(store);
+
+        final BsonDocument response = dispatcher.dispatch(BsonDocument.parse(
+                "{\"createIndexes\":\"users\",\"$db\":\"app\",\"commitQuorum\":\"majority\",\"indexes\":[{\"name\":\"email_1\",\"key\":{\"email\":1}}]}"));
+
+        assertEquals(1.0, response.get("ok").asNumber().doubleValue());
+        assertEquals("majority", response.getString("commitQuorum").getValue());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- evaluate test-level `runOnRequirements` when runtime context is available (same as file-level runOn)
- preserve parity by explicitly filtering unsupported `let` options and unsupported `$merge` aggregate stage at importer boundary
- align createIndexes compatibility details for newly imported scenarios:
  - importer forwards/defaults `commitQuorum`
  - command response includes `commitQuorum`
  - `createdCollectionAutomatically` now reflects collection existence

## Validation
- `./.tooling/gradle-8.10.2/bin/gradle --no-daemon test --tests org.jongodb.testkit.UnifiedSpecImporterTest --tests org.jongodb.command.CommandDispatcherE2ETest`
- `./.tooling/gradle-8.10.2/bin/gradle --no-daemon -Pr3SpecRepoRoot="/tmp/jongodb-r4/specifications" -Pr3FailureLedgerOutputDir="/tmp/jongodb-r4/r3-ledger-after-v6" -Pr3FailureLedgerMongoUri="mongodb://127.0.0.1:27017/?replicaSet=rs0" -Pr3FailureLedgerFailOnFailures=true r3FailureLedger`

## Impact (R3 ledger local comparison)
- baseline(main): imported=508 skipped=851 unsupported=222 mismatch=0 error=0
- after patch: imported=700 skipped=533 unsupported=348 mismatch=0 error=0
- delta: imported +192, skipped -318, unsupported +126, mismatch 0 유지

Closes #404
