### PR TITLE
test(regression): cover upsert duplicate-key path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 ## [Unreleased]
 
 ### Added
-- Added regression coverage for `findOneAndUpdate`/upsert duplicate-key behavior when `_id` matches an existing document but other predicates do not.
+- Added regression coverage for `findOneAndUpdate`/upsert duplicate-key behavior when `_id` matches an existing document but other predicates do not, including `$and`-wrapped filters.
 - Added declarative fixture manifest schema (`fixture-manifest.v1`) with standardized `dev`/`smoke`/`full` profile model.
 - Added fixture manifest loader/validator with path-aware aggregated validation errors.
 - Added deterministic fixture extraction planner + profile fingerprint generation.
@@ -42,6 +42,9 @@ All notable changes to this project are documented in this file.
 - Added process-exit launcher cleanup hook (`cleanupOnProcessExit`) to reduce orphan runtime processes after abrupt test termination.
 - Added fixed-port collision retry/backoff strategy (`portRetryAttempts`, `portRetryBackoffMs`) with next-port fallback behavior.
 - Added structured runtime logging contract (`onLog`, `logFormat`) with expanded log levels (`error`/`warn`/`info`/`debug`).
+
+### Fixed
+- Fixed upsert seed extraction to honor equality clauses nested inside `$and`, restoring duplicate-key behavior for `findOneAndUpdate` lock-style filters.
 
 ## [0.1.3] - 2026-02-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 ## [Unreleased]
 
 ### Added
+- Added regression coverage for `findOneAndUpdate`/upsert duplicate-key behavior when `_id` matches an existing document but other predicates do not.
 - Added declarative fixture manifest schema (`fixture-manifest.v1`) with standardized `dev`/`smoke`/`full` profile model.
 - Added fixture manifest loader/validator with path-aware aggregated validation errors.
 - Added deterministic fixture extraction planner + profile fingerprint generation.

--- a/src/main/java/org/jongodb/engine/InMemoryCollectionStore.java
+++ b/src/main/java/org/jongodb/engine/InMemoryCollectionStore.java
@@ -391,9 +391,23 @@ public final class InMemoryCollectionStore implements CollectionStore {
             return seed;
         }
 
-        for (final Map.Entry<String, Object> entry : filter.entrySet()) {
-            final String key = entry.getKey();
+        appendUpsertSeed(seed, filter);
+        return seed;
+    }
+
+    private static void appendUpsertSeed(final Document seed, final Map<?, ?> filter) {
+        if (filter == null || filter.isEmpty()) {
+            return;
+        }
+
+        for (final Map.Entry<?, ?> entry : filter.entrySet()) {
+            if (!(entry.getKey() instanceof String key)) {
+                continue;
+            }
             if (key == null || key.isEmpty() || key.startsWith("$")) {
+                if ("$and".equals(key)) {
+                    appendUpsertSeedFromAndClauses(seed, entry.getValue());
+                }
                 continue;
             }
             if (isOperatorDocument(entry.getValue())) {
@@ -404,7 +418,18 @@ public final class InMemoryCollectionStore implements CollectionStore {
             }
             setPathValue(seed, key, entry.getValue());
         }
-        return seed;
+    }
+
+    private static void appendUpsertSeedFromAndClauses(final Document seed, final Object clausesValue) {
+        if (!(clausesValue instanceof List<?> clauses)) {
+            return;
+        }
+
+        for (final Object clause : clauses) {
+            if (clause instanceof Map<?, ?> clauseMap) {
+                appendUpsertSeed(seed, clauseMap);
+            }
+        }
     }
 
     private static boolean isOperatorDocument(final Object value) {

--- a/src/test/java/org/jongodb/command/CommandDispatcherE2ETest.java
+++ b/src/test/java/org/jongodb/command/CommandDispatcherE2ETest.java
@@ -8,6 +8,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import org.bson.BsonArray;
+import org.bson.BsonBoolean;
+import org.bson.BsonDateTime;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
 import org.bson.BsonInt64;
@@ -1184,6 +1186,36 @@ class CommandDispatcherE2ETest {
         assertEquals(1.0, response.get("ok").asNumber().doubleValue());
         assertEquals("Neo", response.getDocument("value").getString("name").getValue());
         assertEquals("inserted", response.getDocument("value").getString("createdAt").getValue());
+    }
+
+    @Test
+    void findOneAndUpdateCommandRejectsUpsertWhenExistingIdFailsPredicate() {
+        final CommandDispatcher dispatcher = new CommandDispatcher(new EngineBackedCommandStore(new InMemoryEngineStore()));
+        final long existingLockUntil = 1775001600000L;
+        final long now = 1774968000000L;
+
+        dispatcher.dispatch(new BsonDocument("insert", new BsonString("locks"))
+                .append("$db", new BsonString("app"))
+                .append("documents", new BsonArray(List.of(new BsonDocument("_id", new BsonString("myLock"))
+                        .append("lockUntil", new BsonDateTime(existingLockUntil))))));
+
+        final BsonDocument response = dispatcher.dispatch(new BsonDocument("findOneAndUpdate", new BsonString("locks"))
+                .append("$db", new BsonString("app"))
+                .append("filter", new BsonDocument("_id", new BsonString("myLock"))
+                        .append("lockUntil", new BsonDocument("$lte", new BsonDateTime(now))))
+                .append("update", new BsonDocument(
+                        "$set",
+                        new BsonDocument("lockUntil", new BsonDateTime(1775005200000L))
+                                .append("lockedBy", new BsonString("host-2"))))
+                .append("upsert", BsonBoolean.TRUE));
+        assertDuplicateKeyError(response);
+
+        final BsonDocument findResponse = dispatcher.dispatch(BsonDocument.parse(
+                "{\"find\":\"locks\",\"$db\":\"app\",\"filter\":{\"_id\":\"myLock\"}}"));
+        final BsonDocument document =
+                findResponse.getDocument("cursor").getArray("firstBatch").get(0).asDocument();
+        assertEquals(existingLockUntil, document.getDateTime("lockUntil").getValue());
+        assertTrue(!document.containsKey("lockedBy"));
     }
 
     @Test

--- a/src/test/java/org/jongodb/command/CommandDispatcherE2ETest.java
+++ b/src/test/java/org/jongodb/command/CommandDispatcherE2ETest.java
@@ -1189,7 +1189,7 @@ class CommandDispatcherE2ETest {
     }
 
     @Test
-    void findOneAndUpdateCommandRejectsUpsertWhenExistingIdFailsPredicate() {
+    void findOneAndUpdateCommandRejectsUpsertWhenExistingIdFailsPredicateInsideAndClause() {
         final CommandDispatcher dispatcher = new CommandDispatcher(new EngineBackedCommandStore(new InMemoryEngineStore()));
         final long existingLockUntil = 1775001600000L;
         final long now = 1774968000000L;
@@ -1201,8 +1201,13 @@ class CommandDispatcherE2ETest {
 
         final BsonDocument response = dispatcher.dispatch(new BsonDocument("findOneAndUpdate", new BsonString("locks"))
                 .append("$db", new BsonString("app"))
-                .append("filter", new BsonDocument("_id", new BsonString("myLock"))
-                        .append("lockUntil", new BsonDocument("$lte", new BsonDateTime(now))))
+                .append(
+                        "filter",
+                        new BsonDocument(
+                                "$and",
+                                new BsonArray(List.of(
+                                        new BsonDocument("_id", new BsonString("myLock")),
+                                        new BsonDocument("lockUntil", new BsonDocument("$lte", new BsonDateTime(now)))))))
                 .append("update", new BsonDocument(
                         "$set",
                         new BsonDocument("lockUntil", new BsonDateTime(1775005200000L))

--- a/src/test/java/org/jongodb/engine/InMemoryCollectionStoreTest.java
+++ b/src/test/java/org/jongodb/engine/InMemoryCollectionStoreTest.java
@@ -480,6 +480,33 @@ class InMemoryCollectionStoreTest {
     }
 
     @Test
+    void upsertWithExistingIdInsideAndClauseThrowsDuplicateKey() {
+        CollectionStore store = new InMemoryCollectionStore();
+        Date existingLockUntil = new Date(1775001600000L);
+        Date now = new Date(1774968000000L);
+        Date updatedLockUntil = new Date(1775005200000L);
+        store.insertMany(List.of(new Document("_id", "myLock").append("lockUntil", existingLockUntil)));
+
+        assertThrows(
+                DuplicateKeyException.class,
+                () -> store.update(
+                        new Document(
+                                "$and",
+                                List.of(
+                                        new Document("_id", "myLock"),
+                                        new Document("lockUntil", new Document("$lte", now)))),
+                        new Document("$set", new Document("lockUntil", updatedLockUntil).append("lockedBy", "host-2")),
+                        false,
+                        true));
+
+        List<Document> all = store.findAll();
+        assertEquals(1, all.size());
+        assertEquals("myLock", all.get(0).getString("_id"));
+        assertEquals(existingLockUntil, all.get(0).getDate("lockUntil"));
+        assertFalse(all.get(0).containsKey("lockedBy"));
+    }
+
+    @Test
     void uniqueIndexWithCollationRejectsCaseInsensitiveDuplicates() {
         CollectionStore store = new InMemoryCollectionStore();
         store.createIndexes(List.of(new CollectionStore.IndexDefinition(

--- a/src/test/java/org/jongodb/engine/InMemoryCollectionStoreTest.java
+++ b/src/test/java/org/jongodb/engine/InMemoryCollectionStoreTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import org.bson.Document;
 import org.junit.jupiter.api.Test;
@@ -453,6 +454,29 @@ class InMemoryCollectionStoreTest {
         assertEquals(1, all.size());
         assertEquals(1, all.get(0).getInteger("_id"));
         assertEquals("ada@example.com", all.get(0).getString("email"));
+    }
+
+    @Test
+    void upsertWithExistingIdAndUnmatchedPredicateThrowsDuplicateKey() {
+        CollectionStore store = new InMemoryCollectionStore();
+        Date existingLockUntil = new Date(1775001600000L);
+        Date now = new Date(1774968000000L);
+        Date updatedLockUntil = new Date(1775005200000L);
+        store.insertMany(List.of(new Document("_id", "myLock").append("lockUntil", existingLockUntil)));
+
+        assertThrows(
+                DuplicateKeyException.class,
+                () -> store.update(
+                        new Document("_id", "myLock").append("lockUntil", new Document("$lte", now)),
+                        new Document("$set", new Document("lockUntil", updatedLockUntil).append("lockedBy", "host-2")),
+                        false,
+                        true));
+
+        List<Document> all = store.findAll();
+        assertEquals(1, all.size());
+        assertEquals("myLock", all.get(0).getString("_id"));
+        assertEquals(existingLockUntil, all.get(0).getDate("lockUntil"));
+        assertFalse(all.get(0).containsKey("lockedBy"));
     }
 
     @Test


### PR DESCRIPTION
Closes #465

## Summary
- fix upsert seed extraction so equality clauses nested inside `$and` are preserved during insert-style upserts
- add engine-level regression coverage for both flat and `$and`-wrapped duplicate-key scenarios
- add command-level `findOneAndUpdate` regression coverage for the Java driver `Filters.and(...)` shape

## Root Cause
`InMemoryCollectionStore.upsertSeed(...)` only inspected top-level non-operator fields. When the Java driver serialized the filter as:

```json
{"$and":[{"_id":"myLock"},{"lockUntil":{"$lte":...}}]}
```

the `_id` equality clause was skipped during upsert seed extraction. That left the inserted candidate without `_id`, so the engine generated a fresh `ObjectId` instead of colliding with the existing `_id` document.

## Verification
- manually recompiled the relevant main/test sources and executed:
  - `InMemoryCollectionStoreTest#upsertWithExistingIdAndUnmatchedPredicateThrowsDuplicateKey`
  - `InMemoryCollectionStoreTest#upsertWithExistingIdInsideAndClauseThrowsDuplicateKey`
  - `CommandDispatcherE2ETest#findOneAndUpdateCommandRejectsUpsertWhenExistingIdFailsPredicateInsideAndClause`
