### PR TITLE
[phase:r4] Add listIndexes snapshot-operation control subset

### DIFF
--- a/src/main/java/org/jongodb/testkit/UnifiedSpecImporter.java
+++ b/src/main/java/org/jongodb/testkit/UnifiedSpecImporter.java
@@ -1395,6 +1395,7 @@ public final class UnifiedSpecImporter {
                         "endSession",
                         "listCollections",
                         "listDatabases",
+                        "listIndexes",
                         "assertCollectionNotExists",
                         "assertIndexNotExists",
                         "assertSessionNotDirty",

--- a/src/test/java/org/jongodb/testkit/UnifiedSpecImporterTest.java
+++ b/src/test/java/org/jongodb/testkit/UnifiedSpecImporterTest.java
@@ -983,6 +983,7 @@ class UnifiedSpecImporterTest {
                         {"name": "modifyCollection"},
                         {"name": "listCollections"},
                         {"name": "listDatabases"},
+                        {"name": "listIndexes", "arguments": {"databaseName": "app", "collectionName": "users"}},
                         {"name": "createCollection", "arguments": {"collection": "users_view", "viewOn": "users", "pipeline": [{"$match": {"_id": {"$gt": 0}}}]}},
                         {"name": "assertCollectionNotExists", "arguments": {"databaseName": "app", "collectionName": "users_shadow"}},
                         {"name": "assertIndexNotExists", "arguments": {"databaseName": "app", "collectionName": "users", "indexName": "ix_missing"}},


### PR DESCRIPTION
## Summary
- add `listIndexes` to UTF snapshot/control no-op operation subset in importer context
- extend control-op regression fixture to cover `listIndexes`

## Verification
- `./.tooling/gradle-8.10.2/bin/gradle --no-daemon test --tests org.jongodb.testkit.UnifiedSpecImporterTest --tests org.jongodb.testkit.RealMongodBackendTest`
- `./scripts/ci/run-utf-shard.sh --spec-repo-root third_party/mongodb-specs/.checkout/specifications --shard-index 0 --shard-count 1 --output-dir build/reports/utf-shard-issue418 --seed issue418-20260228 --mongo-uri 'mongodb://127.0.0.1:27017/?replicaSet=rs0&retryWrites=false&directConnection=true' --gradle-cmd './.tooling/gradle-8.10.2/bin/gradle'`

## UTF Delta (vs `utf-shard-issue415`)
- before: imported 778 / skipped 537 / unsupported 266 / mismatch 0 / error 0
- after: imported 778 / skipped 539 / unsupported 264 / mismatch 0 / error 0
- targeted bucket:
  - `unsupported UTF operation: listDatabases/listCollections/listIndexes`: 2 (listIndexes only) -> 0

Closes #418
