### PR TITLE
feat: add hint/unacknowledged runOn version lane (closes #424)

### DIFF
--- a/src/test/java/org/jongodb/testkit/UnifiedSpecImporterTest.java
+++ b/src/test/java/org/jongodb/testkit/UnifiedSpecImporterTest.java
@@ -286,6 +286,70 @@ class UnifiedSpecImporterTest {
     }
 
     @Test
+    void appliesHintLegacyServerVersionLaneOverride() throws IOException {
+        final Path suiteRoot = tempDir.resolve("crud/tests/unified");
+        Files.createDirectories(suiteRoot);
+        Files.writeString(
+                suiteRoot.resolve("updateOne-hint-unacknowledged.json"),
+                """
+                {
+                  "database_name": "app",
+                  "collection_name": "users",
+                  "tests": [
+                    {
+                      "description": "legacy hint lane",
+                      "runOnRequirements": [{"maxServerVersion": "4.0.99"}],
+                      "operations": [
+                        {"name": "find", "arguments": {"filter": {"_id": 1}}}
+                      ]
+                    }
+                  ]
+                }
+                """);
+
+        final UnifiedSpecImporter importer = new UnifiedSpecImporter();
+        final UnifiedSpecImporter.ImportResult result = importer.importCorpus(
+                tempDir,
+                UnifiedSpecImporter.RunOnContext.evaluated("7.0.25", "replicaset", false, false));
+
+        assertEquals(1, result.importedCount());
+        assertEquals(0, result.skippedCount());
+        assertEquals(0, result.unsupportedCount());
+    }
+
+    @Test
+    void keepsRunOnVersionChecksForNonHintLaneFiles() throws IOException {
+        final Path suiteRoot = tempDir.resolve("crud/tests/unified");
+        Files.createDirectories(suiteRoot);
+        Files.writeString(
+                suiteRoot.resolve("updateOne-legacy-unacknowledged.json"),
+                """
+                {
+                  "database_name": "app",
+                  "collection_name": "users",
+                  "tests": [
+                    {
+                      "description": "legacy non-lane",
+                      "runOnRequirements": [{"maxServerVersion": "4.0.99"}],
+                      "operations": [
+                        {"name": "find", "arguments": {"filter": {"_id": 1}}}
+                      ]
+                    }
+                  ]
+                }
+                """);
+
+        final UnifiedSpecImporter importer = new UnifiedSpecImporter();
+        final UnifiedSpecImporter.ImportResult result = importer.importCorpus(
+                tempDir,
+                UnifiedSpecImporter.RunOnContext.evaluated("7.0.25", "replicaset", false, false));
+
+        assertEquals(0, result.importedCount());
+        assertEquals(1, result.skippedCount());
+        assertTrue(result.skippedCases().get(0).reason().contains("runOnRequirements not satisfied"));
+    }
+
+    @Test
     void importsBulkWriteOperationWhenOrderedIsSupported() throws IOException {
         Files.writeString(
                 tempDir.resolve("bulk-write.json"),


### PR DESCRIPTION
## Summary
- generalize runOn lane handling to evaluate multiple bounded lane contexts per source-path cluster
- keep existing `mongos-pin-auto` topology lane, and add a legacy server-version lane for CRUD hint client/server/unacknowledged files
- legacy hint lane evaluates requirements against bounded historical versions (`3.3.99`, `4.0.99`, `4.1.9`, `4.2.99`, `4.3.3`) while preserving the default strict runtime context for non-lane files
- add importer tests verifying the hint lane override and non-lane guard behavior

## Validation
- `./.tooling/gradle-8.10.2/bin/gradle -q test --tests UnifiedSpecImporterTest`
- `scripts/ci/run-utf-shard.sh --spec-repo-root third_party/mongodb-specs/.checkout/specifications --shard-index 0 --shard-count 1 --output-dir build/reports/utf-shard-issue424 --seed issue424-20260228 --mongo-uri "mongodb://127.0.0.1:27017/?replicaSet=rs0&retryWrites=false&directConnection=true" --gradle-cmd "./.tooling/gradle-8.10.2/bin/gradle"`

## UTF delta (vs baseline `utf-shard-issue422c`)
- imported: `866 -> 994` (+128)
- skipped: `549 -> 421` (-128)
- unsupported: `166 -> 166` (no regression)
- mismatch/error: `0/0 -> 0/0` (unchanged)
- global `runOnRequirements not satisfied`: `463 -> 335` (-128)
- hint lane `runOnRequirements not satisfied`: `128 -> 0` (-128)

Closes #424
