### PR TITLE
Add forbidden keyword scan workflow

### DIFF
--- a/.github/workflows/forbidden-keyword-scan.yml
+++ b/.github/workflows/forbidden-keyword-scan.yml
@@ -1,0 +1,27 @@
+name: Forbidden Keyword Scan
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: forbidden-keyword-scan-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: Forbidden keyword scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: midagedev/review-actions/forbidden-keyword-scan@v1
+        with:
+          keywords: ${{ secrets.FORBIDDEN_KEYWORDS }}
+          fail-on-empty: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}


### PR DESCRIPTION
## Summary
- add a standalone forbidden keyword scan workflow using midagedev/review-actions
- read blocked terms from the FORBIDDEN_KEYWORDS repository secret

## Verification
- git diff --check
- rg -n "FORBIDDEN_KEYWORDS|forbidden-keyword-scan" .github scripts README.md docs

Closes #477