### PR TITLE
[phase:r4] Reduce replacement multi=true unsupported bucket (bulk paths)

### DIFF
--- a/src/main/java/org/jongodb/testkit/UnifiedSpecImporter.java
+++ b/src/main/java/org/jongodb/testkit/UnifiedSpecImporter.java
@@ -516,18 +516,6 @@ public final class UnifiedSpecImporter {
         return new ScenarioCommand("replaceOne", immutableMap(payload));
     }
 
-    private static boolean isReplacementDocument(final Object rawUpdate) {
-        if (!(rawUpdate instanceof Map<?, ?> mapped) || mapped.isEmpty()) {
-            return false;
-        }
-        for (final Object key : mapped.keySet()) {
-            if (!(key instanceof String field) || !field.startsWith("$")) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     private static boolean containsUnsupportedKeyPath(final Object value) {
         if (value instanceof Map<?, ?> mapValue) {
             for (final Map.Entry<?, ?> entry : mapValue.entrySet()) {
@@ -546,6 +534,18 @@ public final class UnifiedSpecImporter {
                 if (containsUnsupportedKeyPath(item)) {
                     return true;
                 }
+            }
+        }
+        return false;
+    }
+
+    private static boolean isReplacementDocument(final Object rawUpdate) {
+        if (!(rawUpdate instanceof Map<?, ?> mapped) || mapped.isEmpty()) {
+            return false;
+        }
+        for (final Object key : mapped.keySet()) {
+            if (!(key instanceof String field) || !field.startsWith("$")) {
+                return true;
             }
         }
         return false;
@@ -681,9 +681,6 @@ public final class UnifiedSpecImporter {
             throw new IllegalArgumentException("bulkWrite update operation requires update argument");
         }
         validateSupportedUpdatePipeline(updateValue);
-        if (multi && isReplacementDocument(updateValue)) {
-            throw new UnsupportedOperationException("unsupported UTF replacement update with multi=true");
-        }
     }
 
     private static void validateSupportedUpdatePipeline(final Object updateValue) {

--- a/src/test/java/org/jongodb/testkit/UnifiedSpecImporterTest.java
+++ b/src/test/java/org/jongodb/testkit/UnifiedSpecImporterTest.java
@@ -538,6 +538,50 @@ class UnifiedSpecImporterTest {
     }
 
     @Test
+    void importsBulkReplacementUpdateWithMultiTrueForRuntimeValidation() throws IOException {
+        Files.writeString(
+                tempDir.resolve("replacement-multi-true-validation.json"),
+                """
+                {
+                  "database_name": "app",
+                  "collection_name": "users",
+                  "tests": [
+                    {
+                      "description": "bulk replacement update with multi=true",
+                      "operations": [
+                        {
+                          "name": "bulkWrite",
+                          "arguments": {
+                            "requests": [
+                              {
+                                "updateMany": {
+                                  "filter": {"_id": 1},
+                                  "update": {"name": "next"}
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """);
+
+        final UnifiedSpecImporter importer = new UnifiedSpecImporter();
+        final UnifiedSpecImporter.ImportResult result = importer.importCorpus(tempDir);
+
+        assertEquals(1, result.importedCount());
+        assertEquals(0, result.unsupportedCount());
+        final Scenario scenario = result.importedScenarios().get(0).scenario();
+        assertEquals(1, scenario.commands().size());
+        assertEquals("bulkWrite", scenario.commands().get(0).commandName());
+        final Object operationsValue = scenario.commands().get(0).payload().get("operations");
+        assertTrue(operationsValue instanceof List<?>);
+        assertEquals(1, ((List<?>) operationsValue).size());
+    }
+
+    @Test
     void marksMergeStageAndBypassValidationTrueAsUnsupported() throws IOException {
         Files.writeString(
                 tempDir.resolve("unsupported-aggregation.json"),


### PR DESCRIPTION
## Summary
- Reduce UTF unsupported bucket for replacement-update multi=true by allowing bulk paths to be imported and validated at runtime.
- Keep direct `updateMany` replacement updates as importer-unsupported to avoid mismatch in known validation-message divergence lane.
- Preserve strict-lane differential stability while lowering unsupported volume.

## Implementation
- `UnifiedSpecImporter.update(...)`
  - keep guard for replacement document with `multi=true` (direct updateMany path remains unsupported).
- `UnifiedSpecImporter.validateBulkWriteUpdate(...)`
  - remove importer-side `multi=true replacement` hard reject for bulkWrite/clientBulkWrite paths.
  - bulk paths now flow to runtime validation consistently.
- Add importer test:
  - `importsBulkReplacementUpdateWithMultiTrueForRuntimeValidation`

## Evidence (local UTF shard, strict lane)
Before (`build/reports/utf-shard-issue419`):
- imported=760, skipped=537, unsupported=284, mismatch=0, error=0

After (`build/reports/utf-shard-issue420c`):
- imported=764, skipped=537, unsupported=280, mismatch=0, error=0

Delta:
- imported **+4**
- unsupported **-4**
- mismatch/error unchanged at **0**

Reason impact:
- `unsupported UTF replacement update with multi=true`: **6 -> 2**
  - remaining 2 are direct `updateMany` validation specs (`updateMany-validation.{json,yml}`)

## Validation
- `./.tooling/gradle-8.10.2/bin/gradle --no-daemon test --tests org.jongodb.testkit.UnifiedSpecImporterTest`
- `./scripts/ci/run-utf-shard.sh --spec-repo-root third_party/mongodb-specs/.checkout/specifications --shard-index 0 --shard-count 1 --output-dir build/reports/utf-shard-issue420c --seed issue420c-20260228 --mongo-uri 'mongodb://127.0.0.1:27017/?replicaSet=rs0&retryWrites=false&directConnection=true' --gradle-cmd './.tooling/gradle-8.10.2/bin/gradle'`

Closes #420
