### PR TITLE
[phase:r4] Support UTF insertMany ordered=false subset

### DIFF
--- a/src/main/java/org/jongodb/testkit/UnifiedSpecImporter.java
+++ b/src/main/java/org/jongodb/testkit/UnifiedSpecImporter.java
@@ -294,9 +294,6 @@ public final class UnifiedSpecImporter {
             final Map<String, Object> arguments,
             final String database,
             final String collection) {
-        if (Boolean.FALSE.equals(arguments.get("ordered"))) {
-            throw new UnsupportedOperationException("unsupported UTF insertMany option: ordered=false");
-        }
         final List<Object> documents = asList(arguments.get("documents"), "insertMany.arguments.documents");
         final List<Object> copied = new ArrayList<>(documents.size());
         for (final Object document : documents) {
@@ -305,6 +302,7 @@ public final class UnifiedSpecImporter {
         }
         final Map<String, Object> payload = commandEnvelope("insert", database, collection);
         payload.put("documents", List.copyOf(copied));
+        copyIfPresent(arguments, payload, "ordered");
         return new ScenarioCommand("insert", immutableMap(payload));
     }
 


### PR DESCRIPTION
## Summary
- Expand UTF importer subset to allow `insertMany` with `ordered: false`.
- Keep payload parity by forwarding `ordered` to the emitted `insert` command.
- Update importer tests to reflect the new subset and preserve arrayFilters regression coverage.

## Evidence (local UTF shard, strict lane)
Before (`build/reports/utf-shard-wave3d`):
- imported=756, skipped=537, unsupported=288, mismatch=0, error=0

After (`build/reports/utf-shard-issue419`):
- imported=760, skipped=537, unsupported=284, mismatch=0, error=0

Delta:
- imported **+4**
- unsupported **-4**
- mismatch/error unchanged at **0**

Reason removed:
- `unsupported UTF insertMany option: ordered=false` (4 -> 0)

## Validation
- `./.tooling/gradle-8.10.2/bin/gradle --no-daemon test --tests org.jongodb.testkit.UnifiedSpecImporterTest`
- `./scripts/ci/run-utf-shard.sh --spec-repo-root third_party/mongodb-specs/.checkout/specifications --shard-index 0 --shard-count 1 --output-dir build/reports/utf-shard-issue419 --seed issue419-20260228 --mongo-uri 'mongodb://127.0.0.1:27017/?replicaSet=rs0&retryWrites=false&directConnection=true' --gradle-cmd './.tooling/gradle-8.10.2/bin/gradle'`

Closes #419
