### PR TITLE
[phase:r4] Support assert*NotExists control ops + stabilize mongod reset

### DIFF
--- a/src/main/java/org/jongodb/testkit/UnifiedSpecImporter.java
+++ b/src/main/java/org/jongodb/testkit/UnifiedSpecImporter.java
@@ -1394,6 +1394,8 @@ public final class UnifiedSpecImporter {
                         "endSession",
                         "listCollections",
                         "listDatabases",
+                        "assertCollectionNotExists",
+                        "assertIndexNotExists",
                         "assertSessionNotDirty",
                         "assertSameLsidOnLastTwoCommands",
                         "assertSessionTransactionState" -> List.of();

--- a/src/test/java/org/jongodb/testkit/UnifiedSpecImporterTest.java
+++ b/src/test/java/org/jongodb/testkit/UnifiedSpecImporterTest.java
@@ -983,6 +983,8 @@ class UnifiedSpecImporterTest {
                         {"name": "modifyCollection"},
                         {"name": "listCollections"},
                         {"name": "listDatabases"},
+                        {"name": "assertCollectionNotExists", "arguments": {"databaseName": "app", "collectionName": "users_shadow"}},
+                        {"name": "assertIndexNotExists", "arguments": {"databaseName": "app", "collectionName": "users", "indexName": "ix_missing"}},
                         {"name": "dropCollection"},
                         {"name": "find", "arguments": {"filter": {"_id": 1}}}
                       ]


### PR DESCRIPTION
## Summary
- add `assertCollectionNotExists` and `assertIndexNotExists` to UTF control-operation no-op subset
- extend importer regression test fixture to include both operations
- harden `RealMongodBackend` database reset to avoid indefinite lock waits in UTF lane:
  - use `dropDatabase` with bounded `maxTimeMS`
  - on first reset failure, run `killAllSessionsByPattern` and retry once

## Verification
- `./.tooling/gradle-8.10.2/bin/gradle --no-daemon test --tests org.jongodb.testkit.RealMongodBackendTest --tests org.jongodb.testkit.UnifiedSpecImporterTest`
- `./scripts/ci/run-utf-shard.sh --spec-repo-root third_party/mongodb-specs/.checkout/specifications --shard-index 0 --shard-count 1 --output-dir build/reports/utf-shard-issue416c --seed issue416c-20260228 --mongo-uri 'mongodb://127.0.0.1:27017/?replicaSet=rs0&retryWrites=false&directConnection=true' --gradle-cmd './.tooling/gradle-8.10.2/bin/gradle'`

## UTF Delta (vs `utf-shard-issue414b`)
- before: imported 776 / skipped 537 / unsupported 268 / mismatch 0 / error 0
- after: imported 776 / skipped 537 / unsupported 268 / mismatch 0 / error 0
- targeted bucket reduced:
  - `unsupported UTF operation: assertCollectionNotExists` + `assertIndexNotExists`: 4 -> 0
- newly surfaced next blocker in same lane:
  - `unsupported UTF operation: assertCollectionExists` + `assertIndexExists`: 0 -> 4

Closes #416
