### PR TITLE
[codex] Refresh 0.1.9 release evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,11 +186,11 @@ Support manifest summary:
 - `Partial`: 7
 - `Unsupported`: 0
 
-Historical certification evidence (2026-02-28; refresh on the release-candidate commit before tagging):
-- Official Suite Sharded: run `22516323868` (`total=508`, `mismatch=0`, `error=0`)
-- R3 Failure Ledger: run `22516324202` (`failureCount=0`)
-- Complex Query Certification: run `22516137734` (`packVersion=complex-query-pack-v3`, `mismatchCount=0`, `unsupportedByPolicyCount=0`)
-- R3 External Canary (latest success): run `22378993613` (2026-02-25)
+Release-candidate certification evidence for `v0.1.9` (2026-05-09; commit `b44be73`):
+- Official Suite Sharded: run `25603109902` (`total=1292`, `mismatch=0`, `error=0`, strict gate)
+- R3 Failure Ledger: run `25603109886` (`failureCount=0`)
+- Complex Query Certification: run `25603109905` (`packVersion=complex-query-pack-v3`, `mismatchCount=0`, `unsupportedByPolicyCount=0`)
+- R3 External Canary: run `25603109900` (`projectCount=3`, `canaryFail=0`, `rollbackSuccess=3`)
 
 Details:
 - `docs/SUPPORT_MATRIX.md`

--- a/docs/COMPATIBILITY_SCORECARD.md
+++ b/docs/COMPATIBILITY_SCORECARD.md
@@ -4,6 +4,13 @@ Status date: 2026-05-09
 
 This scorecard tracks MongoDB UTF compatibility progress with a focus on `runOnRequirements not satisfied` reduction while preserving differential stability. Historical checkpoints below may not match the latest release-candidate artifacts; refresh this page from the RC workflow outputs before tagging.
 
+Latest release-candidate gate (`v0.1.9`, commit `b44be73`, run `25603109902`):
+
+- Official Suite Sharded strict gate: `total=1292`, `match=1292`, `mismatch=0`, `error=0`
+- R3 Failure Ledger: run `25603109886`, `failureCount=0`
+- Complex Query Certification: run `25603109905`, `mismatchCount=0`, `unsupportedByPolicyCount=0`
+- R3 External Canary: run `25603109900`, `projectCount=3`, `canaryFail=0`, `rollbackSuccess=3`
+
 ## Lane model
 
 - Strict lane (baseline): runOn lane overrides disabled.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -4,29 +4,30 @@ Status date: 2026-05-09
 
 ## R3 Certification Sign-Off
 
-- [ ] Official suite sharded run on the release-candidate commit completed with zero mismatch/error.
-  - run id: `22516323868` (commit `d2ba61b`)
-- [ ] R3 failure ledger run on the release-candidate commit completed with `failureCount=0`.
-  - run id: `22516324202` (commit `d2ba61b`)
+- [x] Official suite sharded run on the release-candidate commit completed with zero mismatch/error.
+  - run id: `25603109902` (commit `b44be73`, `total=1292`, `mismatch=0`, `error=0`, strict gate)
+- [x] R3 failure ledger run on the release-candidate commit completed with `failureCount=0`.
+  - run id: `25603109886` (commit `b44be73`)
 - [x] External canary certification completed for 3 projects with rollback success.
-  - latest success run id: `22378993613` (commit `868bbc7`)
+  - latest success run id: `25603109900` (commit `b44be73`, `projectCount=3`, `canaryFail=0`, `rollbackSuccess=3`)
 - [x] Complex-query certification gate completed on `main` with no supported-subset regressions.
   - workflow: `.github/workflows/complex-query-certification.yml`
-  - run id: `22516137734` (pack `complex-query-pack-v3`)
-- [ ] Release-readiness streak threshold (`readiness_min_streak=3`) is satisfied on `main`.
-  - latest run id: `22516324202`
+  - run id: `25603109905` (pack `complex-query-pack-v3`, `mismatchCount=0`, `unsupportedByPolicyCount=0`)
+- [ ] Scheduled release-readiness streak threshold (`readiness_min_streak=3`) is satisfied on `main`.
+  - latest run id: `25603109886`
   - counters: `officialZeroMismatchStreak=0`, `r3LedgerZeroFailureStreak=1`
   - readiness: `satisfied=false`
+  - note: scheduled-history streak still reflects failures before the `b44be73` gate fix; manual release-candidate gates above are clean.
 - [x] Support boundary documents are updated.
   - `docs/SUPPORT_MATRIX.md`
   - `docs/COMPATIBILITY_SCORECARD.md`
-- [ ] README certification snapshot is updated and links current release-candidate evidence docs.
+- [x] README certification snapshot is updated and links current release-candidate evidence docs.
 
 ## Current Release-Line Notes
 
 - Latest Java release tag: `v0.1.8` (run `23785415137`, commit `7b8ef1f`).
 - Latest Node adapter tag: `node-v0.1.4` (run `22379340586`, commit `868bbc7`).
-- Latest compatibility certification snapshot: commit `d2ba61b` (runs `22516323868`, `22516324202`, `22516137734`).
+- Latest compatibility certification snapshot: commit `b44be73` (runs `25603109902`, `25603109886`, `25603109905`, `25603109900`).
 - Next Java tag candidate: `v0.1.9`; regenerate certification artifacts against the release-candidate commit, not reuse historical tag evidence.
 
 ## Tagging Gate

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -131,11 +131,11 @@ OpMsg res = codec.decode(ingress.handle(codec.encode(req)));
 
 ## Verification and Evidence Tasks
 
-Historical certified reference runs (as of 2026-02-28; refresh on the release-candidate commit before tagging):
-- Official Suite Sharded: `22516323868` (`total=508`, `mismatch=0`, `error=0`)
-- R3 Failure Ledger: `22516324202` (`failureCount=0`)
-- Complex Query Certification: `22516137734` (`packVersion=complex-query-pack-v3`)
-- R3 External Canary Certification (latest success): `22378993613` (2026-02-25)
+Release-candidate certification evidence for `v0.1.9` (2026-05-09; commit `b44be73`):
+- Official Suite Sharded: `25603109902` (`total=1292`, `mismatch=0`, `error=0`, strict gate)
+- R3 Failure Ledger: `25603109886` (`failureCount=0`)
+- Complex Query Certification: `25603109905` (`packVersion=complex-query-pack-v3`, `mismatchCount=0`, `unsupportedByPolicyCount=0`)
+- R3 External Canary Certification: `25603109900` (`projectCount=3`, `canaryFail=0`, `rollbackSuccess=3`)
 
 Official Suite Sharded UTF gate modes:
 - `warn` (default for `pull_request`, scheduled `main`, and manual dispatch): publish aggregate `total/match/mismatch/error` + pass rate summary, emit warning when mismatch/error remain.


### PR DESCRIPTION
## Summary
- refresh README, USAGE, release checklist, and compatibility scorecard with the current `v0.1.9` release-candidate evidence
- record the clean strict Official Suite, R3 Ledger, Complex Query, and R3 Canary run IDs
- call out that the scheduled-history readiness streak still reflects pre-fix failures while current manual RC gates are clean

## Validation
- `git diff --check`

Closes #474