### PR TITLE
feat(testkit): support estimatedDocumentCount UTF subset

### DIFF
--- a/src/main/java/org/jongodb/testkit/RealMongodBackend.java
+++ b/src/main/java/org/jongodb/testkit/RealMongodBackend.java
@@ -629,6 +629,8 @@ public final class RealMongodBackend implements DifferentialBackend {
         final ScenarioCommand command,
         final BsonDocument responseBody
     ) {
+        final boolean countCommand = "count".equals(command.commandName());
+        final boolean countDocumentsCommand = "countDocuments".equals(command.commandName());
         if ("distinct".equals(command.commandName())) {
             final BsonValue valuesValue = responseBody.get("values");
             if (valuesValue != null && valuesValue.isArray()) {
@@ -637,10 +639,13 @@ public final class RealMongodBackend implements DifferentialBackend {
             return responseBody;
         }
 
-        if (!"countDocuments".equals(command.commandName())) {
+        if (!countCommand && !countDocumentsCommand) {
             return responseBody;
         }
         if (!responseBody.containsKey("n") || responseBody.containsKey("count")) {
+            if (countCommand) {
+                return responseBody;
+            }
             final BsonValue cursorValue = responseBody.get("cursor");
             if (cursorValue == null || !cursorValue.isDocument()) {
                 return responseBody;

--- a/src/main/java/org/jongodb/testkit/UnifiedSpecImporter.java
+++ b/src/main/java/org/jongodb/testkit/UnifiedSpecImporter.java
@@ -250,6 +250,7 @@ public final class UnifiedSpecImporter {
             case "aggregate" -> aggregate(arguments, database, collection);
             case "count" -> countDocuments(arguments, database, collection);
             case "countDocuments" -> countDocuments(arguments, database, collection);
+            case "estimatedDocumentCount" -> estimatedDocumentCount(arguments, database, collection);
             case "distinct" -> distinct(arguments, database, collection);
             case "updateOne" -> update(arguments, database, collection, false);
             case "updateMany" -> update(arguments, database, collection, true);
@@ -337,6 +338,18 @@ public final class UnifiedSpecImporter {
         copyIfPresent(arguments, payload, "hint");
         copyIfPresent(arguments, payload, "collation");
         return new ScenarioCommand("countDocuments", immutableMap(payload));
+    }
+
+    private static ScenarioCommand estimatedDocumentCount(
+            final Map<String, Object> arguments,
+            final String database,
+            final String collection) {
+        final Map<String, Object> payload = commandEnvelope("count", database, collection);
+        payload.put("query", Map.of());
+        copyIfPresent(arguments, payload, "maxTimeMS");
+        copyIfPresent(arguments, payload, "comment");
+        // In the current strict lane (<8.2), rawData must be ignored.
+        return new ScenarioCommand("count", immutableMap(payload));
     }
 
     private static ScenarioCommand distinct(


### PR DESCRIPTION
## Summary
- add UTF importer adapter for `estimatedDocumentCount` using deterministic `count` command subset
- support `maxTimeMS` and `comment` passthrough; ignore `rawData` in current strict (<8.2) lane
- normalize real-mongod `count` responses to include `count` alias for differential parity
- add importer/backend tests for the new subset

## Validation
- `./.tooling/gradle-8.10.2/bin/gradle --no-daemon test --tests org.jongodb.testkit.UnifiedSpecImporterTest --tests org.jongodb.testkit.RealMongodBackendTest`
- `./.tooling/gradle-8.10.2/bin/gradle --no-daemon -Pr3SpecRepoRoot="/tmp/jongodb-r4/specifications" -Pr3FailureLedgerOutputDir="/tmp/jongodb-r4/r3-ledger-after-wave2" -Pr3FailureLedgerMongoUri="mongodb://127.0.0.1:27017/?replicaSet=rs0" -Pr3FailureLedgerFailOnFailures=true r3FailureLedger`

## Impact
- baseline(main): imported=508 skipped=851 unsupported=222 mismatch=0 error=0
- after wave1 + this change: imported=716 skipped=533 unsupported=332 mismatch=0 error=0
- net delta vs baseline: imported +208, skipped -318, unsupported +110
- specific bucket: `unsupported UTF operation: estimatedDocumentCount` reduced to 0 in local strict run

Closes #407
