### PR TITLE
[phase:r4] Support createCollection control subset in strict UTF lane

### DIFF
--- a/src/main/java/org/jongodb/testkit/UnifiedSpecImporter.java
+++ b/src/main/java/org/jongodb/testkit/UnifiedSpecImporter.java
@@ -1389,6 +1389,7 @@ public final class UnifiedSpecImporter {
                 case "commitTransaction" -> List.of(completeTransaction("commitTransaction", objectName, arguments));
                 case "abortTransaction" -> List.of(completeTransaction("abortTransaction", objectName, arguments));
                 case "dropCollection",
+                        "createCollection",
                         "modifyCollection",
                         "getSnapshotTime",
                         "endSession",

--- a/src/test/java/org/jongodb/testkit/UnifiedSpecImporterTest.java
+++ b/src/test/java/org/jongodb/testkit/UnifiedSpecImporterTest.java
@@ -983,6 +983,7 @@ class UnifiedSpecImporterTest {
                         {"name": "modifyCollection"},
                         {"name": "listCollections"},
                         {"name": "listDatabases"},
+                        {"name": "createCollection", "arguments": {"collection": "users_view", "viewOn": "users", "pipeline": [{"$match": {"_id": {"$gt": 0}}}]}},
                         {"name": "assertCollectionNotExists", "arguments": {"databaseName": "app", "collectionName": "users_shadow"}},
                         {"name": "assertIndexNotExists", "arguments": {"databaseName": "app", "collectionName": "users", "indexName": "ix_missing"}},
                         {"name": "dropCollection"},


### PR DESCRIPTION
## Summary
- add `createCollection` to the UTF control-operation no-op subset in `FileConversionContext`
- extend control-op importer regression fixture to cover `createCollection` arguments (`collection/viewOn/pipeline`)

## Verification
- `./.tooling/gradle-8.10.2/bin/gradle --no-daemon test --tests org.jongodb.testkit.UnifiedSpecImporterTest --tests org.jongodb.testkit.RealMongodBackendTest`
- `./scripts/ci/run-utf-shard.sh --spec-repo-root third_party/mongodb-specs/.checkout/specifications --shard-index 0 --shard-count 1 --output-dir build/reports/utf-shard-issue415 --seed issue415-20260228 --mongo-uri 'mongodb://127.0.0.1:27017/?replicaSet=rs0&retryWrites=false&directConnection=true' --gradle-cmd './.tooling/gradle-8.10.2/bin/gradle'`

## UTF Delta (vs `utf-shard-issue416c`)
- before: imported 776 / skipped 537 / unsupported 268 / mismatch 0 / error 0
- after: imported 778 / skipped 537 / unsupported 266 / mismatch 0 / error 0
- targeted bucket:
  - `unsupported UTF operation: createCollection`: 6 -> 0

Closes #415
